### PR TITLE
always return response as object with data/meta

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -851,12 +851,13 @@ var Client = module.exports = function(config) {
 
             var ret;
             try {
+                var data = res.data;
+                
                 var contentType = res.headers["content-type"];
                 if (contentType && contentType.indexOf("application/json") !== -1) {
-                    ret = res.data && JSON.parse(res.data);
-                } else {
-                    ret = {data: res.data};
+                    data = res.data && JSON.parse(res.data);
                 }
+                ret = {data: data};
             } catch (ex) {
                 if (callback) {
                     callback(new error.InternalServerError(ex.message), res);


### PR DESCRIPTION
Always return a response as an object with data and meta attributes.

resolves #497
resolves #504