### PR TITLE
code: Add `maintainer_can_modify` flag to create pull request

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1249,6 +1249,7 @@ declare namespace Github {
     & {
       title: string;
       body?: string[];
+      maintainer_can_modify?: boolean;
     };
   export type PullRequestsCreateFromIssueParams =
     & Owner

--- a/lib/index.js.flow
+++ b/lib/index.js.flow
@@ -1244,6 +1244,7 @@ declare module "github" {
     & {
       title: string;
       body?: string[];
+      maintainer_can_modify?: boolean;
     };
   declare type PullRequestsCreateFromIssueParams =
     & Owner

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -3871,6 +3871,12 @@
                     "validation": "",
                     "invalidmsg": "",
                     "description": "The contents of the pull request."
+                },
+                "maintainer_can_modify": {
+                    "type": "Boolean",
+                    "required": false,
+                    "default": "true",
+                    "description": "Indicates whether maintainers can modify the pull request."
                 }
             },
             "description": "Create a pull request"

--- a/test/pullRequestsTest.js
+++ b/test/pullRequestsTest.js
@@ -50,7 +50,8 @@ describe("[pullRequests]", function() {
                 title: "String",
                 head: "String",
                 base: "String",
-                body: "String"
+                body: "String",
+                maintainer_can_modify: "Boolean"
             },
             function(err, res) {
                 Assert.equal(err, null);


### PR DESCRIPTION
When creating a pull request against a HEAD that you don't own, an error is thrown when this isn't set to `false`.

I updated `lib/routes.json` with the additional parameter (`maintainer_can_modify`) and ran `node lib/generate.js` to regenerate the routes as mentioned in `CONTRIBUTING.md`.

See https://github.com/mikedeboer/node-github/issues/490 for an explanation for why this is the case.