### PR TITLE
Update issues.create -- labels are not required

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -894,7 +894,7 @@
                 },
                 "labels": {
                     "type": "Json",
-                    "required": true,
+                    "required": false,
                     "validation": "",
                     "invalidmsg": "",
                     "description": "Array of strings - Labels to associate with this issue."


### PR DESCRIPTION
When creating an issue, labels are not required by GitHub API v3
