### PR TITLE
Remove node-github deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-**NOTE: The `node-github` npm package is deprecated. You want the `github` npm package (see Installation).**
-
 # Node-github
 
 [![npm](https://img.shields.io/npm/v/github.svg)](https://www.npmjs.com/package/github)


### PR DESCRIPTION
I found the deprecation warning confusion because I assumed it meant _this_ repo was deprecated. https://www.npmjs.com/package/node-github would probably be a better place to publish the deprecation warning.

It looks like `node-github` hasn't been used for 5 years, and currently only has ~200 downloads/week, compared to >115,000 downloads for the `github` package. Is it safe to assume it's dead?