### PR TITLE
Allow for passing some required parameters as null

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -160,9 +160,11 @@ var Client = module.exports = function(config) {
 
                 value = trim(msg[paramName]);
                 if (typeof value != "boolean" && !value) {
-                    // we don't need to validation for undefined parameter values
+                    // we don't need validation for undefined parameter values
                     // that are not required.
-                    if (!def.required || (def["allow-empty"] && value === ""))
+                    if (!def.required || 
+                        (def["allow-empty"] && value === "") || 
+                        (def["allow-null"] && value === null))
                         continue;
                     throw new error.BadRequest("Empty value for parameter '" +
                         paramName + "': " + value);

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -3950,6 +3950,7 @@
                 "required_status_checks": {
                     "type": "Json",
                     "required": true,
+                    "allow-null": true,
                     "validation": "",
                     "invalidmsg": "",
                     "description": "JSON object that contains the following keys: `include_admins` - Enforce required status checks for repository administrators, `strict` - Require branches to be up to date before merging, `contexts` - The list of status checks to require in order to merge into this branch. This object can have the value of `null` for disabled."
@@ -3957,6 +3958,7 @@
                 "restrictions": {
                     "type": "Json",
                     "required": true,
+                    "allow-null": true,
                     "validation": "",
                     "invalidmsg": "",
                     "description": "JSON object that contains the following keys: `users` - The list of user logins with push access, `teams` - The list of team slugs with push access. This object can have the value of `null` for disabled."


### PR DESCRIPTION
The new "update branch protection" endpoint requires passing both `required_status_checks` and `restrictions` objects, although both can be passed as nulls.

This PR adds an `allow-null` that can be set for specific parameters, similar to `allow-empty` for required but empty strings, and sets `allow-null` to true for `required_status_checks` and `restrictions`.

I have not added/updated any tests, as it looks like they're automatically generated. I ran `generate.js`, but it didn't pick up any changes to include.
