### PR TITLE
Fix #328 - WebPack compatibility - don't use var in require()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -777,8 +777,14 @@ var Client = module.exports = function(config) {
         }
 
         function httpSendRequest() {
-            var reqModule = self.config.followRedirects === false ? protocol : 'follow-redirects/' + protocol;
-            var req = require(reqModule).request(options, function(res) {
+            // Verbosity for WebPack compliance
+            if (self.config.followRedirects === false) {
+                var reqModule = protocol == 'http' ? require('http') : require('https')
+            } else {
+                var reqModule = protocol == 'http' ? require('follow-redirects/http') : require('follow-redirects/https')
+            }
+
+            var req = reqModule.request(options, function(res) {
                 if (self.debug) {
                     console.log("STATUS: " + res.statusCode);
                     console.log("HEADERS: " + JSON.stringify(res.headers));


### PR DESCRIPTION
Fixes the warning that is reported in #328 
```
WARNING in ./~/github/lib/index.js
781:22-40 Critical dependency: the request of a dependency is an expression
```

WebPack doesn't like seeing vars in `require()`.
This code change def. doesn't win beauty awards, but if you want to be compliant without warnings :-)