### PR TITLE
merge button rename squash param to merge_method

### DIFF
--- a/doc/apidoc.js
+++ b/doc/apidoc.js
@@ -2664,10 +2664,10 @@ github.pullRequests.getFiles({ ... });
  * @apiParam {String} user  
  * @apiParam {String} repo  
  * @apiParam {Number} number  
+ * @apiParam {String} [commit_title]  Title for the automatic commit message. (In preview period. See README.)
  * @apiParam {String} [commit_message]  Extra detail to append to automatic commit message.
  * @apiParam {String} [sha]  SHA that pull request head must match to allow merge
- * @apiParam {String} [commit_title]  Title for the automatic commit message. (In preview period. See README.)
- * @apiParam {Boolean} [squash]  Commit a single commit to the head branch. (In preview period. See README.)
+ * @apiParam {String} [merge_method=merge]  Merge method to use. Possible values are `merge`, `squash`, or `rebase`. (In preview period. See README.)
  * @apiExample {js} ex:
 github.pullRequests.merge({ ... });
  */

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -3379,6 +3379,13 @@
                 "$user": null,
                 "$repo": null,
                 "$number": null,
+                "commit_title": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "Title for the automatic commit message. (In preview period. See README.)"
+                },
                 "commit_message": {
                     "type": "String",
                     "required": false,
@@ -3393,19 +3400,13 @@
                     "invalidmsg": "",
                     "description": "SHA that pull request head must match to allow merge"
                 },
-                "commit_title": {
+                "merge_method": {
                     "type": "String",
                     "required": false,
-                    "validation": "",
-                    "invalidmsg": "",
-                    "description": "Title for the automatic commit message. (In preview period. See README.)"
-                },
-                "squash": {
-                    "type": "Boolean",
-                    "required": false,
-                    "validation": "",
-                    "invalidmsg": "",
-                    "description": "Commit a single commit to the head branch. (In preview period. See README.)"
+                    "validation": "^(merge|squash|rebase)$",
+                    "invalidmsg": "Possible values are: `merge`, `squash`, `rebase` Default: `merge`",
+                    "description": "Merge method to use. Possible values are `merge`, `squash`, or `rebase`. (In preview period. See README.)",
+                    "default": "merge"
                 }
             },
             "description": "Merge a pull request (Merge Button)"

--- a/test/pullRequestsTest.js
+++ b/test/pullRequestsTest.js
@@ -271,10 +271,10 @@ describe("[pullRequests]", function() {
                 user: "String",
                 repo: "String",
                 number: "Number",
+                commit_title: "String",
                 commit_message: "String",
                 sha: "String",
-                commit_title: "String",
-                squash: "Boolean"
+                merge_method: "String"
             },
             function(err, res) {
                 Assert.equal(err, null);


### PR DESCRIPTION
Merge button squash boolean param has been renamed to merge_method
string param.
