### PR TITLE
GitHub Integrations => GitHub Apps

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -547,28 +547,28 @@ declare namespace Github {
       tree: string;
       base_tree?: string;
     };
-  export type IntegrationsGetInstallationsParams =
+  export type AppsGetInstallationsParams =
     & Page
     & PerPage
     ;
-  export type IntegrationsCreateInstallationTokenParams =
+  export type AppsCreateInstallationTokenParams =
     & InstallationId
     & {
       user_id?: string;
     };
-  export type IntegrationsGetUserIdentityParams =
+  export type AppsGetUserIdentityParams =
     & {
       nonce?: string;
     };
-  export type IntegrationsGetInstallationRepositoriesParams =
+  export type AppsGetInstallationRepositoriesParams =
     & {
       user_id?: string;
     };
-  export type IntegrationsAddRepoToInstallationParams =
+  export type AppsAddRepoToInstallationParams =
     & InstallationId
     & RepositoryId
     ;
-  export type IntegrationsRemoveRepoFromInstallationParams =
+  export type AppsRemoveRepoFromInstallationParams =
     & InstallationId
     & RepositoryId
     ;
@@ -2692,13 +2692,13 @@ declare class Github {
     getTree(params: Github.GitdataGetTreeParams, callback?: Github.Callback): Promise<any>;
     createTree(params: Github.GitdataCreateTreeParams, callback?: Github.Callback): Promise<any>;
   };
-  integrations: {
-    getInstallations(params: Github.IntegrationsGetInstallationsParams, callback?: Github.Callback): Promise<any>;
-    createInstallationToken(params: Github.IntegrationsCreateInstallationTokenParams, callback?: Github.Callback): Promise<any>;
-    getUserIdentity(params: Github.IntegrationsGetUserIdentityParams, callback?: Github.Callback): Promise<any>;
-    getInstallationRepositories(params: Github.IntegrationsGetInstallationRepositoriesParams, callback?: Github.Callback): Promise<any>;
-    addRepoToInstallation(params: Github.IntegrationsAddRepoToInstallationParams, callback?: Github.Callback): Promise<any>;
-    removeRepoFromInstallation(params: Github.IntegrationsRemoveRepoFromInstallationParams, callback?: Github.Callback): Promise<any>;
+  apps: {
+    getInstallations(params: Github.AppsGetInstallationsParams, callback?: Github.Callback): Promise<any>;
+    createInstallationToken(params: Github.AppsCreateInstallationTokenParams, callback?: Github.Callback): Promise<any>;
+    getUserIdentity(params: Github.AppsGetUserIdentityParams, callback?: Github.Callback): Promise<any>;
+    getInstallationRepositories(params: Github.AppsGetInstallationRepositoriesParams, callback?: Github.Callback): Promise<any>;
+    addRepoToInstallation(params: Github.AppsAddRepoToInstallationParams, callback?: Github.Callback): Promise<any>;
+    removeRepoFromInstallation(params: Github.AppsRemoveRepoFromInstallationParams, callback?: Github.Callback): Promise<any>;
   };
   issues: {
     getAll(params: Github.IssuesGetAllParams, callback?: Github.Callback): Promise<any>;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -547,6 +547,31 @@ declare namespace Github {
       tree: string;
       base_tree?: string;
     };
+  export type IntegrationsGetInstallationsParams =
+    & Page
+    & PerPage
+    ;
+  export type IntegrationsCreateInstallationTokenParams =
+    & InstallationId
+    & {
+      user_id?: string;
+    };
+  export type IntegrationsGetUserIdentityParams =
+    & {
+      nonce?: string;
+    };
+  export type IntegrationsGetInstallationRepositoriesParams =
+    & {
+      user_id?: string;
+    };
+  export type IntegrationsAddRepoToInstallationParams =
+    & InstallationId
+    & RepositoryId
+    ;
+  export type IntegrationsRemoveRepoFromInstallationParams =
+    & InstallationId
+    & RepositoryId
+    ;
   export type AppsGetInstallationsParams =
     & Page
     & PerPage
@@ -2691,6 +2716,14 @@ declare class Github {
     getTagSignatureVerification(params: Github.GitdataGetTagSignatureVerificationParams, callback?: Github.Callback): Promise<any>;
     getTree(params: Github.GitdataGetTreeParams, callback?: Github.Callback): Promise<any>;
     createTree(params: Github.GitdataCreateTreeParams, callback?: Github.Callback): Promise<any>;
+  };
+  integrations: {
+    getInstallations(params: Github.IntegrationsGetInstallationsParams, callback?: Github.Callback): Promise<any>;
+    createInstallationToken(params: Github.IntegrationsCreateInstallationTokenParams, callback?: Github.Callback): Promise<any>;
+    getUserIdentity(params: Github.IntegrationsGetUserIdentityParams, callback?: Github.Callback): Promise<any>;
+    getInstallationRepositories(params: Github.IntegrationsGetInstallationRepositoriesParams, callback?: Github.Callback): Promise<any>;
+    addRepoToInstallation(params: Github.IntegrationsAddRepoToInstallationParams, callback?: Github.Callback): Promise<any>;
+    removeRepoFromInstallation(params: Github.IntegrationsRemoveRepoFromInstallationParams, callback?: Github.Callback): Promise<any>;
   };
   apps: {
     getInstallations(params: Github.AppsGetInstallationsParams, callback?: Github.Callback): Promise<any>;

--- a/lib/index.js
+++ b/lib/index.js
@@ -252,6 +252,12 @@ var Client = module.exports = function(config) {
                     }
 
                     self[section][funcName] = function(msg, callback) {
+                        if (block.deprecated) {
+                          const caller = (new Error()).stack.split('\n')[2];
+                          console.warn('DEPRECATED: ' + block.deprecated);
+                          console.warn(caller);
+                        }
+
                         try {
                             parseParams(msg, block.params);
                         } catch (ex) {

--- a/lib/index.js.flow
+++ b/lib/index.js.flow
@@ -542,28 +542,28 @@ declare module "github" {
       tree: string;
       base_tree?: string;
     };
-  declare type IntegrationsGetInstallationsParams =
+  declare type AppsGetInstallationsParams =
     & Page
     & PerPage
     ;
-  declare type IntegrationsCreateInstallationTokenParams =
+  declare type AppsCreateInstallationTokenParams =
     & InstallationId
     & {
       user_id?: string;
     };
-  declare type IntegrationsGetUserIdentityParams =
+  declare type AppsGetUserIdentityParams =
     & {
       nonce?: string;
     };
-  declare type IntegrationsGetInstallationRepositoriesParams =
+  declare type AppsGetInstallationRepositoriesParams =
     & {
       user_id?: string;
     };
-  declare type IntegrationsAddRepoToInstallationParams =
+  declare type AppsAddRepoToInstallationParams =
     & InstallationId
     & RepositoryId
     ;
-  declare type IntegrationsRemoveRepoFromInstallationParams =
+  declare type AppsRemoveRepoFromInstallationParams =
     & InstallationId
     & RepositoryId
     ;
@@ -2677,13 +2677,13 @@ declare module "github" {
       getTree(params: GitdataGetTreeParams, callback?: Callback): Promise<any>;
       createTree(params: GitdataCreateTreeParams, callback?: Callback): Promise<any>;
     };
-    integrations: {
-      getInstallations(params: IntegrationsGetInstallationsParams, callback?: Callback): Promise<any>;
-      createInstallationToken(params: IntegrationsCreateInstallationTokenParams, callback?: Callback): Promise<any>;
-      getUserIdentity(params: IntegrationsGetUserIdentityParams, callback?: Callback): Promise<any>;
-      getInstallationRepositories(params: IntegrationsGetInstallationRepositoriesParams, callback?: Callback): Promise<any>;
-      addRepoToInstallation(params: IntegrationsAddRepoToInstallationParams, callback?: Callback): Promise<any>;
-      removeRepoFromInstallation(params: IntegrationsRemoveRepoFromInstallationParams, callback?: Callback): Promise<any>;
+    apps: {
+      getInstallations(params: AppsGetInstallationsParams, callback?: Callback): Promise<any>;
+      createInstallationToken(params: AppsCreateInstallationTokenParams, callback?: Callback): Promise<any>;
+      getUserIdentity(params: AppsGetUserIdentityParams, callback?: Callback): Promise<any>;
+      getInstallationRepositories(params: AppsGetInstallationRepositoriesParams, callback?: Callback): Promise<any>;
+      addRepoToInstallation(params: AppsAddRepoToInstallationParams, callback?: Callback): Promise<any>;
+      removeRepoFromInstallation(params: AppsRemoveRepoFromInstallationParams, callback?: Callback): Promise<any>;
     };
     issues: {
       getAll(params: IssuesGetAllParams, callback?: Callback): Promise<any>;

--- a/lib/index.js.flow
+++ b/lib/index.js.flow
@@ -542,6 +542,31 @@ declare module "github" {
       tree: string;
       base_tree?: string;
     };
+  declare type IntegrationsGetInstallationsParams =
+    & Page
+    & PerPage
+    ;
+  declare type IntegrationsCreateInstallationTokenParams =
+    & InstallationId
+    & {
+      user_id?: string;
+    };
+  declare type IntegrationsGetUserIdentityParams =
+    & {
+      nonce?: string;
+    };
+  declare type IntegrationsGetInstallationRepositoriesParams =
+    & {
+      user_id?: string;
+    };
+  declare type IntegrationsAddRepoToInstallationParams =
+    & InstallationId
+    & RepositoryId
+    ;
+  declare type IntegrationsRemoveRepoFromInstallationParams =
+    & InstallationId
+    & RepositoryId
+    ;
   declare type AppsGetInstallationsParams =
     & Page
     & PerPage
@@ -2676,6 +2701,14 @@ declare module "github" {
       getTagSignatureVerification(params: GitdataGetTagSignatureVerificationParams, callback?: Callback): Promise<any>;
       getTree(params: GitdataGetTreeParams, callback?: Callback): Promise<any>;
       createTree(params: GitdataCreateTreeParams, callback?: Callback): Promise<any>;
+    };
+    integrations: {
+      getInstallations(params: IntegrationsGetInstallationsParams, callback?: Callback): Promise<any>;
+      createInstallationToken(params: IntegrationsCreateInstallationTokenParams, callback?: Callback): Promise<any>;
+      getUserIdentity(params: IntegrationsGetUserIdentityParams, callback?: Callback): Promise<any>;
+      getInstallationRepositories(params: IntegrationsGetInstallationRepositoriesParams, callback?: Callback): Promise<any>;
+      addRepoToInstallation(params: IntegrationsAddRepoToInstallationParams, callback?: Callback): Promise<any>;
+      removeRepoFromInstallation(params: IntegrationsRemoveRepoFromInstallationParams, callback?: Callback): Promise<any>;
     };
     apps: {
       getInstallations(params: AppsGetInstallationsParams, callback?: Callback): Promise<any>;

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -474,8 +474,10 @@
                 "/repos/:owner/:repo/import"
             ],
             "application/vnd.github.machine-man-preview": [
+                "/integration/installations",
                 "/app/installations",
                 "/installations/:installation_id/access_tokens",
+                "/integration/identity/user",
                 "/app/identity/user",
                 "/installation/repositories",
                 "/installations/:installation_id/repositories/:repository_id"
@@ -1625,6 +1627,78 @@
                 }
             },
             "description": "Create a Tree"
+        }
+    },
+    "integrations": {
+        "get-installations": {
+            "url": "/app/installations",
+            "method": "GET",
+            "params": {
+                "$page": null,
+                "$per_page": null
+            },
+            "description": "List the app's installations. (In preview period. See README.)"
+        },
+        "create-installation-token": {
+            "url": "/installations/:installation_id/access_tokens",
+            "method": "POST",
+            "params": {
+                "$installation_id": null,
+                "user_id": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "The id of the user for whom the app is acting on behalf of."
+                }
+            },
+            "description": "Create a new installation token. (In preview period. See README.)"
+        },
+        "get-user-identity": {
+            "url": "/app/identity/user",
+            "method": "POST",
+            "params": {
+                "nonce": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                }
+            },
+            "description": "Request identity of user. (In preview period. See README.)"
+        },
+        "get-installation-repositories": {
+            "url": "/installation/repositories",
+            "method": "GET",
+            "params": {
+                "user_id": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "The integer ID of a user, to filter results to repositories that are visible to both the installation and the given user."
+                }
+            },
+            "description": "List repositories that are accessible to the authenticated installation. (In preview period. See README.)"
+        },
+        "add-repo-to-installation": {
+            "url": "/installations/:installation_id/repositories/:repository_id",
+            "method": "POST",
+            "params": {
+                "$installation_id": null,
+                "$repository_id": null
+            },
+            "description": "Add a single repository to an installation. (In preview period. See README.)"
+        },
+        "remove-repo-from-installation": {
+            "url": "/installations/:installation_id/repositories/:repository_id",
+            "method": "POST",
+            "params": {
+                "$installation_id": null,
+                "$repository_id": null
+            },
+            "description": "Remove a single repository from an installation. (In preview period. See README.)"
         }
     },
     "apps": {

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -474,9 +474,9 @@
                 "/repos/:owner/:repo/import"
             ],
             "application/vnd.github.machine-man-preview": [
-                "/integration/installations",
+                "/app/installations",
                 "/installations/:installation_id/access_tokens",
-                "/integration/identity/user",
+                "/app/identity/user",
                 "/installation/repositories",
                 "/installations/:installation_id/repositories/:repository_id"
             ],
@@ -1627,15 +1627,15 @@
             "description": "Create a Tree"
         }
     },
-    "integrations": {
+    "apps": {
         "get-installations": {
-            "url": "/integration/installations",
+            "url": "/app/installations",
             "method": "GET",
             "params": {
                 "$page": null,
                 "$per_page": null
             },
-            "description": "List the integration's installations. (In preview period. See README.)"
+            "description": "List the app's installations. (In preview period. See README.)"
         },
         "create-installation-token": {
             "url": "/installations/:installation_id/access_tokens",
@@ -1647,13 +1647,13 @@
                     "required": false,
                     "validation": "",
                     "invalidmsg": "",
-                    "description": "The id of the user for whom the integration is acting on behalf of."
+                    "description": "The id of the user for whom the app is acting on behalf of."
                 }
             },
             "description": "Create a new installation token. (In preview period. See README.)"
         },
         "get-user-identity": {
-            "url": "/integration/identity/user",
+            "url": "/app/identity/user",
             "method": "POST",
             "params": {
                 "nonce": {

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -1637,6 +1637,7 @@
                 "$page": null,
                 "$per_page": null
             },
+            "deprecated": "`integrations` has been renamed to `apps`",
             "description": "List the app's installations. (In preview period. See README.)"
         },
         "create-installation-token": {
@@ -1652,6 +1653,7 @@
                     "description": "The id of the user for whom the app is acting on behalf of."
                 }
             },
+            "deprecated": "`integrations` has been renamed to `apps`",
             "description": "Create a new installation token. (In preview period. See README.)"
         },
         "get-user-identity": {
@@ -1666,6 +1668,7 @@
                     "description": ""
                 }
             },
+            "deprecated": "`integrations` has been renamed to `apps`",
             "description": "Request identity of user. (In preview period. See README.)"
         },
         "get-installation-repositories": {
@@ -1680,6 +1683,7 @@
                     "description": "The integer ID of a user, to filter results to repositories that are visible to both the installation and the given user."
                 }
             },
+            "deprecated": "`integrations` has been renamed to `apps`",
             "description": "List repositories that are accessible to the authenticated installation. (In preview period. See README.)"
         },
         "add-repo-to-installation": {
@@ -1689,6 +1693,7 @@
                 "$installation_id": null,
                 "$repository_id": null
             },
+            "deprecated": "`integrations` has been renamed to `apps`",
             "description": "Add a single repository to an installation. (In preview period. See README.)"
         },
         "remove-repo-from-installation": {
@@ -1698,6 +1703,7 @@
                 "$installation_id": null,
                 "$repository_id": null
             },
+            "deprecated": "`integrations` has been renamed to `apps`",
             "description": "Remove a single repository from an installation. (In preview period. See README.)"
         }
     },

--- a/test/appsTest.js
+++ b/test/appsTest.js
@@ -13,7 +13,7 @@ var Assert = require("assert");
 var Client = require("./../lib/index");
 var testAuth = require("./../testAuth.json");
 
-describe("[integrations]", function() {
+describe("[apps]", function() {
     var client;
     var token = testAuth["token"];
 
@@ -26,7 +26,7 @@ describe("[integrations]", function() {
     });
 
     it("should successfully execute POST /installations/:installation_id/repositories/:repository_id (addRepoToInstallation)",  function(next) {
-        client.integrations.addRepoToInstallation(
+        client.apps.addRepoToInstallation(
             {
                 installation_id: "String",
                 repository_id: "String"
@@ -40,7 +40,7 @@ describe("[integrations]", function() {
     });
 
     it("should successfully execute POST /installations/:installation_id/access_tokens (createInstallationToken)",  function(next) {
-        client.integrations.createInstallationToken(
+        client.apps.createInstallationToken(
             {
                 installation_id: "String",
                 user_id: "String"
@@ -54,7 +54,7 @@ describe("[integrations]", function() {
     });
 
     it("should successfully execute GET /installation/repositories (getInstallationRepositories)",  function(next) {
-        client.integrations.getInstallationRepositories(
+        client.apps.getInstallationRepositories(
             {
                 user_id: "String"
             },
@@ -66,8 +66,8 @@ describe("[integrations]", function() {
         );
     });
 
-    it("should successfully execute GET /integration/installations (getInstallations)",  function(next) {
-        client.integrations.getInstallations(
+    it("should successfully execute GET /app/installations (getInstallations)",  function(next) {
+        client.apps.getInstallations(
             {
                 page: "Number",
                 per_page: "Number"
@@ -80,8 +80,8 @@ describe("[integrations]", function() {
         );
     });
 
-    it("should successfully execute POST /integration/identity/user (getUserIdentity)",  function(next) {
-        client.integrations.getUserIdentity(
+    it("should successfully execute POST /app/identity/user (getUserIdentity)",  function(next) {
+        client.apps.getUserIdentity(
             {
                 nonce: "String"
             },
@@ -94,7 +94,7 @@ describe("[integrations]", function() {
     });
 
     it("should successfully execute POST /installations/:installation_id/repositories/:repository_id (removeRepoFromInstallation)",  function(next) {
-        client.integrations.removeRepoFromInstallation(
+        client.apps.removeRepoFromInstallation(
             {
                 installation_id: "String",
                 repository_id: "String"

--- a/test/integrationsTest.js
+++ b/test/integrationsTest.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2012 Cloud9 IDE, Inc.
+ *
+ * This product includes software developed by
+ * Cloud9 IDE, Inc (http://c9.io).
+ *
+ * Author: Mike de Boer <info@mikedeboer.nl>
+ */
+
+"use strict";
+
+var Assert = require("assert");
+var Client = require("./../lib/index");
+var testAuth = require("./../testAuth.json");
+
+describe("[integrations]", function() {
+    var client;
+    var token = testAuth["token"];
+
+    beforeEach(function() {
+        client = new Client();
+        client.authenticate({
+            type: "oauth",
+            token: token
+        });
+    });
+
+    it("should successfully execute POST /installations/:installation_id/repositories/:repository_id (addRepoToInstallation)",  function(next) {
+        client.integrations.addRepoToInstallation(
+            {
+                installation_id: "String",
+                repository_id: "String"
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                // other assertions go here
+                next();
+            }
+        );
+    });
+
+    it("should successfully execute POST /installations/:installation_id/access_tokens (createInstallationToken)",  function(next) {
+        client.integrations.createInstallationToken(
+            {
+                installation_id: "String",
+                user_id: "String"
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                // other assertions go here
+                next();
+            }
+        );
+    });
+
+    it("should successfully execute GET /installation/repositories (getInstallationRepositories)",  function(next) {
+        client.integrations.getInstallationRepositories(
+            {
+                user_id: "String"
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                // other assertions go here
+                next();
+            }
+        );
+    });
+
+    it("should successfully execute GET /app/installations (getInstallations)",  function(next) {
+        client.integrations.getInstallations(
+            {
+                page: "Number",
+                per_page: "Number"
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                // other assertions go here
+                next();
+            }
+        );
+    });
+
+    it("should successfully execute POST /app/identity/user (getUserIdentity)",  function(next) {
+        client.integrations.getUserIdentity(
+            {
+                nonce: "String"
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                // other assertions go here
+                next();
+            }
+        );
+    });
+
+    it("should successfully execute POST /installations/:installation_id/repositories/:repository_id (removeRepoFromInstallation)",  function(next) {
+        client.integrations.removeRepoFromInstallation(
+            {
+                installation_id: "String",
+                repository_id: "String"
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                // other assertions go here
+                next();
+            }
+        );
+    });
+});


### PR DESCRIPTION
GitHub Integrations were renamed to GitHub Apps. The old endpoints will be [deprecated on Nov 22](https://developer.github.com/changes/2017-07-19-removal-of-integrations-routes/). This updates the routes to point to the new endpoints.

~~Note that this is a breaking change. It's likely possible to implement in a way that is backward compatible with deprecation warnings, but that doesn't seem to be a pattern that's been used on this library in the past.~~ Update: I added support for deprecating routes: 37c954d

I'll remove the `WIP` tag from the title once this has been tested and is ready for merge.