### PR TITLE
missing comment. msg.filePath of uploadAsset

### DIFF
--- a/api/v3.0.0/releases.js
+++ b/api/v3.0.0/releases.js
@@ -386,6 +386,7 @@ var releases = module.exports = {
      *  - id (Number): Required. 
      *  - repo (String): Required. 
      *  - name (String): Required. the file name of the asset
+     *  - filePath (String): Required. the file path of the asset
      **/
     this.uploadAsset = function(msg, block, callback) {
         var self = this;


### PR DESCRIPTION
I think that `msg.filePath` of uploadAsset is required.
