### PR TITLE
avoid a code pyramid

### DIFF
--- a/examples/testPromise.js
+++ b/examples/testPromise.js
@@ -13,8 +13,7 @@ github.orgs.getAll({
     per_page: 100
 }).then(function(res) {
     console.log(res);
-    
-    github.users.getById({ id: "429706" }).then(function(res) {
-        console.log(res);
-    });
+    return github.users.getById({ id: "429706" });
+}).then(function(res) {
+   console.log(res);
 });


### PR DESCRIPTION
This modifies the bluebird promise example to avoid the [callback hell](http://callbackhell.com/) nested code phenomenon.