### PR TITLE
use follow-redirects

### DIFF
--- a/index.js
+++ b/index.js
@@ -775,7 +775,7 @@ var Client = module.exports = function(config) {
             console.log("REQUEST: ", options);
 
         function httpSendRequest() {
-            var req = require(protocol).request(options, function(res) {
+            var req = require('follow-redirects/' + protocol).request(options, function(res) {
                 if (self.debug) {
                     console.log("STATUS: " + res.statusCode);
                     console.log("HEADERS: " + JSON.stringify(res.headers));

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "node": ">=0.4.0"
     },
     "dependencies": {
+      "follow-redirects": "0.0.7",
       "mime": "^1.2.11"
     },
     "devDependencies": {


### PR DESCRIPTION
Swaps vanilla `http` / `https` for `follow-redirets`.

Tests appear to be about the same amount of broken with/without my changes. 

Fixes #257

People can install this modified version via:

```
$ npm install jamestalmage/node-github#follow-redirects
```
