### PR TITLE
New method: getLatestRelease

### DIFF
--- a/api/v3.0.0/releases.js
+++ b/api/v3.0.0/releases.js
@@ -119,6 +119,54 @@ var releases = module.exports = {
     };
 
     /** section: github
+     *  releases#getLatestRelease(msg, callback) -> null
+     *      - msg (Object): Object that contains the parameters and their values to be sent to the server.
+     *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.
+     *
+     *  ##### Params on the `msg` object:
+     *
+     *  - headers (Object): Optional. Key/ value pair of request headers to pass along with the HTTP request. Valid headers are: 'If-Modified-Since', 'If-None-Match', 'Cookie', 'User-Agent', 'Accept', 'X-GitHub-OTP'.
+     *  - owner (String): Required. 
+     *  - repo (String): Required. 
+     *
+     * https://developer.github.com/v3/repos/releases/#get-the-latest-release
+     **/
+    this.getLatestRelease = function(msg, block, callback) {
+        var self = this;
+        this.client.httpSend(msg, block, function(err, res) {
+            if (err)
+                return self.sendError(err, null, msg, callback);
+
+            var ret;
+            try {
+                ret = res.data;
+                var contentType = res.headers["content-type"];
+                if (contentType && contentType.indexOf("application/json") !== -1)
+                    ret = JSON.parse(ret);
+            }
+            catch (ex) {
+                if (callback)
+                    callback(new error.InternalServerError(ex.message), res);
+                return;
+            }
+
+            if (!ret)
+                ret = {};
+            if (typeof ret == "object") {
+                if (!ret.meta)
+                    ret.meta = {};
+                ["x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-reset", "x-oauth-scopes", "link", "location", "last-modified", "etag", "status"].forEach(function(header) {
+                    if (res.headers[header])
+                        ret.meta[header] = res.headers[header];
+                });
+            }
+
+            if (callback)
+                callback(null, ret);
+        });
+    };
+
+    /** section: github
      *  releases#createRelease(msg, callback) -> null
      *      - msg (Object): Object that contains the parameters and their values to be sent to the server.
      *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.

--- a/api/v3.0.0/releasesTest.js
+++ b/api/v3.0.0/releasesTest.js
@@ -76,6 +76,19 @@ describe("[releases]", function() {
         );
     });
 
+    it("should successfully execute GET /repos/:owner/:repo/releases/latest (getLatestRelease)",  function(next) {
+        client.releases.getLatestRelease(
+            {
+                owner: owner,
+                repo: repo
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                next();
+            }
+        );
+    });
+
     it("should successfully execute POST /repos/:owner/:repo/releases (createRelease)",  function(next) {
         if (!haveWriteAccess) {
           next();

--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -3484,6 +3484,20 @@
                 "$repo": null
             }
         },
+        "get-latest-release": {
+            "url": "/repos/:owner/:repo/releases/latest",
+            "method": "GET",
+            "params": {
+                "owner": {
+                    "type": "String",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "$repo": null
+            }
+        },
         "create-release": {
             "url": "/repos/:owner/:repo/releases",
             "method": "POST",


### PR DESCRIPTION
Created method `getLatestRelease` in API V3 to fetch _/repos/:owner/:repo/releases/latest_, as described in https://developer.github.com/v3/repos/releases/#get-the-latest-release.
