### PR TITLE
make it work with browserify

### DIFF
--- a/api/v3.0.0/index.js
+++ b/api/v3.0.0/index.js
@@ -19,7 +19,7 @@ var error = require("./../../error");
 
 var GithubHandler = module.exports = function(client) {
     this.client = client;
-    this.routes = JSON.parse(Fs.readFileSync(__dirname + "/routes.json", "utf8"));
+    this.routes = require("./routes.json");
 };
 
 var proto = {
@@ -33,8 +33,20 @@ var proto = {
     }
 };
 
-["gists", "gitdata", "issues", "authorization", "orgs", "statuses", "pullRequests", "repos", "user", "events", "releases", "search", "markdown", "gitignore", "misc"].forEach(function(api) {
-    Util.extend(proto, require("./" + api));
-});
+Util.extend(proto, require("./gists"));
+Util.extend(proto, require("./gitdata"));
+Util.extend(proto, require("./issues"));
+Util.extend(proto, require("./authorization"));
+Util.extend(proto, require("./orgs"));
+Util.extend(proto, require("./statuses"));
+Util.extend(proto, require("./pullRequests"));
+Util.extend(proto, require("./repos"));
+Util.extend(proto, require("./user"));
+Util.extend(proto, require("./events"));
+Util.extend(proto, require("./releases"));
+Util.extend(proto, require("./search"));
+Util.extend(proto, require("./markdown"));
+Util.extend(proto, require("./gitignore"));
+Util.extend(proto, require("./misc"));
 
 GithubHandler.prototype = proto;

--- a/generate.js
+++ b/generate.js
@@ -242,11 +242,15 @@ var main = module.exports = function(versions, tests, restore) {
             var sectionNames = Object.keys(sections);
 
             Util.log("Writing index.js file for version " + version);
+
+            var scripts = sectionNames.map(function(sectionName) {
+                return 'Util.extend(proto, require("./' + sectionName + '"));';
+            }).join('\n');
             Fs.writeFileSync(Path.join(dir, "index.js"),
                 IndexTpl
                     .replace("<%name%>", defines.constants.name)
                     .replace("<%description%>", defines.constants.description)
-                    .replace("<%scripts%>", "\"" + sectionNames.join("\", \"") + "\""),
+                    .replace("<%scripts%>", scripts),
                 "utf8");
 
             Object.keys(sections).forEach(function(section) {

--- a/templates/index.js.tpl
+++ b/templates/index.js.tpl
@@ -19,7 +19,7 @@ var error = require("./../../error");
 
 var GithubHandler = module.exports = function(client) {
     this.client = client;
-    this.routes = JSON.parse(Fs.readFileSync(__dirname + "/routes.json", "utf8"));
+    this.routes = require("./routes.json");
 };
 
 var proto = {
@@ -33,8 +33,6 @@ var proto = {
     }
 };
 
-[<%scripts%>].forEach(function(api) {
-    Util.extend(proto, require("./" + api));
-});
+<%scripts%>
 
 GithubHandler.prototype = proto;


### PR DESCRIPTION
The main issue preventing browserify usage was computed paths
in require statements: `require("./" + someVariable)`. Those have
all been eliminated.

This patch only adds browser support for `v3.0.0` (see the throwing
code in `/index.js` where it states exactly that to understand why).
Hint: it's related to computed paths again.

There were also a number of issues in `browserify-http`, and
`browserify-https` that I needed to code around to get things working:
- https://github.com/substack/https-browserify/pull/1
- https://github.com/substack/http-browserify/pull/90
- https://github.com/substack/http-browserify/issues/21
- https://github.com/substack/http-browserify/pull/10
