### PR TITLE
reject promise for missing parameters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -259,6 +259,9 @@ var Client = module.exports = function(config) {
                             self.sendError(ex, block, msg, callback);
                             if (self.debug)
                                 Util.log(ex.message, "fatal");
+
+                            if (self.Promise && typeof callback !== 'function') return self.Promise.reject(ex)
+
                             // on error, there's no need to continue.
                             return;
                         }


### PR DESCRIPTION
Hey,

right now the library doesn't throw an error if I specify the wrong parameters and using Promises. This PR adds the rejection that should happen in that case.

Best,
Finn
