### PR TITLE
(bug): Change pulls getComments to issues

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -4048,7 +4048,7 @@
             "description": "Dismiss a pull request review. (In preview period. See README.)"
         },
         "get-comments": {
-            "url": "/repos/:owner/:repo/pulls/:number/comments",
+            "url": "/repos/:owner/:repo/issues/:number/comments",
             "method": "GET",
             "params": {
                 "$owner": null,


### PR DESCRIPTION
There is no comments end point on pulls, to get PR comments you have to go through the issues API. Not sure if this is the only end point affected, but this was a bug that I was running into in #497 and further outlined by @therobinkim in #510. 