### PR TITLE
Allow for multiple calls to the same method with different values by cloning the 'block'

### DIFF
--- a/index.js
+++ b/index.js
@@ -363,7 +363,7 @@ var Client = module.exports = function(config) {
                             return;
                         }
 
-                        api[section][funcName].call(api, msg, block, callback);
+                        api[section][funcName].call(api, msg, JSON.parse(JSON.stringify(block)), callback);
                     };
                 }
                 else {


### PR DESCRIPTION
Example: client.issues.repoIssues called twice in a row with a different repo each time - after the first call the repo is 'filled in' (':repo' is expanded in the 'block' object itself) the path and therefore cannot be changed for the second (or any subsequent) call so that second call fails.
