### PR TITLE
Add parameters available to preview for create-deployment endpoint

### DIFF
--- a/doc/apidoc.js
+++ b/doc/apidoc.js
@@ -2829,14 +2829,16 @@ github.repos.createCommitComment({ ... });
  * @apiGroup repos
  *
  * @apiParam {String} user  
- * @apiParam {String} repo  
  * @apiParam {String} ref  The ref to deploy. This can be a branch, tag, or sha.
+ * @apiParam {String} repo  
  * @apiParam {String} [task=deploy]  The named task to execute. e.g. deploy or deploy:migrations. Default: deploy
  * @apiParam {Boolean} [auto_merge=true]  Optional parameter to merge the default branch into the requested ref if it is behind the default branch. Default: true
- * @apiParam {Array} [required_contexts]  Optional array of status contexts verified against commit status checks. If this parameter is omitted from the parameters then all unique contexts will be verified before a deployment is created. To bypass checking entirely pass an empty array. Defaults to all unique contexts.
+ * @apiParam {Boolean} [production_environment]  Specifies if the given environment is a one that end-users directly interact with. Default: true when environment is `production` and false otherwise. (In preview period. See README.)
  * @apiParam {String} [payload=""]  Optional JSON payload with extra information about the deployment. Default: ""
  * @apiParam {String} [environment=none]  The name of the environment that was deployed to. e.g. staging or production. Default: none.
  * @apiParam {String} [description=""]  Optional short description. Default: ""
+ * @apiParam {Boolean} [transient_environment=false]  Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future. Default: false. (In preview period. See README.)
+ * @apiParam {Array} [required_contexts]  Optional array of status contexts verified against commit status checks. If this parameter is omitted from the parameters then all unique contexts will be verified before a deployment is created. To bypass checking entirely pass an empty array. Defaults to all unique contexts.
  * @apiExample {js} ex:
 github.repos.createDeployment({ ... });
  */
@@ -2855,7 +2857,7 @@ github.repos.createDeployment({ ... });
  * @apiParam {String} [log_url=""]  Functionally equivalent to target_url. Default: "". (In preview period. See README.)
  * @apiParam {String} [description=""]  A short description of the status. Default: ""
  * @apiParam {String} [environment_url=""]  URL for accessing the deployment environment. Default: "". (In preview period. See README.)
- * @apiParam {Boolean} [auto_inactive=true]  When true the new `inactive` status is added to all other all non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment.. Default: true. (In preview period. See README.)
+ * @apiParam {Boolean} [auto_inactive=true]  When true the new `inactive` status is added to all other non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment. Default: true. (In preview period. See README.)
  * @apiExample {js} ex:
 github.repos.createDeploymentStatus({ ... });
  */

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -4433,6 +4433,21 @@
                     "invalidmsg": "",
                     "description": "Optional short description. Default: \"\"",
                     "default": "\"\""
+                },
+                "transient_environment": {
+                    "type": "Boolean",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future. Default: false. (In preview period. See README.)",
+                    "default": false
+                },
+                "production_environment": {
+                    "type": "Boolean",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "Specifies if the given environment is a one that end-users directly interact with. Default: true when environment is `production` and false otherwise. (In preview period. See README.)"
                 }
             },
             "description": "Create a deployment."
@@ -4500,7 +4515,7 @@
                     "required": false,
                     "validation": "",
                     "invalidmsg": "",
-                    "description": "When true the new `inactive` status is added to all other all non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment.. Default: true. (In preview period. See README.)",
+                    "description": "When true the new `inactive` status is added to all other non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment. Default: true. (In preview period. See README.)",
                     "default": true
                 }
             },

--- a/test/reposTest.js
+++ b/test/reposTest.js
@@ -124,7 +124,9 @@ describe("[repos]", function() {
                 required_contexts: "Array",
                 payload: "String",
                 environment: "String",
-                description: "String"
+                description: "String",
+                transient_environment: "Boolean",
+                production_environment: "Boolean"
             },
             function(err, res) {
                 Assert.equal(err, null);


### PR DESCRIPTION
Adds two parameters `transient_environment` and `production_environment` available for preview from the [create deployment endpoint](https://developer.github.com/v3/repos/deployments/#create-a-deployment).

Also fixes a small mistake in the description of a parameter from my previous PR.
