### PR TITLE
Allow lazy instantiation

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,6 +175,10 @@ var Url = require("url");
  *      }
  **/
 var Client = module.exports = function(config) {
+    if (!(this instanceof Client)) {
+        return new Client(config);
+    }
+
     config.headers = config.headers || {};
     this.config = config;
     this.debug = Util.isTrue(config.debug);


### PR DESCRIPTION
Because it’s nice being able to get an instance on require like so:

``` js
var github = require('github')({
  version: '3.0.0'
})
```
