### PR TITLE
Provides correct values for moveProjectsCard "position" parameter

### DIFF
--- a/doc/apidoc.js
+++ b/doc/apidoc.js
@@ -31334,7 +31334,7 @@ github.projects.getRepoProjects({ ... });
  * @apiGroup projects
  *
  * @apiParam {String} id  
- * @apiParam {String} position  Can be one of first, last, or after:<column-id>, where <column-id> is the id value of a column in the same project.
+ * @apiParam {String} position  Can be one of top, bottom, or after:<column-id>, where <column-id> is the id value of a column in the same project.
  * @apiParam {String} [column_id]  The id value of a column in the same project.
  * @apiExample {js} ex:
 github.projects.moveProjectCard({ ... });

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -3705,9 +3705,9 @@
                 "position": {
                     "type": "String",
                     "required": true,
-                    "validation": "^(first|last|after:\\d)$",
+                    "validation": "^(top|bottom|after:\\d)$",
                     "invalidmsg": "",
-                    "description": "Can be one of first, last, or after:<column-id>, where <column-id> is the id value of a column in the same project."
+                    "description": "Can be one of top, bottom, or after:<column-id>, where <column-id> is the id value of a column in the same project."
                 },
                 "column_id": {
                     "type": "String",


### PR DESCRIPTION
As per https://developer.github.com/v3/projects/cards/#move-a-project-card

Valid values with the Node module for the "position" parameter are currently `first|last|after:`
Putting those into `github.projects.moveProjectsCard` passes internal validation, but the API returns:
```
Move failed: {"message":"Invalid request.\n\nfirst does not match /^(?:top|bottom|after:\\d+)$/.", "documentation_url":"https://developer.github.com/v3"}
```

I've changed the validation property in `routes.json` as well as the description to match the API, and the `top|bottom` values work fine. 

I have *not* run `node lib/generate.js` as it changed a ton in doc/apidoc.js with the 7.0.1 switch, and I'm not sure how to verify that all that should be correct. `npm test` also only passes 11 of 300+, but that is also the case for the current HEAD.

Let me know if anything else is necessary for this.