### PR TITLE
Adding CA parameter to allow SSL with self signed certificates

### DIFF
--- a/index.js
+++ b/index.js
@@ -671,6 +671,7 @@ var Client = module.exports = function(config) {
         var host = block.host || this.config.host || this.constants.host;
         var port = this.config.port || this.constants.port || (protocol == "https" ? 443 : 80);
         var proxyUrl;
+        var ca = this.config.ca;
         if (this.config.proxy !== undefined) {
             proxyUrl = this.config.proxy;
         } else {
@@ -765,7 +766,8 @@ var Client = module.exports = function(config) {
             port: port,
             path: path,
             method: method,
-            headers: headers
+            headers: headers,
+            ca: ca
         };
 
         if (this.config.rejectUnauthorized !== undefined)


### PR DESCRIPTION
This may be needed in some corporate environments in order to prevent "Certificate not trusted" errors when the GitHub Enterprise installation uses a corporate (self signed) SSL certificate.

Nodes HTTPS module [offers this parameter](https://nodejs.org/api/https.html#https_https_request_options_callback), we just have to hand it over.
