### PR TITLE
clean up package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,8 @@
       "email": "joe@brassafrax.com"
     }
   ],
-  "homepage": "https://github.com/mikedeboer/node-github",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/mikedeboer/node-github.git"
-  },
-  "engine": {
+  "repository": "https://github.com/mikedeboer/node-github",
+  "engines": {
     "node": ">=0.4.0"
   },
   "dependencies": {


### PR DESCRIPTION
`repository` can just be a string instead of an object, and `homepage` need not be set if it's the same URL as the repo.