### PR TITLE
Added X-Poll-Interval header for events API

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -16,6 +16,7 @@
             "X-RateLimit-Remaining",
             "X-RateLimit-Reset",
             "X-Oauth-Scopes",
+            "X-Poll-Interval",
             "Link",
             "Location",
             "Last-Modified",


### PR DESCRIPTION
The [Activity API](https://developer.github.com/v3/activity/events/#events) supports the `X-Poll-Interval` header so that you can throttle your calls to this api. This PR just adds this header to the defaults in `lib/routes.json`.

I didn't add a test since running `npm test` throws an error:
`Error: Cannot find module './../testAuth.json'`

Right now I get around this issue with:

``` js
const api = new GitHubAPI();
api.responseHeaders.unshift('x-poll-interval');
```
