### PR TITLE
allow authorization header in request

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -34,6 +34,7 @@
             "Status"
         ],
         "request-headers": [
+            "authorization",
             "If-Modified-Since",
             "If-None-Match",
             "Cookie",

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -34,7 +34,7 @@
             "Status"
         ],
         "request-headers": [
-            "authorization",
+            "Authorization",
             "If-Modified-Since",
             "If-None-Match",
             "Cookie",


### PR DESCRIPTION
I have a multi user application and I want to avoid calling the authenticate() method on every request
This will work only with the token auth type, for a global solution, we could pass an _authenticate_ object as a parameter to the requests, this will require a very little modification in the code
