### PR TITLE
Updated getForUser for Organizations

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -2678,7 +2678,7 @@
         },
 
         "get-for-user": {
-            "url": "/users/:user/orgs",
+            "url": "/user/orgs",
             "method": "GET",
             "params": {
                 "$user": null,


### PR DESCRIPTION
- Update getForUser to use /user/orgs rather than /users/:user/orgs
