### PR TITLE
Storing GitHub request ID and retry-after header

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -17,6 +17,8 @@
             "X-RateLimit-Reset",
             "X-Oauth-Scopes",
             "X-Poll-Interval",
+            "X-GitHub-Request-Id",
+            "Retry-After",
             "Link",
             "Location",
             "Last-Modified",


### PR DESCRIPTION
This adds two additional headers to those available in
the response metadata:

X-GitHub-RequestId: ID that is helpful to GitHub support if needed

Retry-After: to address abuse rate limits as documented in the GitHub
documentation at https://developer.github.com/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits