### PR TITLE
fix(redirects): Configuration to disable redirects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -676,7 +676,8 @@ var Client = module.exports = function(config) {
             console.log("REQUEST: ", options);
 
         function httpSendRequest() {
-            var req = require('follow-redirects/' + protocol).request(options, function(res) {
+            var reqModule = self.config.followRedirects === false ? protocol : 'follow-redirects/' + protocol;
+            var req = require(reqModule).request(options, function(res) {
                 if (self.debug) {
                     console.log("STATUS: " + res.statusCode);
                     console.log("HEADERS: " + JSON.stringify(res.headers));


### PR DESCRIPTION
closes https://github.com/mikedeboer/node-github/issues/345

Our app is currently broken on the latest version of `node-github` because when we get redirects from GitHub for non-`GET` requests, `node-github` replays them as `GET`s. We were already handling all the redirects on our side, so being able to disable it in `node-github` is enough for us.
