### PR TITLE
Add cache option to enable conditional request

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ var github = new GitHubApi({
     version: "3.0.0",
     // optional
     debug: true,
+    // optional
+    cache: true,
     protocol: "https",
     host: "github.my-GHE-enabled-company.com",
     timeout: 5000

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "engine" : {
         "node": ">=0.4.0"
     },
+    "dependencies": {
+      "osenv": "~0.0.3"
+    },
     "devDependencies": {
         "oauth": "~0.9.7",
         "optimist": "~0.6.0",


### PR DESCRIPTION
Conditional request support was added on #80, although it's very trick to store and use the response etag in order to leverage this improvement.

This issue proposes that `httpSend` handles that out of the box. The cache could be enabled or disabled by a `cache: true` configuration option.
