### PR TITLE
YAPPR - Yet Another Promise PR

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,6 +179,7 @@ var Client = module.exports = function(config) {
     config.headers = config.headers || {};
     this.config = config;
     this.debug = Util.isTrue(config.debug);
+    this.Promise = config.Promise || config.promise || Promise;
 
     this.version = config.version;
     var cls = require("./api/v" + this.version);
@@ -364,24 +365,24 @@ var Client = module.exports = function(config) {
                             return;
                         }
                         if (!callback){
-                            var promise = new Promise(function(resolve,reject){
-                                var cb = function(err, obj){
-                                    if (err){
-                                        reject(err);
-                                    } else {
-                                        resolve(obj);
-                                    }
-                                };
-                                api[section][funcName].call(api, msg, block, cb);
-                            });
-
+                            if (self.Promise) {
+                                return new self.Promise(function(resolve,reject){
+                                    var cb = function(err, obj){
+                                        if (err){
+                                            reject(err);
+                                        } else {
+                                            resolve(obj);
+                                        }
+                                    };
+                                    api[section][funcName].call(api, msg, block, cb);
+                                });
+                            } else {
+                                throw new Error('neither a callback or global promise implementation was provided');
+                            }
                         } else {
                             api[section][funcName].call(api, msg, block, callback);
                         }
 
-                        
-                        
-                        return promise;
                     };
                 }
                 else {

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var fs = require("fs");
 var mime = require("mime");
 var Util = require("./util");
 var Url = require("url");
+var Promise = require("./promise");
 
 /** section: github
  * class Client
@@ -362,8 +363,25 @@ var Client = module.exports = function(config) {
                             // on error, there's no need to continue.
                             return;
                         }
+                        if (!callback){
+                            var promise = new Promise(function(resolve,reject){
+                                var cb = function(err, obj){
+                                    if (err){
+                                        reject(err);
+                                    } else {
+                                        resolve(obj);
+                                    }
+                                };
+                                api[section][funcName].call(api, msg, block, cb);
+                            });
 
-                        api[section][funcName].call(api, msg, block, callback);
+                        } else {
+                            api[section][funcName].call(api, msg, block, callback);
+                        }
+
+                        
+                        
+                        return promise;
                     };
                 }
                 else {

--- a/package.json
+++ b/package.json
@@ -1,45 +1,36 @@
 {
-  "name": "github",
-  "version": "0.2.4",
-  "description": "NodeJS wrapper for the GitHub API",
-  "author": "Mike de Boer <info@mikedeboer.nl>",
-  "contributors": [
-    {
-      "name": "Mike de Boer",
-      "email": "info@mikedeboer.nl"
+    "name" : "github",
+    "version" : "0.2.4",
+    "description" : "NodeJS wrapper for the GitHub API",
+    "author": "Mike de Boer <info@mikedeboer.nl>",
+    "contributors": [
+        { "name": "Mike de Boer", "email": "info@mikedeboer.nl" },
+        { "name": "Fabian Jakobs", "email": "fabian@c9.io" }
+    ],
+    "homepage": "http://github.com/mikedeboer/node-github",
+    "repository" : {
+        "type" : "git",
+        "url" : "http://github.com/mikedeboer/node-github.git"
     },
-    {
-      "name": "Fabian Jakobs",
-      "email": "fabian@c9.io"
-    }
-  ],
-  "homepage": "http://github.com/mikedeboer/node-github",
-  "repository": {
-    "type": "git",
-    "url": "http://github.com/mikedeboer/node-github.git"
-  },
-  "engine": {
-    "node": ">=0.4.0"
-  },
-  "dependencies": {
-    "es6-promise": "^2.2.0",
-    "mime": "^1.2.11"
-  },
-  "devDependencies": {
-    "async": "^0.9.0",
-    "oauth": "~0.9.7",
-    "optimist": "~0.6.0",
-    "mocha": "~1.13.0"
-  },
-  "main": ".",
-  "scripts": {
-    "test": "node ./test/all.js"
-  },
-  "license": "MIT",
-  "licenses": [
-    {
-      "type": "The MIT License",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    }
-  ]
+    "engine" : {
+        "node": ">=0.4.0"
+    },
+    "dependencies": {
+      "mime": "^1.2.11"
+    },
+    "devDependencies": {
+        "async": "^0.9.0",
+        "oauth": "~0.9.7",
+        "optimist": "~0.6.0",
+        "mocha": "~1.13.0"
+    },
+    "main" : ".",
+    "scripts": {
+        "test": "node ./test/all.js"
+    },
+    "license": "MIT",
+    "licenses": [{
+        "type": "The MIT License",
+        "url": "http://www.opensource.org/licenses/mit-license.php"
+    }]
 }

--- a/package.json
+++ b/package.json
@@ -1,36 +1,45 @@
 {
-    "name" : "github",
-    "version" : "0.2.4",
-    "description" : "NodeJS wrapper for the GitHub API",
-    "author": "Mike de Boer <info@mikedeboer.nl>",
-    "contributors": [
-        { "name": "Mike de Boer", "email": "info@mikedeboer.nl" },
-        { "name": "Fabian Jakobs", "email": "fabian@c9.io" }
-    ],
-    "homepage": "http://github.com/mikedeboer/node-github",
-    "repository" : {
-        "type" : "git",
-        "url" : "http://github.com/mikedeboer/node-github.git"
+  "name": "github",
+  "version": "0.2.4",
+  "description": "NodeJS wrapper for the GitHub API",
+  "author": "Mike de Boer <info@mikedeboer.nl>",
+  "contributors": [
+    {
+      "name": "Mike de Boer",
+      "email": "info@mikedeboer.nl"
     },
-    "engine" : {
-        "node": ">=0.4.0"
-    },
-    "dependencies": {
-      "mime": "^1.2.11"
-    },
-    "devDependencies": {
-        "async": "^0.9.0",
-        "oauth": "~0.9.7",
-        "optimist": "~0.6.0",
-        "mocha": "~1.13.0"
-    },
-    "main" : ".",
-    "scripts": {
-        "test": "node ./test/all.js"
-    },
-    "license": "MIT",
-    "licenses": [{
-        "type": "The MIT License",
-        "url": "http://www.opensource.org/licenses/mit-license.php"
-    }]
+    {
+      "name": "Fabian Jakobs",
+      "email": "fabian@c9.io"
+    }
+  ],
+  "homepage": "http://github.com/mikedeboer/node-github",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/mikedeboer/node-github.git"
+  },
+  "engine": {
+    "node": ">=0.4.0"
+  },
+  "dependencies": {
+    "es6-promise": "^2.2.0",
+    "mime": "^1.2.11"
+  },
+  "devDependencies": {
+    "async": "^0.9.0",
+    "oauth": "~0.9.7",
+    "optimist": "~0.6.0",
+    "mocha": "~1.13.0"
+  },
+  "main": ".",
+  "scripts": {
+    "test": "node ./test/all.js"
+  },
+  "license": "MIT",
+  "licenses": [
+    {
+      "type": "The MIT License",
+      "url": "http://www.opensource.org/licenses/mit-license.php"
+    }
+  ]
 }

--- a/promise.js
+++ b/promise.js
@@ -1,0 +1,48 @@
+/*jslint browser: true, node: true, maxlen: 128 */
+/*global self */
+
+"use strict";
+
+var globalObject, hasPromiseSupport;
+
+function isFunction(x) {
+    return typeof x === "function";
+}
+
+// Seek the global object
+if (global !== undefined) {
+    globalObject = global;
+} else if (window !== undefined && window.document) {
+    globalObject = window;
+} else {
+    globalObject = self;
+}
+
+hasPromiseSupport =
+
+    globalObject.hasOwnProperty("Promise") &&
+
+    // Some of these methods are missing from
+    // Firefox/Chrome experimental implementations
+    globalObject.Promise.hasOwnProperty("resolve") &&
+    globalObject.Promise.hasOwnProperty("reject") &&
+    globalObject.Promise.hasOwnProperty("all") &&
+    globalObject.Promise.hasOwnProperty("race") &&
+
+    // Older version of the spec had a resolver object
+    // as the arg rather than a function
+    (function () {
+        /*jslint unparam: true */
+        var resolve, p;
+        p = new globalObject.Promise(function (r) { resolve = r; });
+        return isFunction(resolve);
+    }());
+
+// Export the native Promise implementation if it looks like it matches
+// the specificiation. Otherwise, return the es6-promise implementation
+// by @jaffathecake.
+if (hasPromiseSupport) {
+    module.exports = globalObject.Promise;
+} else {
+    module.exports = require("es6-promise").Promise;
+}

--- a/promise.js
+++ b/promise.js
@@ -1,48 +1,17 @@
-/*jslint browser: true, node: true, maxlen: 128 */
-/*global self */
-
 "use strict";
 
-var globalObject, hasPromiseSupport;
+var Promise = global.Promise || null;
+
+if (isFunction(Promise)) {
+    new Promise(function(resolver) {
+        if (!isFunction(resolver)) {
+            Promise = null;
+        }
+    });
+}
+
+module.exports = Promise;
 
 function isFunction(x) {
     return typeof x === "function";
-}
-
-// Seek the global object
-if (global !== undefined) {
-    globalObject = global;
-} else if (window !== undefined && window.document) {
-    globalObject = window;
-} else {
-    globalObject = self;
-}
-
-hasPromiseSupport =
-
-    globalObject.hasOwnProperty("Promise") &&
-
-    // Some of these methods are missing from
-    // Firefox/Chrome experimental implementations
-    globalObject.Promise.hasOwnProperty("resolve") &&
-    globalObject.Promise.hasOwnProperty("reject") &&
-    globalObject.Promise.hasOwnProperty("all") &&
-    globalObject.Promise.hasOwnProperty("race") &&
-
-    // Older version of the spec had a resolver object
-    // as the arg rather than a function
-    (function () {
-        /*jslint unparam: true */
-        var resolve, p;
-        p = new globalObject.Promise(function (r) { resolve = r; });
-        return isFunction(resolve);
-    }());
-
-// Export the native Promise implementation if it looks like it matches
-// the specificiation. Otherwise, return the es6-promise implementation
-// by @jaffathecake.
-if (hasPromiseSupport) {
-    module.exports = globalObject.Promise;
-} else {
-    module.exports = require("es6-promise").Promise;
 }


### PR DESCRIPTION
this simplifies the initial implementation of Promise support by @gero3, and allows for pluggable promise implementations. If a global `Promise` function exists, it will use that. Optionally, users can supply a promise implementation via `config.Promise`:

``` javascript
var GitHubApi = require('github');

var gh = new GitHubApi ({
  version: '3.0.0',
  Promise: require('bluebird')
});
```

This keeps the dependency list small, and gives people the freedom to choose their favorite Promise library (there have been at least 3 different libraries recommended in the issues so far). Most promise libraries are pretty huge, and now that I [have this working in the browser](https://github.com/mikedeboer/node-github/pull/261), I would be concerned about forcing large dependencies on people. This also has potential benefits for browser frameworks with existing promise implementations (I'm thinking specifically of [angular.js $q](https://docs.angularjs.org/api/ng/service/$q)).

see #258, #232 
