### PR TITLE
Collaborators preview API "direct" affiliation

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1786,7 +1786,7 @@ declare namespace Github {
     & Page
     & PerPage
     & {
-      affiliation?: "outside"|"all";
+      affiliation?: "outside"|"all"|"direct";
     };
   export type ReposCheckCollaboratorParams =
     & Owner

--- a/lib/index.js.flow
+++ b/lib/index.js.flow
@@ -1781,7 +1781,7 @@ declare module "github" {
     & Page
     & PerPage
     & {
-      affiliation?: "outside"|"all";
+      affiliation?: "outside"|"all"|"direct";
     };
   declare type ReposCheckCollaboratorParams =
     & Owner

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -5177,12 +5177,13 @@
                 "affiliation": {
                     "type": "String",
                     "required": false,
-                    "validation": "^(outside|all)$",
-                    "invalidmsg": "outside, all, default: all",
+                    "validation": "^(outside|all|direct)$",
+                    "invalidmsg": "outside, all, direct, default: all",
                     "description": "Filter collaborators returned by their affiliation.",
                     "enum": [
                         "outside",
-                        "all"
+                        "all",
+                        "direct"
                     ],
                     "default": "all"
                 },


### PR DESCRIPTION
The Collaborators preview API also supports an affiliation value
of "direct" in addition to "all" and "outside". This adds the
value to the route and regenerates the API docs.

Fixes #520 