### PR TITLE
Org blocks

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1144,6 +1144,23 @@ declare namespace Github {
     & Org
     & Id
     ;
+  export type OrgsGetBlockedUsersParams =
+    & Org
+    & Page
+    & PerPage
+    ;
+  export type OrgsCheckBlockedUserParams =
+    & Org
+    & Username
+    ;
+  export type OrgsBlockUserParams =
+    & Org
+    & Username
+    ;
+  export type OrgsUnblockUserParams =
+    & Org
+    & Username
+    ;
   export type ProjectsGetRepoProjectsParams =
     & Owner
     & Repo
@@ -2761,6 +2778,10 @@ declare class Github {
     editHook(params: Github.OrgsEditHookParams, callback?: Github.Callback): Promise<any>;
     pingHook(params: Github.OrgsPingHookParams, callback?: Github.Callback): Promise<any>;
     deleteHook(params: Github.OrgsDeleteHookParams, callback?: Github.Callback): Promise<any>;
+    getBlockedUsers(params: Github.OrgsGetBlockedUsersParams, callback?: Github.Callback): Promise<any>;
+    checkBlockedUser(params: Github.OrgsCheckBlockedUserParams, callback?: Github.Callback): Promise<any>;
+    blockUser(params: Github.OrgsBlockUserParams, callback?: Github.Callback): Promise<any>;
+    unblockUser(params: Github.OrgsUnblockUserParams, callback?: Github.Callback): Promise<any>;
   };
   projects: {
     getRepoProjects(params: Github.ProjectsGetRepoProjectsParams, callback?: Github.Callback): Promise<any>;

--- a/lib/index.js.flow
+++ b/lib/index.js.flow
@@ -1139,6 +1139,23 @@ declare module "github" {
     & Org
     & Id
     ;
+  declare type OrgsGetBlockedUsersParams =
+    & Org
+    & Page
+    & PerPage
+    ;
+  declare type OrgsCheckBlockedUserParams =
+    & Org
+    & Username
+    ;
+  declare type OrgsBlockUserParams =
+    & Org
+    & Username
+    ;
+  declare type OrgsUnblockUserParams =
+    & Org
+    & Username
+    ;
   declare type ProjectsGetRepoProjectsParams =
     & Owner
     & Repo
@@ -2746,6 +2763,10 @@ declare module "github" {
       editHook(params: OrgsEditHookParams, callback?: Callback): Promise<any>;
       pingHook(params: OrgsPingHookParams, callback?: Callback): Promise<any>;
       deleteHook(params: OrgsDeleteHookParams, callback?: Callback): Promise<any>;
+      getBlockedUsers(params: OrgsGetBlockedUsersParams, callback?: Callback): Promise<any>;
+      checkBlockedUser(params: OrgsCheckBlockedUserParams, callback?: Callback): Promise<any>;
+      blockUser(params: OrgsBlockUserParams, callback?: Callback): Promise<any>;
+      unblockUser(params: OrgsUnblockUserParams, callback?: Callback): Promise<any>;
     };
     projects: {
       getRepoProjects(params: ProjectsGetRepoProjectsParams, callback?: Callback): Promise<any>;

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -562,7 +562,9 @@
             ],
             "application/vnd.github.giant-sentry-fist-preview+json": [
                 "/user/blocks",
-                "/user/blocks/:username"
+                "/user/blocks/:username",
+                "/orgs/:org/blocks",
+                "/orgs/:org/blocks/:username"
             ]
         }
     },
@@ -3453,6 +3455,43 @@
                 "$id": null
             },
             "description": "Delete a hook"
+        },
+        "get-blocked-users": {
+            "url": "/orgs/:org/blocks",
+            "method": "GET",
+            "params": {
+                "$org": null,
+                "$page": null,
+                "$per_page": null
+            },
+            "description": "List blocked users. (In preview period. See README.)"
+        },
+        "check-blocked-user": {
+            "url": "/orgs/:org/blocks/:username",
+            "method": "GET",
+            "params": {
+                "$org": null,
+                "$username": null
+            },
+            "description": "Check whether you've blocked a user. (In preview period. See README.)"
+        },
+        "block-user": {
+            "url": "/orgs/:org/blocks/:username",
+            "method": "PUT",
+            "params": {
+                "$org": null,
+                "$username": null
+            },
+            "description": "Block a user. (In preview period. See README.)"
+        },
+        "unblock-user": {
+            "url": "/orgs/:org/blocks/:username",
+            "method": "DELETE",
+            "params": {
+                "$org": null,
+                "$username": null
+            },
+            "description": "Unblock a user. (In preview period. See README.)"
         }
     },
     "projects": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "description": "NodeJS wrapper for the GitHub API",
   "author": "Mike de Boer <info@mikedeboer.nl>",
   "contributors": [

--- a/test/orgsTest.js
+++ b/test/orgsTest.js
@@ -71,6 +71,34 @@ describe("[orgs]", function() {
         );
     });
 
+    it("should successfully execute PUT /orgs/:org/blocks/:username (blockUser)",  function(next) {
+        client.orgs.blockUser(
+            {
+                org: "String",
+                username: "String"
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                // other assertions go here
+                next();
+            }
+        );
+    });
+
+    it("should successfully execute GET /orgs/:org/blocks/:username (checkBlockedUser)",  function(next) {
+        client.orgs.checkBlockedUser(
+            {
+                org: "String",
+                username: "String"
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                // other assertions go here
+                next();
+            }
+        );
+    });
+
     it("should successfully execute GET /orgs/:org/members/:username (checkMembership)",  function(next) {
         client.orgs.checkMembership(
             {
@@ -271,6 +299,21 @@ describe("[orgs]", function() {
         client.orgs.getAll(
             {
                 since: "String",
+                page: "Number",
+                per_page: "Number"
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                // other assertions go here
+                next();
+            }
+        );
+    });
+
+    it("should successfully execute GET /orgs/:org/blocks (getBlockedUsers)",  function(next) {
+        client.orgs.getBlockedUsers(
+            {
+                org: "String",
                 page: "Number",
                 per_page: "Number"
             },
@@ -560,6 +603,20 @@ describe("[orgs]", function() {
         client.orgs.removeTeamMembership(
             {
                 id: "String",
+                username: "String"
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                // other assertions go here
+                next();
+            }
+        );
+    });
+
+    it("should successfully execute DELETE /orgs/:org/blocks/:username (unblockUser)",  function(next) {
+        client.orgs.unblockUser(
+            {
+                org: "String",
                 username: "String"
             },
             function(err, res) {


### PR DESCRIPTION
The Org Blocking API is the same as the User Blocking API, so I basically just copied commit 8413595a3c5071addef14d679cc51a8c35e54f44 and added the `org` parameter.

Also: I just found (not surprising) that API supports pagination when listing the block users. So, I added `page` and `per_page` params.

https://developer.github.com/v3/orgs/blocking/