### PR TITLE
Fixed Browserify compatibility

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,7 +74,7 @@ var Client = module.exports = function(config) {
     this.config = config;
     this.debug = Util.isTrue(config.debug);
 
-    this.routes = JSON.parse(fs.readFileSync(__dirname + "/routes.json", "utf8"));
+    this.routes = require("./routes.json");
 
     var pathPrefix = "";
     // Check if a prefix is passed in the config and strip any leading or trailing slashes from it.
@@ -413,7 +413,7 @@ var Client = module.exports = function(config) {
                 callback(null, ret);
         });
     }
-    
+
     /**
      *  Client#getAllPages(method, options, callback) -> null
      *      - method (Function): github client method to be called recursively
@@ -678,8 +678,24 @@ var Client = module.exports = function(config) {
             console.log("REQUEST: ", options);
 
         function httpSendRequest() {
-            var reqModule = self.config.followRedirects === false ? protocol : 'follow-redirects/' + protocol;
-            var req = require(reqModule).request(options, function(res) {
+            var requestModule;
+
+        	if(self.config.followRedirects === false) {
+        		if(protocol === 'https') {
+        			requestModule = require('https');
+        		} else {
+        			requestModule = require('http');
+        		}
+
+        	} else {
+        		if(protocol === 'https') {
+        			requestModule = require('follow-redirects/https');
+        		} else {
+        			requestModule = require('follow-redirects/http');
+        		}
+        	}
+
+            var req = requestModule.request(options, function(res) {
                 if (self.debug) {
                     console.log("STATUS: " + res.statusCode);
                     console.log("HEADERS: " + JSON.stringify(res.headers));

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,7 +74,7 @@ var Client = module.exports = function(config) {
     this.config = config;
     this.debug = Util.isTrue(config.debug);
 
-    this.routes = require("./routes.json");
+    this.routes = Object.assign({}, require("./routes.json"));
 
     var pathPrefix = "";
     // Check if a prefix is passed in the config and strip any leading or trailing slashes from it.


### PR DESCRIPTION
Browserify is unable to follow dynamically generated paths. By swapping out the `fs.readFileSync` in favour or a `require` call, this makes the library work nicely with Browserify.

Some changes were needed in the http requests code. Are http and https the only supported protocols? I could not find any documentation on this.

I am unable to run the tests, even on master. Can you provide some more explanation on how I should run them? `npm test` throws errors, even on master.

Aside from that, everything seems to work fine.
