### PR TITLE
Add API  for get SHA-1 of Commit Reference

### DIFF
--- a/doc/apidoc.js
+++ b/doc/apidoc.js
@@ -3753,6 +3753,19 @@ github.repos.getReleases({ ... });
  */
 
 /**
+ * @api {get} /repos/:user/:repo/commits/:ref getShaOfCommitRef
+ * @apiName getShaOfCommitRef
+ * @apiDescription Get the SHA-1 of a commit reference.
+ * @apiGroup repos
+ *
+ * @apiParam {String} user  
+ * @apiParam {String} repo  
+ * @apiParam {String} ref  String of the name of the fully qualified reference (ie: heads/master). If it doesn’t have at least one slash, it will be rejected.
+ * @apiExample {js} ex:
+github.repos.getShaOfCommitRef({ ... });
+ */
+
+/**
  * @api {get} /repos/:user/:repo/stats/code_frequency getStatsCodeFrequency
  * @apiName getStatsCodeFrequency
  * @apiDescription Get the number of additions and deletions per week.

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -4115,6 +4115,17 @@
             "description": "Get a single commit."
         },
 
+        "get-sha-of-commit-ref": {
+            "url": "/repos/:user/:repo/commits/:ref",
+            "method": "GET",
+            "params": {
+                "$user": null,
+                "$repo": null,
+                "$ref": null
+            },
+            "description": "Get the SHA-1 of a commit reference."
+        },
+
         "compare-commits": {
             "url": "/repos/:user/:repo/compare/:base...:head",
             "method": "GET",

--- a/test/reposTest.js
+++ b/test/reposTest.js
@@ -1109,6 +1109,21 @@ describe("[repos]", function() {
         );
     });
 
+    it("should successfully execute GET /repos/:user/:repo/commits/:ref (getShaOfCommitRef)",  function(next) {
+        client.repos.getShaOfCommitRef(
+            {
+                user: "String",
+                repo: "String",
+                ref: "String"
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                // other assertions go here
+                next();
+            }
+        );
+    });
+
     it("should successfully execute GET /repos/:user/:repo/stats/code_frequency (getStatsCodeFrequency)",  function(next) {
         client.repos.getStatsCodeFrequency(
             {


### PR DESCRIPTION
Found that this API in repos is missing.  Hence, add it back.
