### PR TITLE
fix permission param

### DIFF
--- a/doc/apidoc.js
+++ b/doc/apidoc.js
@@ -2029,7 +2029,7 @@ github.orgs.addTeamMembership({ ... });
  * @apiParam {String} id  
  * @apiParam {String} org  
  * @apiParam {String} repo  
- * @apiParam {String} [permission=pull]  `pull` - team members can pull, but not push or administer this repositories (Default), `push` - team members can pull and push, but not administer this repositores, `admin` - team members can pull, push and administer these repositories.
+ * @apiParam {String} [permission]  `pull` - team members can pull, but not push or administer this repository, `push` - team members can pull and push, but not administer this repository, `admin` - team members can pull, push and administer this repository.
  * @apiExample {js} ex:
 github.orgs.addTeamRepo({ ... });
  */
@@ -2808,7 +2808,7 @@ github.reactions.getForPullRequestReviewComment({ ... });
  * @apiParam {String} user  
  * @apiParam {String} repo  
  * @apiParam {String} collabuser  
- * @apiParam {String} [permission=pull]  `pull` - team members can pull, but not push or administer this repositories (Default), `push` - team members can pull and push, but not administer this repositores, `admin` - team members can pull, push and administer these repositories.
+ * @apiParam {String} [permission=push]  `pull` - can pull, but not push to or administer this repository, `push` - can pull and push, but not administer this repository, `admin` - can pull, push and administer this repository.
  * @apiExample {js} ex:
 github.repos.addCollaborator({ ... });
  */
@@ -4551,7 +4551,7 @@ github.repos.updateFile({ ... });
  *
  * @apiParam {String} repo  
  * @apiParam {String} id  
- * @apiParam {String} [permission]  The permissions that the associated user will have on the repository. Valid values are read, write, and admin.
+ * @apiParam {String} [permission]  The permissions that the associated user will have on the repository.
  * @apiExample {js} ex:
 github.repos.updateInvite({ ... });
  */

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -154,14 +154,6 @@
                 "invalidmsg": "6 character hex code, without a leading #.",
                 "description": "6 character hex code, without a leading #."
             },
-            "permission": {
-                "type": "String",
-                "required": false,
-                "validation": "^(pull|push|admin)$",
-                "invalidmsg": "",
-                "description": "`pull` - team members can pull, but not push or administer this repositories (Default), `push` - team members can pull and push, but not administer this repositores, `admin` - team members can pull, push and administer these repositories.",
-                "default": "pull"
-            },
             "base": {
                 "type": "String",
                 "required": true,
@@ -3057,7 +3049,13 @@
                 "$id": null,
                 "$org": null,
                 "$repo": null,
-                "$permission": null
+                "permission": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "^(pull|push|admin)$",
+                    "invalidmsg": "",
+                    "description": "`pull` - team members can pull, but not push or administer this repository, `push` - team members can pull and push, but not administer this repository, `admin` - team members can pull, push and administer this repository."
+                }
             },
             "description": "Add team repository"
         },
@@ -4303,7 +4301,14 @@
                 "$user": null,
                 "$repo": null,
                 "$collabuser": null,
-                "$permission": null
+                "permission": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "^(pull|push|admin)$",
+                    "invalidmsg": "",
+                    "description": "`pull` - can pull, but not push to or administer this repository, `push` - can pull and push, but not administer this repository, `admin` - can pull, push and administer this repository.",
+                    "default": "push"
+                }
             },
             "description": "Add user as a collaborator"
         },
@@ -5035,7 +5040,7 @@
                     "required": false,
                     "validation": "^(read|write|admin)$",
                     "invalidmsg": "Read, write, or admin.",
-                    "description": "The permissions that the associated user will have on the repository. Valid values are read, write, and admin."
+                    "description": "The permissions that the associated user will have on the repository."
                 }
             },
             "description": "Update a repository invitation. (In preview period. See README.)"


### PR DESCRIPTION
The permission param was global in the routes.json but should really be
on a per-endpoint basis since it's slightly different for each. Also
change the add-collaborator default value to push to reflect a change in
the github api doc. The change applies to the following endpoints:

add-collaborator
update-invite
add-team-repo

resolves #421
