### PR TITLE
feat(error-callback): Pass res through to callback when reqeusts have a non-200 response

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -691,7 +691,7 @@ var Client = module.exports = function(config) {
                 });
                 res.on("end", function() {
                     if (res.statusCode >= 400 && res.statusCode < 600 || res.statusCode < 10) {
-                        callCallback(new error.HttpError(data, res.statusCode, res.headers));
+                        callCallback(new error.HttpError(data, res.statusCode, res.headers), res);
                     } else {
                         res.data = data;
                         callCallback(null, res);


### PR DESCRIPTION
We need access to the response body so we can handle errors in the most appropriate way possible.
