### PR TITLE
Fix misc:renderMarkdown

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -791,7 +791,11 @@ var Client = module.exports = function(config) {
 
             var ret;
             try {
-                ret = res.data && JSON.parse(res.data);
+                var contentType = res.headers["content-type"];
+                if (contentType && contentType.indexOf("application/json") !== -1)
+                    ret = res.data && JSON.parse(res.data);
+                else
+                    ret = {data: res.data};
             }
             catch (ex) {
                 if (callback)


### PR DESCRIPTION
Calls to misc:renderMarkdown will fail as it does not return JSON data.

This will check the `content-type` header to ensure a call to `JSON.parse` does not get executed against non JSON data. I'm not sure if this type of cross-cutting approach is the best, but it does solve the edge case of markdown (one of a few(?) API calls that does not return JSON).

resolves #210
