### PR TITLE
correct documentation for pullRequests#createComment

### DIFF
--- a/api/v3.0.0/pullRequests.js
+++ b/api/v3.0.0/pullRequests.js
@@ -591,7 +591,7 @@ var pullRequests = module.exports = {
      *  - body (String): Required. 
      *  - commit_id (String): Required. Sha of the commit to comment on.
      *  - path (String): Required. Relative path of the file to comment on.
-     *  - position (Number): Required. Column index in the diff to comment on.
+     *  - position (Number): Required. Line index in the diff to comment on.
      **/
     this.createComment = function(msg, block, callback) {
         var self = this;


### PR DESCRIPTION
### Changes
- Update documentation for `pullRequests#createComment` to be in line with Github developer documentation: https://developer.github.com/v3/pulls/comments/#create-a-comment
