### PR TITLE
Use body by default for non head/get/delete requests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -601,7 +601,7 @@ var Client = module.exports = function(config) {
         var self = this;
         var method = block.method.toLowerCase();
         var hasFileBody = block.hasFileBody;
-        var hasBody = !hasFileBody && typeof(msg.body) !== "undefined";
+        var hasBody = !hasFileBody && (typeof(msg.body) !== "undefined" || "head|get|delete".indexOf(method) === -1);
         var format = getRequestFormat.call(this, hasBody, block);
         var obj = getQueryAndUrl(msg, block, format, self.config);
         var query = obj.query;


### PR DESCRIPTION
Hey,

I noticed that for `github.repos.createStatus` the parameter were send as query parameter instead of the post body like it used to be. 

This is because of this https://github.com/mikedeboer/node-github/commit/acc62b29007f97736c9582ac67a204fe97beee79 recent change, that required the `msg` to have a `body` attribute, which is not the case here. I readded `("head|get|delete".indexOf(method) === -1)`, so it will use the body for `POST` requests by default.

Best,
Finn
