### PR TITLE
fix client.getPage cannot keep custom headers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -489,19 +489,25 @@ var Client = module.exports = function(config) {
         return getPageLinks(link).first;
     };
 
-    function getPage(link, which, callback) {
+    function getPage(link, which, headers, callback) {
         var url = getPageLinks(link)[which];
         if (!url)
             return callback(new error.NotFound("No " + which + " page found"));
 
         var api = this[this.version];
         var parsedUrl = Url.parse(url, true);
+
+        var msg = Object.create(parsedUrl.query);
+        if (headers != null)
+            msg.headers = headers;
+
         var block = {
             url: parsedUrl.pathname,
             method: "GET",
             params: parsedUrl.query
         };
-        this.httpSend(parsedUrl.query, block, function(err, res) {
+
+        this.httpSend(msg, block, function(err, res) {
             if (err)
                 return api.sendError(err, null, parsedUrl.query, callback);
 
@@ -537,45 +543,65 @@ var Client = module.exports = function(config) {
     /**
      *  Client#getNextPage(link, callback) -> null
      *      - link (mixed): response of a request or the contents of the Link header
+     *      - headers (Object): Optional. Key/ value pair of request headers to pass along with the HTTP request.
      *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.
      *
      *  Get the next page, based on the contents of the `Link` header
      **/
-    this.getNextPage = function(link, callback) {
-        getPage.call(this, link, "next", callback);
+    this.getNextPage = function(link, headers, callback) {
+        if (typeof headers == 'function') {
+            callback = headers;
+            headers = null;
+        }
+        getPage.call(this, link, "next", headers, callback);
     };
 
     /**
      *  Client#getPreviousPage(link, callback) -> null
      *      - link (mixed): response of a request or the contents of the Link header
+     *      - headers (Object): Optional. Key/ value pair of request headers to pass along with the HTTP request.
      *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.
      *
      *  Get the previous page, based on the contents of the `Link` header
      **/
-    this.getPreviousPage = function(link, callback) {
-        getPage.call(this, link, "prev", callback);
+    this.getPreviousPage = function(link, headers, callback) {
+        if (typeof headers == 'function') {
+            callback = headers;
+            headers = null;
+        }
+        getPage.call(this, link, "prev", headers, callback);
     };
 
     /**
      *  Client#getLastPage(link, callback) -> null
      *      - link (mixed): response of a request or the contents of the Link header
+     *      - headers (Object): Optional. Key/ value pair of request headers to pass along with the HTTP request.
      *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.
      *
      *  Get the last page, based on the contents of the `Link` header
      **/
-    this.getLastPage = function(link, callback) {
-        getPage.call(this, link, "last", callback);
+    this.getLastPage = function(link, headers, callback) {
+        if (typeof headers == 'function') {
+            callback = headers;
+            headers = null;
+        }
+        getPage.call(this, link, "last", headers, callback);
     };
 
     /**
      *  Client#getFirstPage(link, callback) -> null
      *      - link (mixed): response of a request or the contents of the Link header
+     *      - headers (Object): Optional. Key/ value pair of request headers to pass along with the HTTP request.
      *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.
      *
      *  Get the first page, based on the contents of the `Link` header
      **/
-    this.getFirstPage = function(link, callback) {
-        getPage.call(this, link, "first", callback);
+    this.getFirstPage = function(link, headers, callback) {
+        if (typeof headers == 'function') {
+            callback = headers;
+            headers = null;
+        }
+        getPage.call(this, link, "first", headers, callback);
     };
 
     function getRequestFormat(hasBody, block) {


### PR DESCRIPTION
When request stargazers with custom header such as `Accept: application/vnd.github.v3.star+json`, `client.getNextPage` cannot keep the custom header. In fact, client did not keep the custom request header, so I added a `header` argument in such methods as a temporary fix.

Unit test cases as follows:

``` js
var assert = require('assert')

var Client = require('./')

describe('client.getPage', function () {
  var client = new Client({ version: '3.0.0' })

  this.timeout(10000)

  it('should keep the star creation timestamp in request.', function (done) {
    var headers = { Accept: 'application/vnd.github.v3.star+json' }
    client.repos.getStargazers({
      user: 'mikedeboer',
      repo: 'node-github',
      per_page: 1,
      headers: headers
    }, function (err, data) {
      assert.ifError(err)
      assert('starred_at' in data[0], 'Star creation timestamps do not exist in first request.')
      client.getNextPage(data, headers, function (err, data) {
        assert.ifError(err)
        assert('starred_at' in data[0], 'Star creation timestamps do not exist in follow requests.')
        done()
      })
    })
  })

  it('should request stargazers without custom header.', function (done) {
    client.repos.getStargazers({
      user: 'mikedeboer',
      repo: 'node-github',
      per_page: 1
    }, function (err, data) {
      assert.ifError(err)
      client.getNextPage(data, done)
    })
  })
})
```
