### PR TITLE
allow empty path for `getContent`

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -3778,6 +3778,7 @@
                 "path": {
                     "type": "String",
                     "required": true,
+                    "allow-empty": true,
                     "validation": "",
                     "invalidmsg": "",
                     "description": "The content path."


### PR DESCRIPTION
Empty path in getContent should be allowed.
It is supposed to return the contents of the root path.

Now it will throw an error according to [the code here](https://github.com/mikedeboer/node-github/blob/master/lib/index.js#L161).
