### PR TITLE
(enhancement): add-team-repo Allow Specification of permission

### DIFF
--- a/doc/apidoc.js
+++ b/doc/apidoc.js
@@ -1623,14 +1623,15 @@ github.orgs.addTeamMembership({ ... });
  */
 
 /**
- * @api {put} /teams/:id/repos/:user/:repo addTeamRepo
+ * @api {put} /teams/:id/repos/:org/:repo addTeamRepo
  * @apiName addTeamRepo
  * @apiDescription Add team repository
  * @apiGroup orgs
  *
  * @apiParam {String} id  
- * @apiParam {String} user  
+ * @apiParam {String} org  
  * @apiParam {String} repo  
+ * @apiParam {String} [permission=pull]  `pull` - team members can pull, but not push or administer this repositories (Default), `push` - team members can pull and push, but not administer this repositores, `admin` - team members can pull, push and administer these repositories.
  * @apiExample {js} ex:
 github.orgs.addTeamRepo({ ... });
  */

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -2638,12 +2638,13 @@
         },
 
         "add-team-repo": {
-            "url": "/teams/:id/repos/:user/:repo",
+            "url": "/teams/:id/repos/:org/:repo",
             "method": "PUT",
             "params": {
                 "$id": null,
-                "$user": null,
-                "$repo": null
+                "$org": null,
+                "$repo": null,
+                "$permission": null
             },
             "description": "Add team repository"
         },

--- a/test/orgsTest.js
+++ b/test/orgsTest.js
@@ -55,12 +55,13 @@ describe("[orgs]", function() {
         );
     });
 
-    it("should successfully execute PUT /teams/:id/repos/:user/:repo (addTeamRepo)",  function(next) {
+    it("should successfully execute PUT /teams/:id/repos/:org/:repo (addTeamRepo)",  function(next) {
         client.orgs.addTeamRepo(
             {
                 id: "String",
-                user: "String",
-                repo: "String"
+                org: "String",
+                repo: "String",
+                permission: "String"
             },
             function(err, res) {
                 Assert.equal(err, null);


### PR DESCRIPTION
The add-team-repo endpoint also takes in a permission paramater (pull, push, admin) that allows you to set the permissions for the team.
