### PR TITLE
set accept header on pagination

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -478,6 +478,7 @@ var Client = module.exports = function(config) {
             callback = headers;
             headers = null;
         }
+        headers = applyAcceptHeader(link, headers);
         return getPage.call(this, link, "next", headers, callback);
     };
 
@@ -494,6 +495,7 @@ var Client = module.exports = function(config) {
             callback = headers;
             headers = null;
         }
+        headers = applyAcceptHeader(link, headers);
         return getPage.call(this, link, "prev", headers, callback);
     };
 
@@ -510,6 +512,7 @@ var Client = module.exports = function(config) {
             callback = headers;
             headers = null;
         }
+        headers = applyAcceptHeader(link, headers);
         return getPage.call(this, link, "last", headers, callback);
     };
 
@@ -526,8 +529,19 @@ var Client = module.exports = function(config) {
             callback = headers;
             headers = null;
         }
+        headers = applyAcceptHeader(link, headers);
         return getPage.call(this, link, "first", headers, callback);
     };
+
+    function applyAcceptHeader(res, headers) {
+        var previous = res.meta && res.meta['x-github-media-type'];
+        if (!previous || (headers && headers.accept)) {
+            return headers;
+        }
+        headers = headers || {};
+        headers.accept = 'application/vnd.' + previous.replace('; format=', '+');
+        return headers;
+    }
 
     function getRequestFormat(hasBody, block) {
         if (hasBody) {

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -18,6 +18,7 @@
             "X-Oauth-Scopes",
             "X-Poll-Interval",
             "X-GitHub-Request-Id",
+            "X-GitHub-Media-Type",
             "Retry-After",
             "Link",
             "Location",


### PR DESCRIPTION
When using the [Preview APIs](https://github.com/mikedeboer/node-github#preview-apis) (which nicely sets the custom `Accept` header) and then trying to paginate using `getNextPage`, `getPreviousPage`, and `getLastPage` fails because the custom `Accept` header does not get set on these calls.

Fortunately, GitHub provides a `X-GitHub-Media-Type` **response** header that echos the requested type. This PR uses this to re-create the `Accept` header on the paged requests.

Example `X-GitHub-Media-Type: github.giant-sentry-fist-preview; format=json`

**Non-preview API calls** return `X-GitHub-Media-Type: github.v3; format=json`... which works just fine also.

related: #229

If this PR is not desirable, I'll note for others that you can get this response header returned in your  meta objects by adding the `X-GitHub-Media-Type` value to the `responseHeaders` array like this:
```js
const GitHubApi = require('github')
const github = new GitHubApi({})

github.responseHeaders.push('x-github-media-type')
```
