### PR TITLE
Updated api urls for convert/remove collaborator. Issue #558

### DIFF
--- a/doc/apidoc.js
+++ b/doc/apidoc.js
@@ -25171,7 +25171,7 @@ github.orgs.concealMembership({ ... });
  */
 
 /**
- * @api {put} /orgs/:org/outside_collaborator/:username convertMemberToOutsideCollaborator
+ * @api {put} /orgs/:org/outside_collaborators/:username convertMemberToOutsideCollaborator
  * @apiVersion 8.2.1
  * @apiName convertMemberToOutsideCollaborator
  * @apiDescription Convert member to outside collaborator.
@@ -25557,7 +25557,7 @@ github.orgs.removeOrgMembership({ ... });
  */
 
 /**
- * @api {delete} /orgs/:org/outside_collaborator/:username removeOutsideCollaborator
+ * @api {delete} /orgs/:org/outside_collaborators/:username removeOutsideCollaborator
  * @apiVersion 8.2.1
  * @apiName removeOutsideCollaborator
  * @apiDescription Remove outside collaborator.
@@ -31196,7 +31196,7 @@ github.orgs.concealMembership({ ... });
  */
 
 /**
- * @api {put} /orgs/:org/outside_collaborator/:username convertMemberToOutsideCollaborator
+ * @api {put} /orgs/:org/outside_collaborators/:username convertMemberToOutsideCollaborator
  * @apiVersion 9.1.0
  * @apiName convertMemberToOutsideCollaborator
  * @apiDescription Convert member to outside collaborator.
@@ -31582,7 +31582,7 @@ github.orgs.removeOrgMembership({ ... });
  */
 
 /**
- * @api {delete} /orgs/:org/outside_collaborator/:username removeOutsideCollaborator
+ * @api {delete} /orgs/:org/outside_collaborators/:username removeOutsideCollaborator
  * @apiVersion 9.1.0
  * @apiName removeOutsideCollaborator
  * @apiDescription Remove outside collaborator.

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -3129,7 +3129,7 @@
             "description": "List all users who are outside collaborators of an organization."
         },
         "remove-outside-collaborator": {
-            "url": "/orgs/:org/outside_collaborator/:username",
+            "url": "/orgs/:org/outside_collaborators/:username",
             "method": "DELETE",
             "params": {
                 "$org": null,
@@ -3138,7 +3138,7 @@
             "description": "Remove outside collaborator."
         },
         "convert-member-to-outside-collaborator": {
-            "url": "/orgs/:org/outside_collaborator/:username",
+            "url": "/orgs/:org/outside_collaborators/:username",
             "method": "PUT",
             "params": {
                 "$org": null,

--- a/test/orgsTest.js
+++ b/test/orgsTest.js
@@ -156,7 +156,7 @@ describe("[orgs]", function() {
         );
     });
 
-    it("should successfully execute PUT /orgs/:org/outside_collaborator/:username (convertMemberToOutsideCollaborator)",  function(next) {
+    it("should successfully execute PUT /orgs/:org/outside_collaborators/:username (convertMemberToOutsideCollaborator)",  function(next) {
         client.orgs.convertMemberToOutsideCollaborator(
             {
                 org: "String",
@@ -585,7 +585,7 @@ describe("[orgs]", function() {
         );
     });
 
-    it("should successfully execute DELETE /orgs/:org/outside_collaborator/:username (removeOutsideCollaborator)",  function(next) {
+    it("should successfully execute DELETE /orgs/:org/outside_collaborators/:username (removeOutsideCollaborator)",  function(next) {
         client.orgs.removeOutsideCollaborator(
             {
                 org: "String",


### PR DESCRIPTION
This is linked to issue #558 
I updated all occurances of `/orgs/:org/outside_collaborator/:username` to `/orgs/:org/outside_collaborators/:username`
This aligns with GitHub's official documentation here: https://developer.github.com/v3/orgs/outside_collaborators/