### PR TITLE
Update messaging to mention all auth types.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -302,7 +302,7 @@ var Client = module.exports = function(config) {
     /**
      *  Client#authenticate(options) -> null
      *      - options (Object): Object containing the authentication type and credentials
-     *          - type (String): One of the following: `basic`, `oauth`, `token`, or `integration`
+     *          - type (String): One of the following: `basic`, `oauth`, `client`, `token`, `integration` or `netrc`
      *          - username (String): Github username
      *          - password (String): Password to your account
      *          - token (String): oauth/jwt token
@@ -349,7 +349,7 @@ var Client = module.exports = function(config) {
             return;
         }
         if (!options.type || "basic|oauth|client|token|integration|netrc".indexOf(options.type) === -1) {
-            throw new Error("Invalid authentication type, must be 'basic', 'integration', 'oauth', 'client' or 'netrc'");
+            throw new Error("Invalid authentication type; must be 'basic', 'oauth', 'client', 'token', 'integration' or 'netrc'");
         }
         if (options.type == "basic" && (!options.username || !options.password)) {
             throw new Error("Basic authentication requires both a username and password to be set");


### PR DESCRIPTION
- Docstring didn't mention `client` or `netrc`.
- Error message didn't mention `client`.