### PR TITLE
add NO_PROXY environment variable handling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -659,11 +659,27 @@ var Client = module.exports = function(config) {
         var agent = undefined;
         if (this.config.proxy !== undefined) {
             proxyUrl = this.config.proxy;
-        } else {
+        } else if (!noProxy(host,port)) {
             proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
         }
         if (proxyUrl) {
             agent = new HttpsProxyAgent(proxyUrl);
+        }
+
+        function noProxy(host, port) {
+            host = host.replace(/^\.*/,'.');
+            var noProxyString = process.env.NO_PROXY || process.env.no_proxy;
+            if (!noProxyString) {
+                return false;
+            }
+            if(noProxyString === '*') {
+                return true;
+            }
+            var noProxyList = noProxyString.split(',').map( function(s) {return s.split(':',2)} );
+            return noProxyList.some(function(noProxyEntry) {
+                var noProxyRegExp = new RegExp(noProxyEntry[0].replace(/^\.*/,'.').split('.').join('\\.')+'$');
+                return noProxyRegExp.test(host,'i') && (!noProxyEntry[1] || noProxyEntry[1]==port);
+            });
         }
         
         var ca = this.config.ca;


### PR DESCRIPTION
Title says it all. Currently only HTTP_PROXY and HTTPS_PROXY are taken into account but NO_PROXY is ignored. This might be important for users behind a corporate firewall connecting to a corporate GitHub that is located inside the corporate network.