### PR TITLE
change descriptions for list-user-org endpoints

### DIFF
--- a/doc/apidoc.js
+++ b/doc/apidoc.js
@@ -2206,7 +2206,7 @@ github.orgs.getAll({ ... });
 /**
  * @api {get} /users/:user/orgs getForUser
  * @apiName getForUser
- * @apiDescription List user's organizations
+ * @apiDescription List public organization memberships for the specified user.
  * @apiGroup orgs
  *
  * @apiParam {String} user  
@@ -4780,7 +4780,7 @@ github.users.getOrganizationMembership({ ... });
 /**
  * @api {get} /user/orgs getOrgs
  * @apiName getOrgs
- * @apiDescription Get your organizations
+ * @apiDescription List organizations for the authenticated user.
  * @apiGroup users
  *
  * @apiParam {Number} [page]  Page number of the results to fetch.

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -2685,7 +2685,7 @@
                 "$page": null,
                 "$per_page": null
             },
-            "description": "List user's organizations"
+            "description": "List public organization memberships for the specified user."
         },
 
         "get": {
@@ -5844,7 +5844,7 @@
                 "$page": null,
                 "$per_page": null
             },
-            "description": "Get your organizations"
+            "description": "List organizations for the authenticated user."
         },
 
         "get-organization-membership": {


### PR DESCRIPTION
Avoid any confusion regarding #413 between users.getOrgs and
orgs.getForUser.
