### PR TITLE
fix typo in validation regex for get-org-membership

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -6495,7 +6495,7 @@
                 "state": {
                     "type": "String",
                     "required": false,
-                    "validation": "^(active|pending|)$",
+                    "validation": "^(active|pending)$",
                     "invalidmsg": "active, pending",
                     "description": "Indicates the state of the memberships to return. Can be either active or pending. If not specified, both active and pending memberships are returned."
                 }


### PR DESCRIPTION
Looks like this should be an "enum" with only two valid values?
https://developer.github.com/v3/orgs/members/#list-your-organization-memberships