### PR TITLE
permission parameter support for add-team-repo

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -1559,7 +1559,8 @@
             "params": {
                 "$id": null,
                 "$user": null,
-                "$repo": null
+                "$repo": null,
+                "$permission": null
             }
         },
 


### PR DESCRIPTION
The github api [had some enhancements](https://developer.github.com/changes/2015-06-24-api-enhancements-for-working-with-organization-permissions/) to the organization permission system, meaning that a team's access to a repository can be set individually for each repository of the organization. 

This enhancement [has been live](https://developer.github.com/changes/2016-01-05-api-enhancements-for-working-with-organization-permissions-are-now-official/) for quite some time.

I added the new parameter to the routes.json file, please let me know what needs to be done to make this parameter available in this sdk.
