### PR TITLE
add spdx license string

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "scripts": {
         "test": "node ./test/all.js"
     },
+    "license": "MIT",
     "licenses": [{
         "type": "The MIT License",
         "url": "http://www.opensource.org/licenses/mit-license.php"


### PR DESCRIPTION
adding "license": "MIT" field in package.json silences
warning from newer `npm` about missing `license` field
