### PR TITLE
fix(types): Fix missing TypeScript interface generics

### DIFF
--- a/lib/generateTypes.js
+++ b/lib/generateTypes.js
@@ -41,10 +41,12 @@ function replaceArrayTypes(type, name) {
         case "required_contexts":
         case "maintainers":
         case "reviewers":
+        case "team_reviewers":
         case "comments":
         case "labels":
         case "teams":
         case "users":
+        case "names":
         case "emails":
             if (type === "Array") {
                 return "string[]";
@@ -159,7 +161,7 @@ var main = module.exports = function(languageName, templateFile, outputFile) {
             methods: methods,
         });
     }, []);
- 
+
     var body = Mustache.render(template, {
         requestHeaders: requestHeaders.map(JSON.stringify),
         params: params,

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -15,7 +15,7 @@ declare namespace Github {
 
   export interface EmptyParams {
   }
-  
+
   export interface Options {
     debug?: boolean;
     protocol?: string;
@@ -1460,7 +1460,7 @@ declare namespace Github {
     & Number
     & {
       reviewers?: string[];
-      team_reviewers?: Array;
+      team_reviewers?: string[];
     };
   export type PullRequestsDeleteReviewRequestParams =
     & Owner
@@ -1468,7 +1468,7 @@ declare namespace Github {
     & Number
     & {
       reviewers?: string[];
-      team_reviewers?: Array;
+      team_reviewers?: string[];
     };
   export type ReactionsGetForCommitCommentParams =
     & Owner

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -15,7 +15,7 @@ declare namespace Github {
 
   export interface EmptyParams {
   }
-
+  
   export interface Options {
     debug?: boolean;
     protocol?: string;
@@ -1629,7 +1629,7 @@ declare namespace Github {
     & Owner
     & Repo
     & {
-      names: Array;
+      names: string[];
     };
   export type ReposGetContributorsParams =
     & Owner

--- a/lib/index.js.flow
+++ b/lib/index.js.flow
@@ -1455,7 +1455,7 @@ declare module "github" {
     & Number
     & {
       reviewers?: string[];
-      team_reviewers?: Array;
+      team_reviewers?: string[];
     };
   declare type PullRequestsDeleteReviewRequestParams =
     & Owner
@@ -1463,7 +1463,7 @@ declare module "github" {
     & Number
     & {
       reviewers?: string[];
-      team_reviewers?: Array;
+      team_reviewers?: string[];
     };
   declare type ReactionsGetForCommitCommentParams =
     & Owner
@@ -1624,7 +1624,7 @@ declare module "github" {
     & Owner
     & Repo
     & {
-      names: Array;
+      names: string[];
     };
   declare type ReposGetContributorsParams =
     & Owner


### PR DESCRIPTION
**This PR fixes typings issues, in particular arrays without generics.** The fix itself was made in the ```generate.js``` file, and affects both the TypeScript and Flow typings.

This issue first occured with node-github version ```9.3```.

Closes #576.