### PR TITLE
use lowercase `accept` header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -660,7 +660,7 @@ var Client = module.exports = function(config) {
                     break;
                 case "integration":
                     headers["Authorization"] = "Bearer " + this.auth.token;
-                    headers["Accept"] = "application/vnd.github.machine-man-preview+json"
+                    headers["accept"] = "application/vnd.github.machine-man-preview+json"
                     break;
                 case "basic":
                     basic = new Buffer(this.auth.username + ":" + this.auth.password, "ascii").toString("base64");


### PR DESCRIPTION
Hi everyone,

using the new `integration` authentication will cause setting the accept header twice (`Accept` and `accept`). This is a quick fix for that issue. We should still think about normalizing all headers.

Best,
Christoph
