### PR TITLE
Episode VI: Return of the Promise PRs (getPage Promise support)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -414,9 +414,12 @@ var Client = module.exports = function(config) {
     };
 
     function getPage(link, which, headers, callback) {
+        var self = this;
         var url = getPageLinks(link)[which];
-        if (!url)
-            return callback(new error.NotFound("No " + which + " page found"));
+        if (!url) {
+            var urlErr = new error.NotFound("No " + which + " page found");
+            return self.Promise && !callback ? self.Promise.reject(urlErr) : callback(urlErr);
+        }
 
         var parsedUrl = Url.parse(url, true);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -466,7 +466,7 @@ var Client = module.exports = function(config) {
             callback = headers;
             headers = null;
         }
-        getPage.call(this, link, "next", headers, callback);
+        return getPage.call(this, link, "next", headers, callback);
     };
 
     /**
@@ -482,7 +482,7 @@ var Client = module.exports = function(config) {
             callback = headers;
             headers = null;
         }
-        getPage.call(this, link, "prev", headers, callback);
+        return getPage.call(this, link, "prev", headers, callback);
     };
 
     /**
@@ -498,7 +498,7 @@ var Client = module.exports = function(config) {
             callback = headers;
             headers = null;
         }
-        getPage.call(this, link, "last", headers, callback);
+        return getPage.call(this, link, "last", headers, callback);
     };
 
     /**
@@ -514,7 +514,7 @@ var Client = module.exports = function(config) {
             callback = headers;
             headers = null;
         }
-        getPage.call(this, link, "first", headers, callback);
+        return getPage.call(this, link, "first", headers, callback);
     };
 
     function getRequestFormat(hasBody, block) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -433,38 +433,24 @@ var Client = module.exports = function(config) {
             params: parsedUrl.query
         };
 
-        var self = this;
-        this.httpSend(msg, block, function(err, res) {
-            if (err)
-                return self.sendError(err, null, parsedUrl.query, callback);
-
-            var ret;
-            try {
-                ret = res.data;
-                var contentType = res.headers["content-type"];
-                if (contentType && contentType.indexOf("application/json") !== -1)
-                    ret = JSON.parse(ret);
-            }
-            catch (ex) {
-                if (callback)
-                    callback(new error.InternalServerError(ex.message), res);
-                return;
-            }
-
-            if (!ret)
-                ret = {};
-            if (typeof ret == "object") {
-                if (!ret.meta)
-                    ret.meta = {};
-                self.responseHeaders.forEach(function(header) {
-                    if (res.headers[header])
-                        ret.meta[header] = res.headers[header];
+        if (!callback) {
+            if (self.Promise) {
+                return new self.Promise(function(resolve,reject) {
+                    var cb = function(err, obj) {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve(obj);
+                        }
+                    };
+                    self.handler(msg, JSON.parse(JSON.stringify(block)), cb);
                 });
+            } else {
+                throw new Error('neither a callback or global promise implementation was provided');
             }
-
-            if (callback)
-                callback(null, ret);
-        });
+        } else {
+            self.handler(msg, JSON.parse(JSON.stringify(block)), callback);
+        }
     }
 
     /**


### PR DESCRIPTION
Was hesitant to re-open the issue you just closed #425. I had a similar situation where I was trying to retrieve a large number or all records via paging and promises.  

This PR follows in the footsteps of #262 and adds pluggable promise support to all `getPage` based methods.

Not as nice as I would've liked. Most of it is duplicated code taken from the #262 solution.
## Example outcome from PR:

``` javascript
var GitHubApi = require('github');

var gh = new GitHubApi ({
  Promise: require('bluebird')
});

function getAllOrgRepos(orgName) {
  var repos = [];

  function pager(res) {
    repos = repos.concat(res);
    if (gh.hasNextPage(res)) {
      return gh.getNextPage(res)
        .then(pager);
    }
    return repos;
  }

  return gh.repos.getForOrg({ org: orgName })
    .then(pager);
}


getAllOrgRepos('organization')
  .then(/* Do stuff with all repos */);
```

If this is not at all how you would like it approached feel free to close this PR, as not to waste your time 😸. Very happy to make changes.

Edit: Tidied up example code. 
