### PR TITLE
Add support for .netrc authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ github.authenticate({
     type: "integration",
     token: "jwt",
 });
+
+// ~/.netrc
+github.authenticate({
+    type: "netrc"
+});
 ```
 
 Note: `authenticate` is synchronous because it only stores the

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 var error = require("./error");
 var fs = require("fs");
 var mime = require("mime");
+var netrc = require("netrc");
 var Util = require("./util");
 var Url = require("url");
 var Promise = require("./promise");
@@ -346,8 +347,8 @@ var Client = module.exports = function(config) {
             this.auth = false;
             return;
         }
-        if (!options.type || "basic|oauth|client|token|integration".indexOf(options.type) === -1) {
-            throw new Error("Invalid authentication type, must be 'basic', 'integration', 'oauth' or 'client'");
+        if (!options.type || "basic|oauth|client|token|integration|netrc".indexOf(options.type) === -1) {
+            throw new Error("Invalid authentication type, must be 'basic', 'integration', 'oauth', 'client' or 'netrc'");
         }
         if (options.type == "basic" && (!options.username || !options.password)) {
             throw new Error("Basic authentication requires both a username and password to be set");
@@ -682,6 +683,13 @@ var Client = module.exports = function(config) {
                     basic = new Buffer(this.auth.username + ":" + this.auth.password, "ascii").toString("base64");
                     headers["Authorization"] = "Basic " + basic;
                     break;
+                case "netrc":
+                    var auth = netrc()["api.github.com"];
+                    if (!auth) {
+                        throw new Error("~/.netrc authentication type chosen but credentials for 'api.github.com' are not available");
+                    }
+                    basic = new Buffer(auth.login + ":" + auth.password, "ascii").toString("base64");
+                    headers["Authorization"] = "Basic " + basic;
                 default:
                     break;
             }

--- a/lib/index.js.flow
+++ b/lib/index.js.flow
@@ -47,12 +47,18 @@ declare module "github" {
     token: string;
   };
 
+  declare type AuthNetrc = {
+    type: "netrc";
+    token: string;
+  };
+
   declare type Auth =
     | AuthBasic
     | AuthOAuthToken
     | AuthOAuthSecret
     | AuthUserToken
-    | AuthJWT;
+    | AuthJWT
+    | AuthNetrc;
 
   declare type Link =
     | { link: string; }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "dependencies": {
     "follow-redirects": "0.0.7",
     "https-proxy-agent": "^1.0.0",
-    "mime": "^1.2.11"
+    "mime": "^1.2.11",
+    "netrc": "^0.1.4"
   },
   "devDependencies": {
     "mocha": "~1.13.0",


### PR DESCRIPTION
Super quick PR to enable `.netrc` authentication. Closes https://github.com/mikedeboer/node-github/issues/466.

Add the following configuration to your `~/.netrc` file:

```sh
> ~/.netrc
machine api.github.com
login <username>
password <token>
protocol https
```

Then simply authenticate with `github.authenticate({ type: 'netrc' })`. 

Let me know if there's anything missing.