### PR TITLE
Pass res through to callback when reqeusts have a non 200 response

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -691,7 +691,7 @@ var Client = module.exports = function(config) {
                 });
                 res.on("end", function() {
                     if (res.statusCode >= 400 && res.statusCode < 600 || res.statusCode < 10) {
-                        callCallback(new error.HttpError(data, res.statusCode, res.headers));
+                        callCallback(new error.HttpError(data, res.statusCode), res);
                     } else {
                         res.data = data;
                         callCallback(null, res);


### PR DESCRIPTION
We log out requests that we make to GitHub. Currently if the request has a non 200 response, we do not have a handle to the response object. Ironically, it is in that case that we most care about having it.
