### PR TITLE
Adds the upload asset release api

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ github.authorization.create({
 * Search: 100%
 * Markdown: 100%
 * Rate Limit: 100%
-* Releases: 90%
+* Releases: 100%
 * Gitignore: 100%
 * Meta: 100%
 * Emojis: 100%

--- a/api/v3.0.0/releases.js
+++ b/api/v3.0.0/releases.js
@@ -326,6 +326,49 @@ var releases = module.exports = {
     };
 
     /** section: github
+     *  releases#uploadAsset(msg, callback) -> null
+     *      - msg (Object): Object that contains the parameters and their values to be sent to the server.
+     *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.
+     *
+     *  ##### Params on the `msg` object:
+     *
+     *  - headers (Object): Optional. Key/ value pair of request headers to pass along with the HTTP request. Valid headers are: 'If-Modified-Since', 'If-None-Match', 'Cookie', 'User-Agent', 'Accept', 'X-GitHub-OTP'.
+     *  - owner (String): Required. 
+     *  - id (Number): Required. 
+     *  - repo (String): Required. 
+     *  - name (String): Required. the file name of the asset
+     **/
+    this.uploadAsset = function(msg, block, callback) {
+        var self = this;
+        this.client.httpSend(msg, block, function(err, res) {
+            if (err)
+                return self.sendError(err, null, msg, callback);
+
+            var ret;
+            try {
+                ret = res.data && JSON.parse(res.data);
+            }
+            catch (ex) {
+                if (callback)
+                    callback(new error.InternalServerError(ex.message), res);
+                return;
+            }
+
+            if (!ret)
+                ret = {};
+            if (!ret.meta)
+                ret.meta = {};
+            ["x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-reset", "x-oauth-scopes", "link", "location", "last-modified", "etag", "status"].forEach(function(header) {
+                if (res.headers[header])
+                    ret.meta[header] = res.headers[header];
+            });
+
+            if (callback)
+                callback(null, ret);
+        });
+    };
+
+    /** section: github
      *  releases#editAsset(msg, callback) -> null
      *      - msg (Object): Object that contains the parameters and their values to be sent to the server.
      *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.

--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -3452,6 +3452,37 @@
                 "$repo": null
             }
         },
+        "upload-asset": {
+            "url": "/repos/:owner/:repo/releases/:id/assets",
+            "method": "POST",
+            "host": "uploads.github.com",
+            "hasFileBody": true,
+            "timeout": 0,
+            "params": {
+                "owner": {
+                    "type": "String",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "id": {
+                    "type": "Number",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "$repo": null,
+                "name": {
+                    "type": "String",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "the file name of the asset"
+                }
+            }
+        },
         "edit-asset": {
             "url": "/repos/:owner/:repo/releases/assets/:id",
             "method": "PATCH",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "engine" : {
         "node": ">=0.4.0"
     },
+    "dependencies": {
+      "mime": "^1.2.11"
+    },
     "devDependencies": {
         "oauth": "~0.9.7",
         "optimist": "~0.6.0",


### PR DESCRIPTION
Here's a first pass at adding this feature. Please tell me if you'd
like it implemented a different way. Of course I like it as is :P
but some things to consider
-   Content-Type
  
  Currently I set the content type automatically based on the name
  you pass in. This is a little magic as it assumes there's both
  a `filePath` and `name` field.
  
  It could be required to be set by the user as in
  
  ```
  github.releases.uploadAsset({
      owner: owner,
      id: releaseId,
      headers: {
         "content-type": "application/zip",
      }
      ...
  ```
  
  Similarly the size could be manually set there. But, since, based
  on the current API there's no way for us to upload the file (we
  don't get the request object back, and we can't just pass the
  data (it's arguably too big. Could be 100s of meg, more than
  fits in node's memory space), it seems like we should lookup
  the size and stream the file as it does now?
-   Timeout
  
  Wasn't sure what to do about that. Timeouts don't seem appropriate
  for uploading giant files or at least can't easily be a global
  setting.

Anyway, if you don't like this patch hopefully you can suggest a way
you'd prefer it.
