### PR TITLE
Use standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,29 +31,29 @@ GitHub API: [developer.github.com/v3](https://developer.github.com/v3/)
 Get all followers for user "defunkt":
 
 ```js
-var GitHubApi = require("github");
+var GitHubApi = require('github')
 
 var github = new GitHubApi({
     // optional
-    debug: true,
-    Promise: require('bluebird'),
-    timeout: 5000,
-    host: "github.my-GHE-enabled-company.com", // should be api.github.com for GitHub
-    pathPrefix: "/api/v3", // for some GHEs; none for GitHub
-    protocol: "https",
-    port: 9898,
-    proxy: "<proxyUrl>",
-    ca: "whatever",
-    headers: {
-        "accept": "application/vnd.github.something-custom",
-        "cookie": "something custom",
-        "user-agent": "something custom"
-    },
-    requestMedia: "application/vnd.github.something-custom",
-    followRedirects: false, // default: true; there's currently an issue with non-get redirects, so allow disabling follow-redirects
-    rejectUnauthorized: false, // default: true
-    family: 6
-});
+  debug: true,
+  Promise: require('bluebird'),
+  timeout: 5000,
+  host: 'github.my-GHE-enabled-company.com', // should be api.github.com for GitHub
+  pathPrefix: '/api/v3', // for some GHEs; none for GitHub
+  protocol: 'https',
+  port: 9898,
+  proxy: '<proxyUrl>',
+  ca: 'whatever',
+  headers: {
+    'accept': 'application/vnd.github.something-custom',
+    'cookie': 'something custom',
+    'user-agent': 'something custom'
+  },
+  requestMedia: 'application/vnd.github.something-custom',
+  followRedirects: false, // default: true; there's currently an issue with non-get redirects, so allow disabling follow-redirects
+  rejectUnauthorized: false, // default: true
+  family: 6
+})
 
 // TODO: optional authentication here depending on desired endpoints. See below in README.
 
@@ -62,10 +62,11 @@ github.users.getFollowingForUser({
     // headers: {
     //     "cookie": "blahblah"
     // },
-    username: "defunkt"
-}, function(err, res) {
-    console.log(JSON.stringify(res));
-});
+  username: 'defunkt'
+}, function (err, res) {
+  if (err) throw err
+  console.log(JSON.stringify(res))
+})
 ```
 
 ## Pagination
@@ -97,40 +98,40 @@ You need the GitHub user name and the API key for authentication. The API key ca
 ```javascript
 // basic
 github.authenticate({
-    type: "basic",
-    username: USERNAME,
-    password: PASSWORD
-});
+  type: 'basic',
+  username: process.env.USERNAME,
+  password: process.env.PASSWORD
+})
 
 // oauth
 github.authenticate({
-    type: "oauth",
-    token: AUTH_TOKEN
-});
+  type: 'oauth',
+  token: process.env.AUTH_TOKEN
+})
 
 // oauth key/secret (to get a token)
 github.authenticate({
-    type: "oauth",
-    key: CLIENT_ID,
-    secret: CLIENT_SECRET
+  type: 'oauth',
+  key: process.env.CLIENT_ID,
+  secret: process.env.CLIENT_SECRET
 })
 
 // user token
 github.authenticate({
-    type: "token",
-    token: "userToken",
-});
+  type: 'token',
+  token: 'userToken'
+})
 
 // integration (jwt)
 github.authenticate({
-    type: "integration",
-    token: "jwt",
-});
+  type: 'integration',
+  token: 'jwt'
+})
 
 // ~/.netrc
 github.authenticate({
-    type: "netrc"
-});
+  type: 'netrc'
+})
 ```
 
 Note: `authenticate` is synchronous because it only stores the
@@ -144,17 +145,18 @@ credentials for the next request.
 
 ```javascript
 github.authorization.create({
-    scopes: ["user", "public_repo", "repo", "repo:status", "gist"],
-    note: "what this auth is for",
-    note_url: "http://url-to-this-auth-app",
-    headers: {
-        "X-GitHub-OTP": "two-factor-code"
-    }
-}, function(err, res) {
-    if (res.token) {
-        //save and use res.token as in the Oauth process above from now on
-    }
-});
+  scopes: ['user', 'public_repo', 'repo', 'repo:status', 'gist'],
+  note: 'what this auth is for',
+  note_url: 'http://url-to-this-auth-app',
+  headers: {
+    'X-GitHub-OTP': 'two-factor-code'
+  }
+}, function (err, res) {
+  if (err) throw err
+  if (res.token) {
+    // save and use res.token as in the Oauth process above from now on
+  }
+})
 ```
 
 ## Create test auth file

--- a/doc/apidoc.js
+++ b/doc/apidoc.js
@@ -5,7 +5,7 @@
  * @apiDescription Check to see if the current user is subscribed to a thread.
  * @apiGroup activity
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.activity.checkNotificationThreadSubscription({ ... });
  */
@@ -17,8 +17,8 @@ github.activity.checkNotificationThreadSubscription({ ... });
  * @apiDescription Check if you are starring a repository
  * @apiGroup activity
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -32,7 +32,7 @@ github.activity.checkStarringRepo({ ... });
  * @apiDescription Delete a notification thread subscription.
  * @apiGroup activity
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.activity.deleteNotificationThreadSubscription({ ... });
  */
@@ -57,7 +57,7 @@ github.activity.getEvents({ ... });
  * @apiDescription List public events for an organization
  * @apiGroup activity
  *
- * @apiParam {String} org  
+ * @apiParam {String} org
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -71,8 +71,8 @@ github.activity.getEventsForOrg({ ... });
  * @apiDescription List repository events
  * @apiGroup activity
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -86,8 +86,8 @@ github.activity.getEventsForRepo({ ... });
  * @apiDescription List issue events for a repository
  * @apiGroup activity
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -101,8 +101,8 @@ github.activity.getEventsForRepoIssues({ ... });
  * @apiDescription List public events for a network of repositories
  * @apiGroup activity
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -116,7 +116,7 @@ github.activity.getEventsForRepoNetwork({ ... });
  * @apiDescription List events performed by a user
  * @apiGroup activity
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -130,8 +130,8 @@ github.activity.getEventsForUser({ ... });
  * @apiDescription List events for a user's organization
  * @apiGroup activity
  *
- * @apiParam {String} username  
- * @apiParam {String} org  
+ * @apiParam {String} username
+ * @apiParam {String} org
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -145,7 +145,7 @@ github.activity.getEventsForUserOrg({ ... });
  * @apiDescription List public events performed by a user
  * @apiGroup activity
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -159,7 +159,7 @@ github.activity.getEventsForUserPublic({ ... });
  * @apiDescription List events that a user has received
  * @apiGroup activity
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -173,7 +173,7 @@ github.activity.getEventsReceived({ ... });
  * @apiDescription List public events that a user has received
  * @apiGroup activity
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -198,7 +198,7 @@ github.activity.getFeeds({ ... });
  * @apiDescription View a single notification thread.
  * @apiGroup activity
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.activity.getNotificationThread({ ... });
  */
@@ -225,8 +225,8 @@ github.activity.getNotifications({ ... });
  * @apiDescription Get all notifications for the given user.
  * @apiGroup activity
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Boolean} [all=false]  If true, show notifications marked as read. Default: false
  * @apiParam {Boolean} [participating=false]  If true, only shows notifications in which the user is directly participating or mentioned. Default: false
  * @apiParam {Date} [since]  Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
@@ -242,8 +242,8 @@ github.activity.getNotificationsForUser({ ... });
  * @apiDescription Get a Repository Subscription.
  * @apiGroup activity
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -257,8 +257,8 @@ github.activity.getRepoSubscription({ ... });
  * @apiDescription List Stargazers
  * @apiGroup activity
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -272,8 +272,8 @@ github.activity.getStargazersForRepo({ ... });
  * @apiDescription List repositories being starred by the authenticated user
  * @apiGroup activity
  *
- * @apiParam {String=created,updated} [sort=created]  
- * @apiParam {String=asc,desc} [direction=desc]  
+ * @apiParam {String=created,updated} [sort=created]
+ * @apiParam {String=asc,desc} [direction=desc]
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -287,9 +287,9 @@ github.activity.getStarredRepos({ ... });
  * @apiDescription List repositories being starred by a user
  * @apiGroup activity
  *
- * @apiParam {String} username  
- * @apiParam {String=created,updated} [sort=created]  
- * @apiParam {String=asc,desc} [direction=desc]  
+ * @apiParam {String} username
+ * @apiParam {String=created,updated} [sort=created]
+ * @apiParam {String=asc,desc} [direction=desc]
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -316,7 +316,7 @@ github.activity.getWatchedRepos({ ... });
  * @apiDescription List repositories being watched by a user.
  * @apiGroup activity
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -330,8 +330,8 @@ github.activity.getWatchedReposForUser({ ... });
  * @apiDescription Get watchers for repository.
  * @apiGroup activity
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -345,7 +345,7 @@ github.activity.getWatchersForRepo({ ... });
  * @apiDescription Mark a notification thread as read.
  * @apiGroup activity
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.activity.markNotificationThreadAsRead({ ... });
  */
@@ -369,8 +369,8 @@ github.activity.markNotificationsAsRead({ ... });
  * @apiDescription Mark notifications in a repo as read.
  * @apiGroup activity
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} [last_read_at=Time.now]  Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. Default: Time.now
  * @apiExample {js} ex:
 github.activity.markNotificationsAsReadForRepo({ ... });
@@ -383,7 +383,7 @@ github.activity.markNotificationsAsReadForRepo({ ... });
  * @apiDescription This lets you subscribe or unsubscribe from a conversation. Unsubscribing from a conversation mutes all future notifications (until you comment or get @mentioned once more).
  * @apiGroup activity
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiParam {Boolean} [subscribed]  Determines if notifications should be received from this thread
  * @apiParam {Boolean} [ignored]  Determines if all notifications should be blocked from this thread
  * @apiExample {js} ex:
@@ -397,8 +397,8 @@ github.activity.setNotificationThreadSubscription({ ... });
  * @apiDescription Set a Repository Subscription
  * @apiGroup activity
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Boolean} [subscribed]  Determines if notifications should be received from this repository.
  * @apiParam {Boolean} [ignored]  Determines if all notifications should be blocked from this repository.
  * @apiExample {js} ex:
@@ -412,8 +412,8 @@ github.activity.setRepoSubscription({ ... });
  * @apiDescription Star a repository
  * @apiGroup activity
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.activity.starRepo({ ... });
  */
@@ -425,8 +425,8 @@ github.activity.starRepo({ ... });
  * @apiDescription Unstar a repository
  * @apiGroup activity
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.activity.unstarRepo({ ... });
  */
@@ -438,8 +438,8 @@ github.activity.unstarRepo({ ... });
  * @apiDescription Unwatch a repository.
  * @apiGroup activity
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.activity.unwatchRepo({ ... });
  */
@@ -451,8 +451,8 @@ github.activity.unwatchRepo({ ... });
  * @apiDescription Add a single repository to an installation. (In preview period. See README.)
  * @apiGroup apps
  *
- * @apiParam {String} installation_id  
- * @apiParam {String} repository_id  
+ * @apiParam {String} installation_id
+ * @apiParam {String} repository_id
  * @apiExample {js} ex:
 github.apps.addRepoToInstallation({ ... });
  */
@@ -464,7 +464,7 @@ github.apps.addRepoToInstallation({ ... });
  * @apiDescription Check if a GitHub account is associated with any Marketplace listing. (In preview period. See README.)
  * @apiGroup apps
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.apps.checkMarketplaceListingAccount({ ... });
  */
@@ -476,7 +476,7 @@ github.apps.checkMarketplaceListingAccount({ ... });
  * @apiDescription Check if a stubbed GitHub account is associated with any Marketplace listing. (In preview period. See README.)
  * @apiGroup apps
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.apps.checkMarketplaceListingStubbedAccount({ ... });
  */
@@ -488,7 +488,7 @@ github.apps.checkMarketplaceListingStubbedAccount({ ... });
  * @apiDescription Create a new installation token. (In preview period. See README.)
  * @apiGroup apps
  *
- * @apiParam {String} installation_id  
+ * @apiParam {String} installation_id
  * @apiParam {String} [user_id]  The id of the user for whom the app is acting on behalf of.
  * @apiExample {js} ex:
 github.apps.createInstallationToken({ ... });
@@ -524,7 +524,7 @@ github.apps.getForSlug({ ... });
  * @apiDescription Get a single installation. (In preview period. See README.)
  * @apiGroup apps
  *
- * @apiParam {String} installation_id  
+ * @apiParam {String} installation_id
  * @apiExample {js} ex:
 github.apps.getInstallation({ ... });
  */
@@ -561,7 +561,7 @@ github.apps.getInstallations({ ... });
  * @apiDescription List all GitHub accounts (user or organization) on a specific plan. (In preview period. See README.)
  * @apiGroup apps
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -588,7 +588,7 @@ github.apps.getMarketplaceListingPlans({ ... });
  * @apiDescription List all GitHub accounts (user or organization) on a specific stubbed plan. (In preview period. See README.)
  * @apiGroup apps
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -615,8 +615,8 @@ github.apps.getMarketplaceListingStubbedPlans({ ... });
  * @apiDescription Remove a single repository from an installation. (In preview period. See README.)
  * @apiGroup apps
  *
- * @apiParam {String} installation_id  
- * @apiParam {String} repository_id  
+ * @apiParam {String} installation_id
+ * @apiParam {String} repository_id
  * @apiExample {js} ex:
 github.apps.removeRepoFromInstallation({ ... });
  */
@@ -658,7 +658,7 @@ github.authorization.create({ ... });
  * @apiDescription Delete an authorization.
  * @apiGroup authorization
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.authorization.delete({ ... });
  */
@@ -670,7 +670,7 @@ github.authorization.delete({ ... });
  * @apiDescription Delete a grant.
  * @apiGroup authorization
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.authorization.deleteGrant({ ... });
  */
@@ -682,7 +682,7 @@ github.authorization.deleteGrant({ ... });
  * @apiDescription Get a single authorization.
  * @apiGroup authorization
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.authorization.get({ ... });
  */
@@ -707,7 +707,7 @@ github.authorization.getAll({ ... });
  * @apiDescription Get a single grant.
  * @apiGroup authorization
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -807,7 +807,7 @@ github.authorization.revokeGrant({ ... });
  * @apiDescription Update an existing authorization.
  * @apiGroup authorization
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiParam {Array} [scopes]  A list of scopes that this authorization is in.
  * @apiParam {Array} [add_scopes]  A list of scopes to add to this authorization.
  * @apiParam {Array} [remove_scopes]  A list of scopes to remove from this authorization.
@@ -869,7 +869,7 @@ github.enterprise.createPreReceiveHook({ ... });
  * @apiDescription Delete a pre-receive environment. (In preview period. See README.)
  * @apiGroup enterprise
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.enterprise.deletePreReceiveEnvironment({ ... });
  */
@@ -881,7 +881,7 @@ github.enterprise.deletePreReceiveEnvironment({ ... });
  * @apiDescription Delete a pre-receive hook. (In preview period. See README.)
  * @apiGroup enterprise
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.enterprise.deletePreReceiveHook({ ... });
  */
@@ -893,7 +893,7 @@ github.enterprise.deletePreReceiveHook({ ... });
  * @apiDescription Create a pre-receive environment. (In preview period. See README.)
  * @apiGroup enterprise
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiParam {String} name  This pre-receive environment's new name.
  * @apiParam {String} image_url  URL from which to download a tarball of this environment.
  * @apiExample {js} ex:
@@ -907,7 +907,7 @@ github.enterprise.editPreReceiveEnvironment({ ... });
  * @apiDescription Edit a pre-receive hook. (In preview period. See README.)
  * @apiGroup enterprise
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiParam {Json} hook  JSON object that contains pre-receive hook info.
  * @apiExample {js} ex:
 github.enterprise.editPreReceiveHook({ ... });
@@ -931,7 +931,7 @@ github.enterprise.getLicense({ ... });
  * @apiDescription Get a single pre-receive environment. (In preview period. See README.)
  * @apiGroup enterprise
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.enterprise.getPreReceiveEnvironment({ ... });
  */
@@ -943,7 +943,7 @@ github.enterprise.getPreReceiveEnvironment({ ... });
  * @apiDescription Get a pre-receive environment's download status. (In preview period. See README.)
  * @apiGroup enterprise
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.enterprise.getPreReceiveEnvironmentDownloadStatus({ ... });
  */
@@ -966,7 +966,7 @@ github.enterprise.getPreReceiveEnvironments({ ... });
  * @apiDescription Get a single pre-receive hook. (In preview period. See README.)
  * @apiGroup enterprise
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.enterprise.getPreReceiveHook({ ... });
  */
@@ -1013,7 +1013,7 @@ github.enterprise.stats({ ... });
  * @apiDescription Sync LDAP mapping for a team.
  * @apiGroup enterprise
  *
- * @apiParam {Number} team_id  
+ * @apiParam {Number} team_id
  * @apiExample {js} ex:
 github.enterprise.syncLdapForTeam({ ... });
  */
@@ -1025,7 +1025,7 @@ github.enterprise.syncLdapForTeam({ ... });
  * @apiDescription Sync LDAP mapping for a user.
  * @apiGroup enterprise
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.enterprise.syncLdapForUser({ ... });
  */
@@ -1037,7 +1037,7 @@ github.enterprise.syncLdapForUser({ ... });
  * @apiDescription Trigger a pre-receive environment download. (In preview period. See README.)
  * @apiGroup enterprise
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.enterprise.triggerPreReceiveEnvironmentDownload({ ... });
  */
@@ -1049,7 +1049,7 @@ github.enterprise.triggerPreReceiveEnvironmentDownload({ ... });
  * @apiDescription Update LDAP mapping for a team.
  * @apiGroup enterprise
  *
- * @apiParam {Number} team_id  
+ * @apiParam {Number} team_id
  * @apiParam {String} ldap_dn  LDAP DN for user
  * @apiExample {js} ex:
 github.enterprise.updateLdapForTeam({ ... });
@@ -1062,7 +1062,7 @@ github.enterprise.updateLdapForTeam({ ... });
  * @apiDescription Update LDAP mapping for a user.
  * @apiGroup enterprise
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiParam {String} ldap_dn  LDAP DN for user
  * @apiExample {js} ex:
 github.enterprise.updateLdapForUser({ ... });
@@ -1075,7 +1075,7 @@ github.enterprise.updateLdapForUser({ ... });
  * @apiDescription Check if a gist is starred
  * @apiGroup gists
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.gists.checkStar({ ... });
  */
@@ -1088,8 +1088,8 @@ github.gists.checkStar({ ... });
  * @apiGroup gists
  *
  * @apiParam {Json} files  Files that make up this gist. The key of which should be a required string filename and the value another required hash with parameters: 'content'
- * @apiParam {Boolean} public  
- * @apiParam {String} [description]  
+ * @apiParam {Boolean} public
+ * @apiParam {String} [description]
  * @apiExample {js} ex:
 github.gists.create({ ... });
  */
@@ -1102,7 +1102,7 @@ github.gists.create({ ... });
  * @apiGroup gists
  *
  * @apiParam {String} gist_id  Id (SHA1 hash) of the gist.
- * @apiParam {String} body  
+ * @apiParam {String} body
  * @apiExample {js} ex:
 github.gists.createComment({ ... });
  */
@@ -1114,7 +1114,7 @@ github.gists.createComment({ ... });
  * @apiDescription Delete a gist
  * @apiGroup gists
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.gists.delete({ ... });
  */
@@ -1127,7 +1127,7 @@ github.gists.delete({ ... });
  * @apiGroup gists
  *
  * @apiParam {String} gist_id  Id (SHA1 hash) of the gist.
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.gists.deleteComment({ ... });
  */
@@ -1139,9 +1139,9 @@ github.gists.deleteComment({ ... });
  * @apiDescription Edit a gist
  * @apiGroup gists
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiParam {Json} files  Files that make up this gist. The key of which should be a required string filename and the value another required hash with parameters: 'content'
- * @apiParam {String} [description]  
+ * @apiParam {String} [description]
  * @apiParam {String} [content]  Updated file contents.
  * @apiParam {String} [filename]  New name for this file.
  * @apiExample {js} ex:
@@ -1156,8 +1156,8 @@ github.gists.edit({ ... });
  * @apiGroup gists
  *
  * @apiParam {String} gist_id  Id (SHA1 hash) of the gist.
- * @apiParam {String} id  
- * @apiParam {String} body  
+ * @apiParam {String} id
+ * @apiParam {String} body
  * @apiExample {js} ex:
 github.gists.editComment({ ... });
  */
@@ -1169,7 +1169,7 @@ github.gists.editComment({ ... });
  * @apiDescription Fork a gist
  * @apiGroup gists
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.gists.fork({ ... });
  */
@@ -1181,7 +1181,7 @@ github.gists.fork({ ... });
  * @apiDescription Get a single gist
  * @apiGroup gists
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.gists.get({ ... });
  */
@@ -1208,7 +1208,7 @@ github.gists.getAll({ ... });
  * @apiGroup gists
  *
  * @apiParam {String} gist_id  Id (SHA1 hash) of the gist.
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.gists.getComment({ ... });
  */
@@ -1232,7 +1232,7 @@ github.gists.getComments({ ... });
  * @apiDescription List gist commits
  * @apiGroup gists
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.gists.getCommits({ ... });
  */
@@ -1244,7 +1244,7 @@ github.gists.getCommits({ ... });
  * @apiDescription List a user's gists
  * @apiGroup gists
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiParam {Date} [since]  Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
@@ -1259,7 +1259,7 @@ github.gists.getForUser({ ... });
  * @apiDescription List gist forks
  * @apiGroup gists
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -1285,8 +1285,8 @@ github.gists.getPublic({ ... });
  * @apiDescription Get a specific revision of a gist
  * @apiGroup gists
  *
- * @apiParam {String} id  
- * @apiParam {String} sha  
+ * @apiParam {String} id
+ * @apiParam {String} sha
  * @apiExample {js} ex:
 github.gists.getRevision({ ... });
  */
@@ -1310,7 +1310,7 @@ github.gists.getStarred({ ... });
  * @apiDescription Star a gist
  * @apiGroup gists
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.gists.star({ ... });
  */
@@ -1322,7 +1322,7 @@ github.gists.star({ ... });
  * @apiDescription Unstar a gist
  * @apiGroup gists
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.gists.unstar({ ... });
  */
@@ -1334,10 +1334,10 @@ github.gists.unstar({ ... });
  * @apiDescription Create a Blob
  * @apiGroup gitdata
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} content  
- * @apiParam {String} encoding  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} content
+ * @apiParam {String} encoding
  * @apiExample {js} ex:
 github.gitdata.createBlob({ ... });
  */
@@ -1349,13 +1349,13 @@ github.gitdata.createBlob({ ... });
  * @apiDescription Create a Commit
  * @apiGroup gitdata
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} message  String of the commit message
  * @apiParam {String} tree  String of the SHA of the tree object this commit points to
  * @apiParam {Array} parents  Array of the SHAs of the commits that were the parents of this commit. If omitted or empty, the commit will be written as a root commit. For a single parent, an array of one SHA should be provided, for a merge commit, an array of more than one should be provided.
- * @apiParam {Json} [author]  
- * @apiParam {Json} [committer]  
+ * @apiParam {Json} [author]
+ * @apiParam {Json} [committer]
  * @apiExample {js} ex:
 github.gitdata.createCommit({ ... });
  */
@@ -1367,10 +1367,10 @@ github.gitdata.createCommit({ ... });
  * @apiDescription Create a Reference
  * @apiGroup gitdata
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} ref  The name of the fully qualified reference (ie: refs/heads/master). If it doesn't start with 'refs' and have at least two slashes, it will be rejected. NOTE: After creating the reference, on calling (get|update|delete)Reference, drop the leading 'refs/' when providing the 'ref' param.
- * @apiParam {String} sha  
+ * @apiParam {String} sha
  * @apiExample {js} ex:
 github.gitdata.createReference({ ... });
  */
@@ -1382,8 +1382,8 @@ github.gitdata.createReference({ ... });
  * @apiDescription Create a Tag Object
  * @apiGroup gitdata
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} tag  String of the tag
  * @apiParam {String} message  String of the tag message
  * @apiParam {String} object  String of the SHA of the git object this is tagging
@@ -1400,8 +1400,8 @@ github.gitdata.createTag({ ... });
  * @apiDescription Create a Tree
  * @apiGroup gitdata
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Json} tree  Array of Hash objects (of path, mode, type and sha) specifying a tree structure
  * @apiParam {String} [base_tree]  String of the SHA1 of the tree you want to update with new data
  * @apiExample {js} ex:
@@ -1415,8 +1415,8 @@ github.gitdata.createTree({ ... });
  * @apiDescription Delete a Reference
  * @apiGroup gitdata
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} ref  String of the name of the fully qualified reference (ie: heads/master). If it doesn’t have at least one slash, it will be rejected.
  * @apiExample {js} ex:
 github.gitdata.deleteReference({ ... });
@@ -1429,9 +1429,9 @@ github.gitdata.deleteReference({ ... });
  * @apiDescription Get a Blob
  * @apiGroup gitdata
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} sha  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} sha
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -1445,9 +1445,9 @@ github.gitdata.getBlob({ ... });
  * @apiDescription Get a Commit
  * @apiGroup gitdata
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} sha  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} sha
  * @apiExample {js} ex:
 github.gitdata.getCommit({ ... });
  */
@@ -1459,9 +1459,9 @@ github.gitdata.getCommit({ ... });
  * @apiDescription Get a Commit Signature Verification. (In preview period. See README.)
  * @apiGroup gitdata
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} sha  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} sha
  * @apiExample {js} ex:
 github.gitdata.getCommitSignatureVerification({ ... });
  */
@@ -1473,8 +1473,8 @@ github.gitdata.getCommitSignatureVerification({ ... });
  * @apiDescription Get a Reference
  * @apiGroup gitdata
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} ref  String of the name of the fully qualified reference (ie: heads/master). If it doesn’t have at least one slash, it will be rejected.
  * @apiExample {js} ex:
 github.gitdata.getReference({ ... });
@@ -1487,8 +1487,8 @@ github.gitdata.getReference({ ... });
  * @apiDescription Get all References
  * @apiGroup gitdata
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -1502,9 +1502,9 @@ github.gitdata.getReferences({ ... });
  * @apiDescription Get a Tag
  * @apiGroup gitdata
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} sha  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} sha
  * @apiExample {js} ex:
 github.gitdata.getTag({ ... });
  */
@@ -1516,9 +1516,9 @@ github.gitdata.getTag({ ... });
  * @apiDescription Get a Tag Signature Verification. (In preview period. See README.)
  * @apiGroup gitdata
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} sha  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} sha
  * @apiExample {js} ex:
 github.gitdata.getTagSignatureVerification({ ... });
  */
@@ -1530,8 +1530,8 @@ github.gitdata.getTagSignatureVerification({ ... });
  * @apiDescription Get all tag References
  * @apiGroup gitdata
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -1545,10 +1545,10 @@ github.gitdata.getTags({ ... });
  * @apiDescription Get a Tree
  * @apiGroup gitdata
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} sha  
- * @apiParam {Boolean} [recursive]  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} sha
+ * @apiParam {Boolean} [recursive]
  * @apiExample {js} ex:
 github.gitdata.getTree({ ... });
  */
@@ -1560,10 +1560,10 @@ github.gitdata.getTree({ ... });
  * @apiDescription Update a Reference
  * @apiGroup gitdata
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} ref  String of the name of the fully qualified reference (ie: heads/master). If it doesn’t have at least one slash, it will be rejected.
- * @apiParam {String} sha  
+ * @apiParam {String} sha
  * @apiParam {Boolean} [force=false]  Boolean indicating whether to force the update or to make sure the update is a fast-forward update. The default is false, so leaving this out or setting it to false will make sure you’re not overwriting work.
  * @apiExample {js} ex:
 github.gitdata.updateReference({ ... });
@@ -1576,8 +1576,8 @@ github.gitdata.updateReference({ ... });
  * @apiDescription Add a single repository to an installation. (In preview period. See README.)
  * @apiGroup integrations
  *
- * @apiParam {String} installation_id  
- * @apiParam {String} repository_id  
+ * @apiParam {String} installation_id
+ * @apiParam {String} repository_id
  * @apiExample {js} ex:
 github.integrations.addRepoToInstallation({ ... });
  */
@@ -1589,7 +1589,7 @@ github.integrations.addRepoToInstallation({ ... });
  * @apiDescription Create a new installation token. (In preview period. See README.)
  * @apiGroup integrations
  *
- * @apiParam {String} installation_id  
+ * @apiParam {String} installation_id
  * @apiParam {String} [user_id]  The id of the user for whom the app is acting on behalf of.
  * @apiExample {js} ex:
 github.integrations.createInstallationToken({ ... });
@@ -1627,8 +1627,8 @@ github.integrations.getInstallations({ ... });
  * @apiDescription Remove a single repository from an installation. (In preview period. See README.)
  * @apiGroup integrations
  *
- * @apiParam {String} installation_id  
- * @apiParam {String} repository_id  
+ * @apiParam {String} installation_id
+ * @apiParam {String} repository_id
  * @apiExample {js} ex:
 github.integrations.removeRepoFromInstallation({ ... });
  */
@@ -1640,9 +1640,9 @@ github.integrations.removeRepoFromInstallation({ ... });
  * @apiDescription Add assignees to an issue.
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiParam {Array} assignees  Logins for the users that should be added to the issue.
  * @apiExample {js} ex:
 github.issues.addAssigneesToIssue({ ... });
@@ -1655,10 +1655,10 @@ github.issues.addAssigneesToIssue({ ... });
  * @apiDescription Add labels to an issue
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
- * @apiParam {Array} labels  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
+ * @apiParam {Array} labels
  * @apiExample {js} ex:
 github.issues.addLabels({ ... });
  */
@@ -1670,8 +1670,8 @@ github.issues.addLabels({ ... });
  * @apiDescription Check assignee
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} assignee  Login for the user that this issue should be assigned to.
  * @apiExample {js} ex:
 github.issues.checkAssignee({ ... });
@@ -1684,10 +1684,10 @@ github.issues.checkAssignee({ ... });
  * @apiDescription Create an issue
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} title  
- * @apiParam {String} [body]  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} title
+ * @apiParam {String} [body]
  * @apiParam {String} [assignee]  Login for the user that this issue should be assigned to.
  * @apiParam {Number} [milestone]  Milestone to associate this issue with.
  * @apiParam {Array} [labels]  Array of strings - Labels to associate with this issue.
@@ -1703,10 +1703,10 @@ github.issues.create({ ... });
  * @apiDescription Create a comment
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
- * @apiParam {String} body  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
+ * @apiParam {String} body
  * @apiExample {js} ex:
 github.issues.createComment({ ... });
  */
@@ -1718,9 +1718,9 @@ github.issues.createComment({ ... });
  * @apiDescription Create a label
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} name  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} name
  * @apiParam {String} color  6 character hex code, without a leading #.
  * @apiExample {js} ex:
 github.issues.createLabel({ ... });
@@ -1733,11 +1733,11 @@ github.issues.createLabel({ ... });
  * @apiDescription Create a milestone
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} title  
- * @apiParam {String=open,closed,all} [state=open]  
- * @apiParam {String} [description]  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} title
+ * @apiParam {String=open,closed,all} [state=open]
+ * @apiParam {String} [description]
  * @apiParam {Date} [due_on]  Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
  * @apiExample {js} ex:
 github.issues.createMilestone({ ... });
@@ -1750,9 +1750,9 @@ github.issues.createMilestone({ ... });
  * @apiDescription Delete a comment
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.issues.deleteComment({ ... });
  */
@@ -1764,9 +1764,9 @@ github.issues.deleteComment({ ... });
  * @apiDescription Delete a label
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} name  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} name
  * @apiExample {js} ex:
 github.issues.deleteLabel({ ... });
  */
@@ -1778,9 +1778,9 @@ github.issues.deleteLabel({ ... });
  * @apiDescription Delete a milestone
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiExample {js} ex:
 github.issues.deleteMilestone({ ... });
  */
@@ -1792,11 +1792,11 @@ github.issues.deleteMilestone({ ... });
  * @apiDescription Edit an issue
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
- * @apiParam {String} [title]  
- * @apiParam {String} [body]  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
+ * @apiParam {String} [title]
+ * @apiParam {String} [body]
  * @apiParam {String} [assignee]  Login for the user that this issue should be assigned to.
  * @apiParam {String=open,closed} [state=open]  open or closed
  * @apiParam {Number} [milestone]  Milestone to associate this issue with.
@@ -1813,10 +1813,10 @@ github.issues.edit({ ... });
  * @apiDescription Edit a comment
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
- * @apiParam {String} body  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
+ * @apiParam {String} body
  * @apiExample {js} ex:
 github.issues.editComment({ ... });
  */
@@ -1828,9 +1828,9 @@ github.issues.editComment({ ... });
  * @apiDescription Get a single issue
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiExample {js} ex:
 github.issues.get({ ... });
  */
@@ -1842,11 +1842,11 @@ github.issues.get({ ... });
  * @apiDescription List all issues across all the authenticated user's visible repositories including owned repositories, member repositories, and organization repositories
  * @apiGroup issues
  *
- * @apiParam {String=all,assigned,created,mentioned,subscribed} [filter]  
+ * @apiParam {String=all,assigned,created,mentioned,subscribed} [filter]
  * @apiParam {String=open,closed,all} [state=open]  open, closed, or all
  * @apiParam {String} [labels]  String list of comma separated Label names. Example: bug,ui,@high
- * @apiParam {String=created,updated,comments} [sort=created]  
- * @apiParam {String=asc,desc} [direction=desc]  
+ * @apiParam {String=created,updated,comments} [sort=created]
+ * @apiParam {String=asc,desc} [direction=desc]
  * @apiParam {Date} [since]  Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
@@ -1861,8 +1861,8 @@ github.issues.getAll({ ... });
  * @apiDescription List assignees
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.issues.getAssignees({ ... });
  */
@@ -1874,9 +1874,9 @@ github.issues.getAssignees({ ... });
  * @apiDescription Get a single comment
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.issues.getComment({ ... });
  */
@@ -1888,9 +1888,9 @@ github.issues.getComment({ ... });
  * @apiDescription List comments on an issue
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiParam {Date} [since]  Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
@@ -1905,10 +1905,10 @@ github.issues.getComments({ ... });
  * @apiDescription List comments in a repository
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String=created,updated} [sort=created]  
- * @apiParam {String=asc,desc} [direction=desc]  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String=created,updated} [sort=created]
+ * @apiParam {String=asc,desc} [direction=desc]
  * @apiParam {Date} [since]  Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
@@ -1923,9 +1923,9 @@ github.issues.getCommentsForRepo({ ... });
  * @apiDescription Get a single event
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.issues.getEvent({ ... });
  */
@@ -1937,9 +1937,9 @@ github.issues.getEvent({ ... });
  * @apiDescription List events for an issue
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} issue_number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} issue_number
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -1953,8 +1953,8 @@ github.issues.getEvents({ ... });
  * @apiDescription List events for a repository
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -1968,9 +1968,9 @@ github.issues.getEventsForRepo({ ... });
  * @apiDescription List events for an issue. (In preview period. See README.)
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} issue_number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} issue_number
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -1984,12 +1984,12 @@ github.issues.getEventsTimeline({ ... });
  * @apiDescription List all issues for a given organization for the authenticated user
  * @apiGroup issues
  *
- * @apiParam {String} org  
- * @apiParam {String=all,assigned,created,mentioned,subscribed} [filter]  
+ * @apiParam {String} org
+ * @apiParam {String=all,assigned,created,mentioned,subscribed} [filter]
  * @apiParam {String=open,closed,all} [state=open]  open, closed, or all
  * @apiParam {String} [labels]  String list of comma separated Label names. Example: bug,ui,@high
- * @apiParam {String=created,updated,comments} [sort=created]  
- * @apiParam {String=asc,desc} [direction=desc]  
+ * @apiParam {String=created,updated,comments} [sort=created]
+ * @apiParam {String=asc,desc} [direction=desc]
  * @apiParam {Date} [since]  Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
@@ -2004,16 +2004,16 @@ github.issues.getForOrg({ ... });
  * @apiDescription List issues for a repository
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} [milestone]  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} [milestone]
  * @apiParam {String=open,closed,all} [state=open]  open, closed, or all
  * @apiParam {String} [assignee]  String User login, `none` for Issues with no assigned User. `*` for Issues with any assigned User.
  * @apiParam {String} [creator]  The user that created the issue.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiParam {String} [labels]  String list of comma separated Label names. Example: bug,ui,@high
- * @apiParam {String=created,updated,comments} [sort=created]  
- * @apiParam {String=asc,desc} [direction=desc]  
+ * @apiParam {String=created,updated,comments} [sort=created]
+ * @apiParam {String=asc,desc} [direction=desc]
  * @apiParam {Date} [since]  Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {String} [mentioned]  String User login.
@@ -2028,11 +2028,11 @@ github.issues.getForRepo({ ... });
  * @apiDescription List all issues across owned and member repositories for the authenticated user
  * @apiGroup issues
  *
- * @apiParam {String=all,assigned,created,mentioned,subscribed} [filter]  
+ * @apiParam {String=all,assigned,created,mentioned,subscribed} [filter]
  * @apiParam {String=open,closed,all} [state=open]  open, closed, or all
  * @apiParam {String} [labels]  String list of comma separated Label names. Example: bug,ui,@high
- * @apiParam {String=created,updated,comments} [sort=created]  
- * @apiParam {String=asc,desc} [direction=desc]  
+ * @apiParam {String=created,updated,comments} [sort=created]
+ * @apiParam {String=asc,desc} [direction=desc]
  * @apiParam {Date} [since]  Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
@@ -2047,9 +2047,9 @@ github.issues.getForUser({ ... });
  * @apiDescription List labels on an issue
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiExample {js} ex:
 github.issues.getIssueLabels({ ... });
  */
@@ -2061,9 +2061,9 @@ github.issues.getIssueLabels({ ... });
  * @apiDescription Get a single label
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} name  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} name
  * @apiExample {js} ex:
 github.issues.getLabel({ ... });
  */
@@ -2075,8 +2075,8 @@ github.issues.getLabel({ ... });
  * @apiDescription List all labels for this repository
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -2090,9 +2090,9 @@ github.issues.getLabels({ ... });
  * @apiDescription Get a single milestone
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiExample {js} ex:
 github.issues.getMilestone({ ... });
  */
@@ -2104,9 +2104,9 @@ github.issues.getMilestone({ ... });
  * @apiDescription Get labels for every issue in a milestone
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiExample {js} ex:
 github.issues.getMilestoneLabels({ ... });
  */
@@ -2118,11 +2118,11 @@ github.issues.getMilestoneLabels({ ... });
  * @apiDescription List milestones for a repository
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String=open,closed,all} [state=open]  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String=open,closed,all} [state=open]
  * @apiParam {String=due_on,completeness} [sort=due_on]  due_on, completeness, default: due_on
- * @apiParam {String=asc,desc} [direction=asc]  
+ * @apiParam {String=asc,desc} [direction=asc]
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -2136,9 +2136,9 @@ github.issues.getMilestones({ ... });
  * @apiDescription Users with push access can lock an issue's conversation.
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiExample {js} ex:
 github.issues.lock({ ... });
  */
@@ -2150,9 +2150,9 @@ github.issues.lock({ ... });
  * @apiDescription Remove all labels from an issue
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiExample {js} ex:
 github.issues.removeAllLabels({ ... });
  */
@@ -2164,10 +2164,10 @@ github.issues.removeAllLabels({ ... });
  * @apiDescription Remove assignees from an issue.
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
- * @apiParam {Json} body  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
+ * @apiParam {Json} body
  * @apiExample {js} ex:
 github.issues.removeAssigneesFromIssue({ ... });
  */
@@ -2179,10 +2179,10 @@ github.issues.removeAssigneesFromIssue({ ... });
  * @apiDescription Remove a label from an issue
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
- * @apiParam {String} name  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
+ * @apiParam {String} name
  * @apiExample {js} ex:
 github.issues.removeLabel({ ... });
  */
@@ -2194,9 +2194,9 @@ github.issues.removeLabel({ ... });
  * @apiDescription Replace all labels for an issue
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiParam {Array} labels  Sending an empty array ([]) will remove all Labels from the Issue.
  * @apiExample {js} ex:
 github.issues.replaceAllLabels({ ... });
@@ -2209,9 +2209,9 @@ github.issues.replaceAllLabels({ ... });
  * @apiDescription Users with push access can unlock an issue's conversation.
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiExample {js} ex:
 github.issues.unlock({ ... });
  */
@@ -2223,8 +2223,8 @@ github.issues.unlock({ ... });
  * @apiDescription Update a label
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} oldname  The old name of the label.
  * @apiParam {String} name  The new name of the label.
  * @apiParam {String} color  6 character hex code, without a leading #.
@@ -2239,12 +2239,12 @@ github.issues.updateLabel({ ... });
  * @apiDescription Update a milestone
  * @apiGroup issues
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
- * @apiParam {String} title  
- * @apiParam {String=open,closed,all} [state=open]  
- * @apiParam {String} [description]  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
+ * @apiParam {String} title
+ * @apiParam {String=open,closed,all} [state=open]
+ * @apiParam {String} [description]
  * @apiParam {Date} [due_on]  Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
  * @apiExample {js} ex:
 github.issues.updateMilestone({ ... });
@@ -2257,8 +2257,8 @@ github.issues.updateMilestone({ ... });
  * @apiDescription Cancel an import. (In preview period. See README.)
  * @apiGroup migrations
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.migrations.cancelImport({ ... });
  */
@@ -2270,8 +2270,8 @@ github.migrations.cancelImport({ ... });
  * @apiDescription Delete a migration archive. (In preview period. See README.)
  * @apiGroup migrations
  *
- * @apiParam {String} org  
- * @apiParam {String} id  
+ * @apiParam {String} org
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.migrations.deleteMigrationArchive({ ... });
  */
@@ -2283,8 +2283,8 @@ github.migrations.deleteMigrationArchive({ ... });
  * @apiDescription Get import commit authors. (In preview period. See README.)
  * @apiGroup migrations
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} [since]  Only authors found after this id are returned. Provide the highest author ID you've seen so far. New authors may be added to the list at any point while the importer is performing the raw step.
  * @apiExample {js} ex:
 github.migrations.getImportCommitAuthors({ ... });
@@ -2297,8 +2297,8 @@ github.migrations.getImportCommitAuthors({ ... });
  * @apiDescription Get import progress. (In preview period. See README.)
  * @apiGroup migrations
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.migrations.getImportProgress({ ... });
  */
@@ -2310,8 +2310,8 @@ github.migrations.getImportProgress({ ... });
  * @apiDescription List files larger than 100MB found during the import. (In preview period. See README.)
  * @apiGroup migrations
  *
- * @apiParam {String} owner  
- * @apiParam {String} name  
+ * @apiParam {String} owner
+ * @apiParam {String} name
  * @apiExample {js} ex:
 github.migrations.getLargeImportFiles({ ... });
  */
@@ -2323,8 +2323,8 @@ github.migrations.getLargeImportFiles({ ... });
  * @apiDescription Get the URL to a migration archive. (In preview period. See README.)
  * @apiGroup migrations
  *
- * @apiParam {String} org  
- * @apiParam {String} id  
+ * @apiParam {String} org
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.migrations.getMigrationArchiveLink({ ... });
  */
@@ -2336,8 +2336,8 @@ github.migrations.getMigrationArchiveLink({ ... });
  * @apiDescription Get the status of a migration. (In preview period. See README.)
  * @apiGroup migrations
  *
- * @apiParam {String} org  
- * @apiParam {String} id  
+ * @apiParam {String} org
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.migrations.getMigrationStatus({ ... });
  */
@@ -2349,7 +2349,7 @@ github.migrations.getMigrationStatus({ ... });
  * @apiDescription Get a list of migrations. (In preview period. See README.)
  * @apiGroup migrations
  *
- * @apiParam {String} org  
+ * @apiParam {String} org
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -2363,8 +2363,8 @@ github.migrations.getMigrations({ ... });
  * @apiDescription Map a commit author. (In preview period. See README.)
  * @apiGroup migrations
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} author_id  The commit author id.
  * @apiParam {String} [email]  The new Git author email.
  * @apiParam {String} [name]  The new Git author name.
@@ -2379,8 +2379,8 @@ github.migrations.mapImportCommitAuthor({ ... });
  * @apiDescription Set import LFS preference. (In preview period. See README.)
  * @apiGroup migrations
  *
- * @apiParam {String} owner  
- * @apiParam {String} name  
+ * @apiParam {String} owner
+ * @apiParam {String} name
  * @apiParam {String} use_lfs  Can be one of `opt_in` (large files will be stored using Git LFS) or `opt_out` (large files will be removed during the import).
  * @apiExample {js} ex:
 github.migrations.setImportLfsPreference({ ... });
@@ -2393,8 +2393,8 @@ github.migrations.setImportLfsPreference({ ... });
  * @apiDescription Start an import. (In preview period. See README.)
  * @apiGroup migrations
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} vcs_url  The URL of the originating repository.
  * @apiParam {String=subversion,git,mercurial,tfvc} [vcs]  The originating VCS type. Please be aware that without this parameter, the import job will take additional time to detect the VCS type before beginning the import. This detection step will be reflected in the response.
  * @apiParam {String} [vcs_username]  If authentication is required, the username to provide to vcs_url.
@@ -2411,7 +2411,7 @@ github.migrations.startImport({ ... });
  * @apiDescription Start a migration. (In preview period. See README.)
  * @apiGroup migrations
  *
- * @apiParam {String} org  
+ * @apiParam {String} org
  * @apiParam {Array} repositories  A list of arrays indicating which repositories should be migrated.
  * @apiParam {Boolean} [lock_repositories=false]  Indicates whether repositories should be locked (to prevent manipulation) while migrating data. Default: false.
  * @apiParam {Boolean} [exclude_attachments=false]  Indicates whether attachments should be excluded from the migration (to reduce migration archive file size). Default: false.
@@ -2426,9 +2426,9 @@ github.migrations.startMigration({ ... });
  * @apiDescription Unlock a repository that was locked for migration. (In preview period. See README.)
  * @apiGroup migrations
  *
- * @apiParam {String} org  
- * @apiParam {String} id  
- * @apiParam {String} repo_name  
+ * @apiParam {String} org
+ * @apiParam {String} id
+ * @apiParam {String} repo_name
  * @apiExample {js} ex:
 github.migrations.unlockRepoLockedForMigration({ ... });
  */
@@ -2440,8 +2440,8 @@ github.migrations.unlockRepoLockedForMigration({ ... });
  * @apiDescription Update existing import. (In preview period. See README.)
  * @apiGroup migrations
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.migrations.updateImport({ ... });
  */
@@ -2555,8 +2555,8 @@ github.misc.getRateLimit({ ... });
  * @apiDescription Get the contents of a repository's code of conduct. (In preview period. See README.)
  * @apiGroup misc
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.misc.getRepoCodeOfConduct({ ... });
  */
@@ -2568,8 +2568,8 @@ github.misc.getRepoCodeOfConduct({ ... });
  * @apiDescription Get the contents of a repository's license. (In preview period. See README.)
  * @apiGroup misc
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.misc.getRepoLicense({ ... });
  */
@@ -2607,8 +2607,8 @@ github.misc.renderMarkdownRaw({ ... });
  * @apiDescription Add or update organization membership
  * @apiGroup orgs
  *
- * @apiParam {String} org  
- * @apiParam {String} username  
+ * @apiParam {String} org
+ * @apiParam {String} username
  * @apiParam {String=admin,member} role=member  The role to give the user in the organization.
  * @apiExample {js} ex:
 github.orgs.addOrgMembership({ ... });
@@ -2621,8 +2621,8 @@ github.orgs.addOrgMembership({ ... });
  * @apiDescription Add team membership
  * @apiGroup orgs
  *
- * @apiParam {String} id  
- * @apiParam {String} username  
+ * @apiParam {String} id
+ * @apiParam {String} username
  * @apiParam {String=member,maintainer} [role=member]  The role that this user should have in the team.
  * @apiExample {js} ex:
 github.orgs.addTeamMembership({ ... });
@@ -2635,9 +2635,9 @@ github.orgs.addTeamMembership({ ... });
  * @apiDescription Add team repository
  * @apiGroup orgs
  *
- * @apiParam {String} id  
- * @apiParam {String} org  
- * @apiParam {String} repo  
+ * @apiParam {String} id
+ * @apiParam {String} org
+ * @apiParam {String} repo
  * @apiParam {String=pull,push,admin} [permission]  `pull` - team members can pull, but not push or administer this repository, `push` - team members can pull and push, but not administer this repository, `admin` - team members can pull, push and administer this repository.
  * @apiExample {js} ex:
 github.orgs.addTeamRepo({ ... });
@@ -2650,8 +2650,8 @@ github.orgs.addTeamRepo({ ... });
  * @apiDescription Block a user. (In preview period. See README.)
  * @apiGroup orgs
  *
- * @apiParam {String} org  
- * @apiParam {String} username  
+ * @apiParam {String} org
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.orgs.blockUser({ ... });
  */
@@ -2663,8 +2663,8 @@ github.orgs.blockUser({ ... });
  * @apiDescription Check whether you've blocked a user. (In preview period. See README.)
  * @apiGroup orgs
  *
- * @apiParam {String} org  
- * @apiParam {String} username  
+ * @apiParam {String} org
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.orgs.checkBlockedUser({ ... });
  */
@@ -2676,8 +2676,8 @@ github.orgs.checkBlockedUser({ ... });
  * @apiDescription Check membership
  * @apiGroup orgs
  *
- * @apiParam {String} org  
- * @apiParam {String} username  
+ * @apiParam {String} org
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.orgs.checkMembership({ ... });
  */
@@ -2689,8 +2689,8 @@ github.orgs.checkMembership({ ... });
  * @apiDescription Check public membership
  * @apiGroup orgs
  *
- * @apiParam {String} org  
- * @apiParam {String} username  
+ * @apiParam {String} org
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.orgs.checkPublicMembership({ ... });
  */
@@ -2702,9 +2702,9 @@ github.orgs.checkPublicMembership({ ... });
  * @apiDescription Check if a team manages a repository
  * @apiGroup orgs
  *
- * @apiParam {String} id  
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} id
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.orgs.checkTeamRepo({ ... });
  */
@@ -2716,8 +2716,8 @@ github.orgs.checkTeamRepo({ ... });
  * @apiDescription Conceal a user's membership
  * @apiGroup orgs
  *
- * @apiParam {String} org  
- * @apiParam {String} username  
+ * @apiParam {String} org
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.orgs.concealMembership({ ... });
  */
@@ -2729,8 +2729,8 @@ github.orgs.concealMembership({ ... });
  * @apiDescription Convert member to outside collaborator.
  * @apiGroup orgs
  *
- * @apiParam {String} org  
- * @apiParam {String} username  
+ * @apiParam {String} org
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.orgs.convertMemberToOutsideCollaborator({ ... });
  */
@@ -2742,7 +2742,7 @@ github.orgs.convertMemberToOutsideCollaborator({ ... });
  * @apiDescription Create a hook
  * @apiGroup orgs
  *
- * @apiParam {String} org  
+ * @apiParam {String} org
  * @apiParam {String} name  Must be passed as "web".
  * @apiParam {Json} config  Key/value pairs to provide settings for this webhook
  * @apiParam {Array} [events=["push"]]  Determines what events the hook is triggered for. Default: ["push"].
@@ -2758,8 +2758,8 @@ github.orgs.createHook({ ... });
  * @apiDescription Create team
  * @apiGroup orgs
  *
- * @apiParam {String} org  
- * @apiParam {String} name  
+ * @apiParam {String} org
+ * @apiParam {String} name
  * @apiParam {String} [description]  The description of the team.
  * @apiParam {Array} [maintainers]  The logins of organization members to add as maintainers of the team.
  * @apiParam {Array} [repo_names]  The full name (e.g., "organization-name/repository-name") of repositories to add the team to.
@@ -2775,8 +2775,8 @@ github.orgs.createTeam({ ... });
  * @apiDescription Delete a hook
  * @apiGroup orgs
  *
- * @apiParam {String} org  
- * @apiParam {String} id  
+ * @apiParam {String} org
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.orgs.deleteHook({ ... });
  */
@@ -2788,7 +2788,7 @@ github.orgs.deleteHook({ ... });
  * @apiDescription Delete team
  * @apiGroup orgs
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.orgs.deleteTeam({ ... });
  */
@@ -2800,9 +2800,9 @@ github.orgs.deleteTeam({ ... });
  * @apiDescription Remove team repository
  * @apiGroup orgs
  *
- * @apiParam {String} id  
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} id
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.orgs.deleteTeamRepo({ ... });
  */
@@ -2814,8 +2814,8 @@ github.orgs.deleteTeamRepo({ ... });
  * @apiDescription Edit a hook
  * @apiGroup orgs
  *
- * @apiParam {String} org  
- * @apiParam {String} id  
+ * @apiParam {String} org
+ * @apiParam {String} id
  * @apiParam {Json} config  Key/value pairs to provide settings for this webhook
  * @apiParam {Array} [events=["push"]]  Determines what events the hook is triggered for. Default: ["push"].
  * @apiParam {Boolean} [active]  Determines whether the hook is actually triggered on pushes.
@@ -2830,8 +2830,8 @@ github.orgs.editHook({ ... });
  * @apiDescription Edit team
  * @apiGroup orgs
  *
- * @apiParam {String} id  
- * @apiParam {String} name  
+ * @apiParam {String} id
+ * @apiParam {String} name
  * @apiParam {String} [description]  The description of the team.
  * @apiParam {String=secret,closed} [privacy=secret]  The level of privacy this team should have.
  * @apiExample {js} ex:
@@ -2845,7 +2845,7 @@ github.orgs.editTeam({ ... });
  * @apiDescription Get an organization
  * @apiGroup orgs
  *
- * @apiParam {String} org  
+ * @apiParam {String} org
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -2873,7 +2873,7 @@ github.orgs.getAll({ ... });
  * @apiDescription List blocked users. (In preview period. See README.)
  * @apiGroup orgs
  *
- * @apiParam {String} org  
+ * @apiParam {String} org
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -2887,7 +2887,7 @@ github.orgs.getBlockedUsers({ ... });
  * @apiDescription List public organization memberships for the specified user.
  * @apiGroup orgs
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -2901,8 +2901,8 @@ github.orgs.getForUser({ ... });
  * @apiDescription Get single hook
  * @apiGroup orgs
  *
- * @apiParam {String} org  
- * @apiParam {String} id  
+ * @apiParam {String} org
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.orgs.getHook({ ... });
  */
@@ -2914,7 +2914,7 @@ github.orgs.getHook({ ... });
  * @apiDescription List hooks
  * @apiGroup orgs
  *
- * @apiParam {String} org  
+ * @apiParam {String} org
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -2928,7 +2928,7 @@ github.orgs.getHooks({ ... });
  * @apiDescription Members list
  * @apiGroup orgs
  *
- * @apiParam {String} org  
+ * @apiParam {String} org
  * @apiParam {String=all,2fa_disabled} [filter=all]  Filter members returned in the list.
  * @apiParam {String=all,admin,member} [role=all]  Filter members returned by their role.
  * @apiParam {Number} [page]  Page number of the results to fetch.
@@ -2944,8 +2944,8 @@ github.orgs.getMembers({ ... });
  * @apiDescription Get organization membership
  * @apiGroup orgs
  *
- * @apiParam {String} org  
- * @apiParam {String} username  
+ * @apiParam {String} org
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.orgs.getOrgMembership({ ... });
  */
@@ -2957,7 +2957,7 @@ github.orgs.getOrgMembership({ ... });
  * @apiDescription List all users who are outside collaborators of an organization.
  * @apiGroup orgs
  *
- * @apiParam {String} org  
+ * @apiParam {String} org
  * @apiParam {String=all,2fa_disabled} [filter=all]  Filter the list of outside collaborators.
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
@@ -2972,7 +2972,7 @@ github.orgs.getOutsideCollaborators({ ... });
  * @apiDescription List pending organization invites.
  * @apiGroup orgs
  *
- * @apiParam {String} org  
+ * @apiParam {String} org
  * @apiExample {js} ex:
 github.orgs.getPendingOrgInvites({ ... });
  */
@@ -2984,7 +2984,7 @@ github.orgs.getPendingOrgInvites({ ... });
  * @apiDescription List pending team invitations.
  * @apiGroup orgs
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -2998,7 +2998,7 @@ github.orgs.getPendingTeamInvites({ ... });
  * @apiDescription Public members list
  * @apiGroup orgs
  *
- * @apiParam {String} org  
+ * @apiParam {String} org
  * @apiExample {js} ex:
 github.orgs.getPublicMembers({ ... });
  */
@@ -3010,7 +3010,7 @@ github.orgs.getPublicMembers({ ... });
  * @apiDescription Get team
  * @apiGroup orgs
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.orgs.getTeam({ ... });
  */
@@ -3022,7 +3022,7 @@ github.orgs.getTeam({ ... });
  * @apiDescription List team members
  * @apiGroup orgs
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiParam {String=member,maintainer,all} [role=all]  Filters members returned by their role in the team.
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
@@ -3037,8 +3037,8 @@ github.orgs.getTeamMembers({ ... });
  * @apiDescription Get team membership
  * @apiGroup orgs
  *
- * @apiParam {String} id  
- * @apiParam {String} username  
+ * @apiParam {String} id
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.orgs.getTeamMembership({ ... });
  */
@@ -3050,7 +3050,7 @@ github.orgs.getTeamMembership({ ... });
  * @apiDescription Get team repos
  * @apiGroup orgs
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -3064,7 +3064,7 @@ github.orgs.getTeamRepos({ ... });
  * @apiDescription List teams
  * @apiGroup orgs
  *
- * @apiParam {String} org  
+ * @apiParam {String} org
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -3078,8 +3078,8 @@ github.orgs.getTeams({ ... });
  * @apiDescription Ping a hook
  * @apiGroup orgs
  *
- * @apiParam {String} org  
- * @apiParam {String} id  
+ * @apiParam {String} org
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.orgs.pingHook({ ... });
  */
@@ -3091,8 +3091,8 @@ github.orgs.pingHook({ ... });
  * @apiDescription Publicize a user's membership
  * @apiGroup orgs
  *
- * @apiParam {String} org  
- * @apiParam {String} username  
+ * @apiParam {String} org
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.orgs.publicizeMembership({ ... });
  */
@@ -3104,8 +3104,8 @@ github.orgs.publicizeMembership({ ... });
  * @apiDescription Remove a member
  * @apiGroup orgs
  *
- * @apiParam {String} org  
- * @apiParam {String} username  
+ * @apiParam {String} org
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.orgs.removeMember({ ... });
  */
@@ -3117,8 +3117,8 @@ github.orgs.removeMember({ ... });
  * @apiDescription Remove organization membership
  * @apiGroup orgs
  *
- * @apiParam {String} org  
- * @apiParam {String} username  
+ * @apiParam {String} org
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.orgs.removeOrgMembership({ ... });
  */
@@ -3130,8 +3130,8 @@ github.orgs.removeOrgMembership({ ... });
  * @apiDescription Remove outside collaborator.
  * @apiGroup orgs
  *
- * @apiParam {String} org  
- * @apiParam {String} username  
+ * @apiParam {String} org
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.orgs.removeOutsideCollaborator({ ... });
  */
@@ -3143,8 +3143,8 @@ github.orgs.removeOutsideCollaborator({ ... });
  * @apiDescription Remove team membership
  * @apiGroup orgs
  *
- * @apiParam {String} id  
- * @apiParam {String} username  
+ * @apiParam {String} id
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.orgs.removeTeamMembership({ ... });
  */
@@ -3156,8 +3156,8 @@ github.orgs.removeTeamMembership({ ... });
  * @apiDescription Unblock a user. (In preview period. See README.)
  * @apiGroup orgs
  *
- * @apiParam {String} org  
- * @apiParam {String} username  
+ * @apiParam {String} org
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.orgs.unblockUser({ ... });
  */
@@ -3169,7 +3169,7 @@ github.orgs.unblockUser({ ... });
  * @apiDescription Edit an organization
  * @apiGroup orgs
  *
- * @apiParam {String} org  
+ * @apiParam {String} org
  * @apiParam {String} [billing_email]  Billing email address. This address is not publicized.
  * @apiParam {String} [company]  The company name.
  * @apiParam {String} [email]  The publicly visible email address.
@@ -3189,9 +3189,9 @@ github.orgs.update({ ... });
  * @apiDescription Create an organization project. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} org  
- * @apiParam {String} name  
- * @apiParam {String} [body]  
+ * @apiParam {String} org
+ * @apiParam {String} name
+ * @apiParam {String} [body]
  * @apiExample {js} ex:
 github.projects.createOrgProject({ ... });
  */
@@ -3203,7 +3203,7 @@ github.projects.createOrgProject({ ... });
  * @apiDescription Create a project card. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} column_id  
+ * @apiParam {String} column_id
  * @apiParam {String} [note]  The note of the card.
  * @apiParam {String} [content_id]  The id of the Issue or Pull Request to associate with this card.
  * @apiParam {String} [content_type]  The type of content to associate with this card. Can be either 'Issue' or 'PullRequest'.
@@ -3218,8 +3218,8 @@ github.projects.createProjectCard({ ... });
  * @apiDescription Create a project column. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} project_id  
- * @apiParam {String} name  
+ * @apiParam {String} project_id
+ * @apiParam {String} name
  * @apiExample {js} ex:
 github.projects.createProjectColumn({ ... });
  */
@@ -3231,10 +3231,10 @@ github.projects.createProjectColumn({ ... });
  * @apiDescription Create a repository project. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} name  
- * @apiParam {String} [body]  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} name
+ * @apiParam {String} [body]
  * @apiExample {js} ex:
 github.projects.createRepoProject({ ... });
  */
@@ -3246,7 +3246,7 @@ github.projects.createRepoProject({ ... });
  * @apiDescription Delete a project. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.projects.deleteProject({ ... });
  */
@@ -3258,7 +3258,7 @@ github.projects.deleteProject({ ... });
  * @apiDescription Delete a project card. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.projects.deleteProjectCard({ ... });
  */
@@ -3270,7 +3270,7 @@ github.projects.deleteProjectCard({ ... });
  * @apiDescription Delete a project column. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.projects.deleteProjectColumn({ ... });
  */
@@ -3282,8 +3282,8 @@ github.projects.deleteProjectColumn({ ... });
  * @apiDescription List organization projects. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} org  
- * @apiParam {String=open,closed,all} [state=open]  
+ * @apiParam {String} org
+ * @apiParam {String=open,closed,all} [state=open]
  * @apiExample {js} ex:
 github.projects.getOrgProjects({ ... });
  */
@@ -3295,7 +3295,7 @@ github.projects.getOrgProjects({ ... });
  * @apiDescription Get a project. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.projects.getProject({ ... });
  */
@@ -3307,7 +3307,7 @@ github.projects.getProject({ ... });
  * @apiDescription Get project card. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.projects.getProjectCard({ ... });
  */
@@ -3319,7 +3319,7 @@ github.projects.getProjectCard({ ... });
  * @apiDescription List project cards. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} column_id  
+ * @apiParam {String} column_id
  * @apiExample {js} ex:
 github.projects.getProjectCards({ ... });
  */
@@ -3331,7 +3331,7 @@ github.projects.getProjectCards({ ... });
  * @apiDescription Get a project column. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.projects.getProjectColumn({ ... });
  */
@@ -3343,7 +3343,7 @@ github.projects.getProjectColumn({ ... });
  * @apiDescription List project columns. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} project_id  
+ * @apiParam {String} project_id
  * @apiExample {js} ex:
 github.projects.getProjectColumns({ ... });
  */
@@ -3355,9 +3355,9 @@ github.projects.getProjectColumns({ ... });
  * @apiDescription List repository projects. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String=open,closed,all} [state=open]  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String=open,closed,all} [state=open]
  * @apiExample {js} ex:
 github.projects.getRepoProjects({ ... });
  */
@@ -3369,7 +3369,7 @@ github.projects.getRepoProjects({ ... });
  * @apiDescription Move a project card. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiParam {String} position  Can be one of top, bottom, or after:<column-id>, where <column-id> is the id value of a column in the same project.
  * @apiParam {String} [column_id]  The id value of a column in the same project.
  * @apiExample {js} ex:
@@ -3383,7 +3383,7 @@ github.projects.moveProjectCard({ ... });
  * @apiDescription Move a project column. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiParam {String} position  Can be one of first, last, or after:<column-id>, where <column-id> is the id value of a column in the same project.
  * @apiExample {js} ex:
 github.projects.moveProjectColumn({ ... });
@@ -3396,10 +3396,10 @@ github.projects.moveProjectColumn({ ... });
  * @apiDescription Update a project. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} id  
- * @apiParam {String} name  
- * @apiParam {String} [body]  
- * @apiParam {String=open,closed,all} [state=open]  
+ * @apiParam {String} id
+ * @apiParam {String} name
+ * @apiParam {String} [body]
+ * @apiParam {String=open,closed,all} [state=open]
  * @apiExample {js} ex:
 github.projects.updateProject({ ... });
  */
@@ -3411,7 +3411,7 @@ github.projects.updateProject({ ... });
  * @apiDescription Update a project card. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiParam {String} [note]  The note of the card.
  * @apiExample {js} ex:
 github.projects.updateProjectCard({ ... });
@@ -3424,8 +3424,8 @@ github.projects.updateProjectCard({ ... });
  * @apiDescription Update a project column. (In preview period. See README.)
  * @apiGroup projects
  *
- * @apiParam {String} id  
- * @apiParam {String} name  
+ * @apiParam {String} id
+ * @apiParam {String} name
  * @apiExample {js} ex:
 github.projects.updateProjectColumn({ ... });
  */
@@ -3437,9 +3437,9 @@ github.projects.updateProjectColumn({ ... });
  * @apiDescription Get if a pull request has been merged
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -3453,8 +3453,8 @@ github.pullRequests.checkMerged({ ... });
  * @apiDescription Create a pull request
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} title  The title of the pull request.
  * @apiParam {String} head  The branch (or git ref) where your changes are implemented.
  * @apiParam {String} base  The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo.
@@ -3471,10 +3471,10 @@ github.pullRequests.create({ ... });
  * @apiDescription Create a comment
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
- * @apiParam {String} body  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
+ * @apiParam {String} body
  * @apiParam {String} commit_id  Sha of the commit to comment on.
  * @apiParam {String} path  Relative path of the file to comment on.
  * @apiParam {Number} position  Column index in the diff to comment on.
@@ -3489,10 +3489,10 @@ github.pullRequests.createComment({ ... });
  * @apiDescription Reply to existing pull request comment
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
- * @apiParam {String} body  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
+ * @apiParam {String} body
  * @apiParam {Number} in_reply_to  The comment id to reply to.
  * @apiExample {js} ex:
 github.pullRequests.createCommentReply({ ... });
@@ -3505,8 +3505,8 @@ github.pullRequests.createCommentReply({ ... });
  * @apiDescription Create a pull request from an existing issue
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} issue  The issue number in this repository to turn into a Pull Request.
  * @apiParam {String} head  The branch (or git ref) where your changes are implemented.
  * @apiParam {String} base  The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo.
@@ -3521,9 +3521,9 @@ github.pullRequests.createFromIssue({ ... });
  * @apiDescription Create a pull request review.
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiParam {String} [commit_id]  Sha of the commit to comment on.
  * @apiParam {String} [body]  The body text of the pull request review.
  * @apiParam {String=APPROVE,REQUEST_CHANGES,COMMENT,PENDING} [event=PENDING]  The event to perform on the review upon submission, can be one of APPROVE, REQUEST_CHANGES, or COMMENT. If left blank, the review will be in the PENDING state.
@@ -3539,9 +3539,9 @@ github.pullRequests.createReview({ ... });
  * @apiDescription Create a review request. (In preview period. See README.)
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiParam {Array} [reviewers]  An array of user logins that will be requested.
  * @apiParam {Array} [team_reviewers]  An array of team slugs that will be requested.
  * @apiExample {js} ex:
@@ -3555,9 +3555,9 @@ github.pullRequests.createReviewRequest({ ... });
  * @apiDescription Delete a comment
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.pullRequests.deleteComment({ ... });
  */
@@ -3569,10 +3569,10 @@ github.pullRequests.deleteComment({ ... });
  * @apiDescription Delete a pending pull request review.
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.pullRequests.deletePendingReview({ ... });
  */
@@ -3584,9 +3584,9 @@ github.pullRequests.deletePendingReview({ ... });
  * @apiDescription Delete a review request. (In preview period. See README.)
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiParam {Array} [reviewers]  An array of user logins that will be requested.
  * @apiParam {Array} [team_reviewers]  An array of team slugs that will be requested.
  * @apiExample {js} ex:
@@ -3600,10 +3600,10 @@ github.pullRequests.deleteReviewRequest({ ... });
  * @apiDescription Dismiss a pull request review.
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
+ * @apiParam {String} id
  * @apiParam {String} [message]  The message for the pull request review dismissal.
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
@@ -3618,10 +3618,10 @@ github.pullRequests.dismissReview({ ... });
  * @apiDescription Edit a comment
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
- * @apiParam {String} body  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
+ * @apiParam {String} body
  * @apiExample {js} ex:
 github.pullRequests.editComment({ ... });
  */
@@ -3633,9 +3633,9 @@ github.pullRequests.editComment({ ... });
  * @apiDescription Get a single pull request
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiExample {js} ex:
 github.pullRequests.get({ ... });
  */
@@ -3647,13 +3647,13 @@ github.pullRequests.get({ ... });
  * @apiDescription List pull requests
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String=open,closed,all} [state=open]  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String=open,closed,all} [state=open]
  * @apiParam {String} [head]  Filter pulls by head user and branch name in the format of user:ref-name. Example: github:new-script-format.
  * @apiParam {String} [base]  Filter pulls by base branch name. Example: gh-pages.
  * @apiParam {String=created,updated,popularity,long-running} [sort=created]  Possible values are: `created`, `updated`, `popularity`, `long-running`, Default: `created`
- * @apiParam {String=asc,desc} [direction=desc]  
+ * @apiParam {String=asc,desc} [direction=desc]
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -3667,9 +3667,9 @@ github.pullRequests.getAll({ ... });
  * @apiDescription Get a single comment
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.pullRequests.getComment({ ... });
  */
@@ -3681,9 +3681,9 @@ github.pullRequests.getComment({ ... });
  * @apiDescription List comments on a pull request
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -3697,10 +3697,10 @@ github.pullRequests.getComments({ ... });
  * @apiDescription List comments in a repository
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String=created,updated} [sort=created]  Possible values are: `created`, `updated`, Default: `created`
- * @apiParam {String=asc,desc} [direction=desc]  
+ * @apiParam {String=asc,desc} [direction=desc]
  * @apiParam {Date} [since]  Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
@@ -3715,9 +3715,9 @@ github.pullRequests.getCommentsForRepo({ ... });
  * @apiDescription List commits on a pull request
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -3731,9 +3731,9 @@ github.pullRequests.getCommits({ ... });
  * @apiDescription List pull requests files
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -3747,10 +3747,10 @@ github.pullRequests.getFiles({ ... });
  * @apiDescription Get a single pull request review.
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.pullRequests.getReview({ ... });
  */
@@ -3762,10 +3762,10 @@ github.pullRequests.getReview({ ... });
  * @apiDescription Get comments for a pull request review.
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
+ * @apiParam {String} id
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -3779,9 +3779,9 @@ github.pullRequests.getReviewComments({ ... });
  * @apiDescription List review requests. (In preview period. See README.)
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -3795,9 +3795,9 @@ github.pullRequests.getReviewRequests({ ... });
  * @apiDescription List reviews on a pull request.
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -3811,9 +3811,9 @@ github.pullRequests.getReviews({ ... });
  * @apiDescription Merge a pull request (Merge Button)
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiParam {String} [commit_title]  Title for the automatic commit message. (In preview period. See README.)
  * @apiParam {String} [commit_message]  Extra detail to append to automatic commit message.
  * @apiParam {String} [sha]  SHA that pull request head must match to allow merge
@@ -3829,10 +3829,10 @@ github.pullRequests.merge({ ... });
  * @apiDescription Submit a pull request review.
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
+ * @apiParam {String} id
  * @apiParam {String} [body]  The body text of the pull request review.
  * @apiParam {String=APPROVE,REQUEST_CHANGES,COMMENT,PENDING} [event=PENDING]  The event to perform on the review upon submission, can be one of APPROVE, REQUEST_CHANGES, or COMMENT. If left blank, the review will be in the PENDING state.
  * @apiExample {js} ex:
@@ -3846,9 +3846,9 @@ github.pullRequests.submitReview({ ... });
  * @apiDescription Update a pull request
  * @apiGroup pullRequests
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiParam {String} [title]  The title of the pull request.
  * @apiParam {String} [body]  The contents of the pull request.
  * @apiParam {String=open,closed} [state]  open or closed
@@ -3865,9 +3865,9 @@ github.pullRequests.update({ ... });
  * @apiDescription Create reaction for a commit comment. (In preview period. See README.)
  * @apiGroup reactions
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiParam {String=+1,-1,laugh,confused,heart,hooray} content  The reaction type.
  * @apiExample {js} ex:
 github.reactions.createForCommitComment({ ... });
@@ -3880,9 +3880,9 @@ github.reactions.createForCommitComment({ ... });
  * @apiDescription Create reaction for an issue. (In preview period. See README.)
  * @apiGroup reactions
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiParam {String=+1,-1,laugh,confused,heart,hooray} content  The reaction type.
  * @apiExample {js} ex:
 github.reactions.createForIssue({ ... });
@@ -3895,9 +3895,9 @@ github.reactions.createForIssue({ ... });
  * @apiDescription Create reaction for an issue comment. (In preview period. See README.)
  * @apiGroup reactions
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiParam {String=+1,-1,laugh,confused,heart,hooray} content  The reaction type.
  * @apiExample {js} ex:
 github.reactions.createForIssueComment({ ... });
@@ -3910,9 +3910,9 @@ github.reactions.createForIssueComment({ ... });
  * @apiDescription Create reaction for a pull request review comment. (In preview period. See README.)
  * @apiGroup reactions
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiParam {String=+1,-1,laugh,confused,heart,hooray} content  The reaction type.
  * @apiExample {js} ex:
 github.reactions.createForPullRequestReviewComment({ ... });
@@ -3925,7 +3925,7 @@ github.reactions.createForPullRequestReviewComment({ ... });
  * @apiDescription Delete a reaction. (In preview period. See README.)
  * @apiGroup reactions
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.reactions.delete({ ... });
  */
@@ -3937,9 +3937,9 @@ github.reactions.delete({ ... });
  * @apiDescription List reactions for a commit comment. (In preview period. See README.)
  * @apiGroup reactions
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiParam {String=+1,-1,laugh,confused,heart,hooray} [content]  Indicates which type of reaction to return.
  * @apiExample {js} ex:
 github.reactions.getForCommitComment({ ... });
@@ -3952,9 +3952,9 @@ github.reactions.getForCommitComment({ ... });
  * @apiDescription List reactions for an issue. (In preview period. See README.)
  * @apiGroup reactions
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {Number} number  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {Number} number
  * @apiParam {String=+1,-1,laugh,confused,heart,hooray} [content]  Indicates which type of reaction to return.
  * @apiExample {js} ex:
 github.reactions.getForIssue({ ... });
@@ -3967,9 +3967,9 @@ github.reactions.getForIssue({ ... });
  * @apiDescription List reactions for an issue comment. (In preview period. See README.)
  * @apiGroup reactions
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiParam {String=+1,-1,laugh,confused,heart,hooray} [content]  Indicates which type of reaction to return.
  * @apiExample {js} ex:
 github.reactions.getForIssueComment({ ... });
@@ -3982,9 +3982,9 @@ github.reactions.getForIssueComment({ ... });
  * @apiDescription List reactions for a pull request review comment. (In preview period. See README.)
  * @apiGroup reactions
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiParam {String=+1,-1,laugh,confused,heart,hooray} [content]  Indicates which type of reaction to return.
  * @apiExample {js} ex:
 github.reactions.getForPullRequestReviewComment({ ... });
@@ -3997,9 +3997,9 @@ github.reactions.getForPullRequestReviewComment({ ... });
  * @apiDescription Add user as a collaborator
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} username  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} username
  * @apiParam {String=pull,push,admin} [permission=push]  `pull` - can pull, but not push to or administer this repository, `push` - can pull and push, but not administer this repository, `admin` - can pull, push and administer this repository.
  * @apiExample {js} ex:
 github.repos.addCollaborator({ ... });
@@ -4012,10 +4012,10 @@ github.repos.addCollaborator({ ... });
  * @apiDescription Add a new deploy key.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} title  
- * @apiParam {String} key  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} title
+ * @apiParam {String} key
  * @apiParam {Boolean} [read_only]  If true, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.
  * @apiExample {js} ex:
 github.repos.addDeployKey({ ... });
@@ -4028,9 +4028,9 @@ github.repos.addDeployKey({ ... });
  * @apiDescription Add admin enforcement of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -4044,9 +4044,9 @@ github.repos.addProtectedBranchAdminEnforcement({ ... });
  * @apiDescription Add required status checks contexts of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Array} contexts  An array of protected branch required status checks contexts (e.g. continuous-integration/jenkins).
  * @apiExample {js} ex:
 github.repos.addProtectedBranchRequiredStatusChecksContexts({ ... });
@@ -4059,9 +4059,9 @@ github.repos.addProtectedBranchRequiredStatusChecksContexts({ ... });
  * @apiDescription Add team restrictions of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Array} teams  An array of team slugs (e.g. justice-league).
  * @apiExample {js} ex:
 github.repos.addProtectedBranchTeamRestrictions({ ... });
@@ -4074,9 +4074,9 @@ github.repos.addProtectedBranchTeamRestrictions({ ... });
  * @apiDescription Add user restrictions of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Array} users  An array of team slugs (e.g. justice-league).
  * @apiExample {js} ex:
 github.repos.addProtectedBranchUserRestrictions({ ... });
@@ -4089,9 +4089,9 @@ github.repos.addProtectedBranchUserRestrictions({ ... });
  * @apiDescription Check if user is a collaborator.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} username  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.repos.checkCollaborator({ ... });
  */
@@ -4103,8 +4103,8 @@ github.repos.checkCollaborator({ ... });
  * @apiDescription Compare two commits.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} base  The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo.
  * @apiParam {String} head  The branch (or git ref) where your changes are implemented.
  * @apiExample {js} ex:
@@ -4118,14 +4118,14 @@ github.repos.compareCommits({ ... });
  * @apiDescription Create a new repository for the authenticated user.
  * @apiGroup repos
  *
- * @apiParam {String} name  
+ * @apiParam {String} name
  * @apiParam {Boolean} [allow_rebase_merge=true]  Either true to allow rebase-merging pull requests, or false to prevent rebase-merging. Default: true. (In preview period. See README.)
- * @apiParam {String} [homepage]  
+ * @apiParam {String} [homepage]
  * @apiParam {Boolean} [private=false]  True to create a private repository, false to create a public one. Creating private repositories requires a paid GitHub account. Default is false.
  * @apiParam {Boolean} [has_issues=true]  True to enable issues for this repository, false to disable them. Default is true.
  * @apiParam {Boolean} [has_projects=true]  True to enable projects for this repository, false to disable them. Default is true.
  * @apiParam {Boolean} [has_wiki=true]  True to enable the wiki for this repository, false to disable it. Default is true.
- * @apiParam {String} [description]  
+ * @apiParam {String} [description]
  * @apiParam {Boolean} [auto_init=false]  True to create an initial commit with empty README. Default is false
  * @apiParam {String} [gitignore_template]  Desired language or platform .gitignore template to apply. Ignored if auto_init parameter is not provided.
  * @apiParam {String} [license_template]  Desired LICENSE template to apply. Use the name of the template without the extension. For example, "mit" or "mozilla".
@@ -4143,10 +4143,10 @@ github.repos.create({ ... });
  * @apiDescription Create a commit comment.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} sha  
- * @apiParam {String} body  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} sha
+ * @apiParam {String} body
  * @apiParam {String} [path]  Relative path of the file to comment on.
  * @apiParam {Number} [position]  Line index in the diff to comment on.
  * @apiExample {js} ex:
@@ -4160,9 +4160,9 @@ github.repos.createCommitComment({ ... });
  * @apiDescription Create a deployment. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
+ * @apiParam {String} owner
  * @apiParam {String} ref  The ref to deploy. This can be a branch, tag, or sha.
- * @apiParam {String} repo  
+ * @apiParam {String} repo
  * @apiParam {String} [task=deploy]  The named task to execute. e.g. deploy or deploy:migrations. Default: deploy
  * @apiParam {Boolean} [auto_merge=true]  Optional parameter to merge the default branch into the requested ref if it is behind the default branch. Default: true
  * @apiParam {Boolean} [production_environment]  Specifies if the given environment is a one that end-users directly interact with. Default: true when environment is `production` and false otherwise. (In preview period. See README.)
@@ -4182,9 +4182,9 @@ github.repos.createDeployment({ ... });
  * @apiDescription Create a deployment status. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiParam {String} [state]  The state of the status. Can be one of pending, success, error, or failure.
  * @apiParam {String} [target_url=""]  The target URL to associate with this status. This URL should contain output to keep the user updated while the task is running or serve as historical information for what happened in the deployment. Default: ""
  * @apiParam {String} [log_url=""]  Functionally equivalent to target_url. Default: "". (In preview period. See README.)
@@ -4202,14 +4202,14 @@ github.repos.createDeploymentStatus({ ... });
  * @apiDescription Create a new file in the given repository.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} path  The content path.
  * @apiParam {String} message  The commit message.
  * @apiParam {String} content  The new file content, Base64 encoded.
  * @apiParam {String} [branch]  The branch name. If not provided, uses the repository’s default branch (usually master).
- * @apiParam {Json} [committer]  
- * @apiParam {Json} [author]  
+ * @apiParam {Json} [committer]
+ * @apiParam {Json} [author]
  * @apiExample {js} ex:
 github.repos.createFile({ ... });
  */
@@ -4221,10 +4221,10 @@ github.repos.createFile({ ... });
  * @apiDescription Create a new repository for an organization.
  * @apiGroup repos
  *
- * @apiParam {String} org  
- * @apiParam {String} name  
- * @apiParam {String} [description]  
- * @apiParam {String} [homepage]  
+ * @apiParam {String} org
+ * @apiParam {String} name
+ * @apiParam {String} [description]
+ * @apiParam {String} [homepage]
  * @apiParam {Boolean} [private=false]  True to create a private repository, false to create a public one. Creating private repositories requires a paid GitHub account. Default is false.
  * @apiParam {Boolean} [has_issues=true]  True to enable issues for this repository, false to disable them. Default is true.
  * @apiParam {Boolean} [has_projects=true]  True to enable projects for this repository, false to disable them. Default is true.
@@ -4247,9 +4247,9 @@ github.repos.createForOrg({ ... });
  * @apiDescription Create a hook.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} name  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} name
  * @apiParam {Json} config  A Hash containing key/value pairs to provide settings for this hook. These settings vary between the services and are defined in the github-services repo. Booleans are stored internally as `1` for true, and `0` for false. Any JSON true/false values will be converted automatically.
  * @apiParam {Array} [events=["push"]]  Determines what events the hook is triggered for. Default: `['push']`.
  * @apiParam {Boolean} [active]  Determines whether the hook is actually triggered on pushes.
@@ -4264,12 +4264,12 @@ github.repos.createHook({ ... });
  * @apiDescription Create a release.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} tag_name  String of the tag
  * @apiParam {String} [target_commitish]  Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch (usually master).
- * @apiParam {String} [name]  
- * @apiParam {String} [body]  
+ * @apiParam {String} [name]
+ * @apiParam {String} [body]
  * @apiParam {Boolean} [draft=false]  true to create a draft (unpublished) release, false to create a published one. Default: false
  * @apiParam {Boolean} [prerelease=false]  true to identify the release as a prerelease. false to identify the release as a full release. Default: false
  * @apiExample {js} ex:
@@ -4283,9 +4283,9 @@ github.repos.createRelease({ ... });
  * @apiDescription Create a status.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} sha  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} sha
  * @apiParam {String=pending,success,error,failure} state  State of the status - can be one of pending, success, error, or failure.
  * @apiParam {String} [target_url]  Target url to associate with this status. This URL will be linked from the GitHub UI to allow users to easily see the ‘source’ of the Status.
  * @apiParam {String} [description]  Short description of the status.
@@ -4301,8 +4301,8 @@ github.repos.createStatus({ ... });
  * @apiDescription Delete a repository.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.repos.delete({ ... });
  */
@@ -4314,9 +4314,9 @@ github.repos.delete({ ... });
  * @apiDescription Delete a release asset.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.repos.deleteAsset({ ... });
  */
@@ -4328,9 +4328,9 @@ github.repos.deleteAsset({ ... });
  * @apiDescription Delete a commit comment.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.repos.deleteCommitComment({ ... });
  */
@@ -4342,9 +4342,9 @@ github.repos.deleteCommitComment({ ... });
  * @apiDescription Remove a deploy key.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.repos.deleteDeployKey({ ... });
  */
@@ -4356,9 +4356,9 @@ github.repos.deleteDeployKey({ ... });
  * @apiDescription Delete a download.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.repos.deleteDownload({ ... });
  */
@@ -4370,14 +4370,14 @@ github.repos.deleteDownload({ ... });
  * @apiDescription Delete a file.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} path  The content path.
  * @apiParam {String} message  The commit message.
  * @apiParam {String} sha  The blob SHA of the file being removed.
  * @apiParam {String} [branch]  The branch name. If not provided, uses the repository’s default branch (usually master).
- * @apiParam {Json} [committer]  
- * @apiParam {Json} [author]  
+ * @apiParam {Json} [committer]
+ * @apiParam {Json} [author]
  * @apiExample {js} ex:
 github.repos.deleteFile({ ... });
  */
@@ -4389,9 +4389,9 @@ github.repos.deleteFile({ ... });
  * @apiDescription Deleate a hook.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.repos.deleteHook({ ... });
  */
@@ -4403,9 +4403,9 @@ github.repos.deleteHook({ ... });
  * @apiDescription Delete a repository invitation.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} invitation_id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} invitation_id
  * @apiExample {js} ex:
 github.repos.deleteInvite({ ... });
  */
@@ -4417,9 +4417,9 @@ github.repos.deleteInvite({ ... });
  * @apiDescription Delete a release
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.repos.deleteRelease({ ... });
  */
@@ -4431,11 +4431,11 @@ github.repos.deleteRelease({ ... });
  * @apiDescription Update a repo.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} name  
- * @apiParam {String} repo  
- * @apiParam {String} [description]  
- * @apiParam {String} [homepage]  
+ * @apiParam {String} owner
+ * @apiParam {String} name
+ * @apiParam {String} repo
+ * @apiParam {String} [description]
+ * @apiParam {String} [homepage]
  * @apiParam {Boolean} [private=false]  True to create a private repository, false to create a public one. Creating private repositories requires a paid GitHub account. Default is false.
  * @apiParam {Boolean} [allow_rebase_merge=true]  Either true to allow rebase-merging pull requests, or false to prevent rebase-merging. Default: true. (In preview period. See README.)
  * @apiParam {Boolean} [has_projects=true]  True to enable projects for this repository, false to disable them. Default is true.
@@ -4455,10 +4455,10 @@ github.repos.edit({ ... });
  * @apiDescription Edit a release asset.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
- * @apiParam {String} name  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
+ * @apiParam {String} name
  * @apiParam {String} [label]  An alternate short description of the asset. Used in place of the filename.
  * @apiExample {js} ex:
 github.repos.editAsset({ ... });
@@ -4471,10 +4471,10 @@ github.repos.editAsset({ ... });
  * @apiDescription Edit a hook.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
- * @apiParam {String} name  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
+ * @apiParam {String} name
  * @apiParam {Json} config  A Hash containing key/value pairs to provide settings for this hook. Modifying this will replace the entire config object. These settings vary between the services and are defined in the github-services repo. Booleans are stored internally as `1` for true, and `0` for false. Any JSON true/false values will be converted automatically.
  * @apiParam {Array} [events=["push"]]  Determines what events the hook is triggered for. This replaces the entire array of events. Default: `['push']`.
  * @apiParam {Array} [add_events]  Determines a list of events to be added to the list of events that the Hook triggers for.
@@ -4491,13 +4491,13 @@ github.repos.editHook({ ... });
  * @apiDescription Edit a release.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiParam {String} tag_name  String of the tag
  * @apiParam {String} [target_commitish]  Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch (usually master).
- * @apiParam {String} [name]  
- * @apiParam {String} [body]  
+ * @apiParam {String} [name]
+ * @apiParam {String} [body]
  * @apiParam {Boolean} [draft=false]  true to create a draft (unpublished) release, false to create a published one. Default: false
  * @apiParam {Boolean} [prerelease=false]  true to identify the release as a prerelease. false to identify the release as a full release. Default: false
  * @apiExample {js} ex:
@@ -4511,8 +4511,8 @@ github.repos.editRelease({ ... });
  * @apiDescription Create a fork.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} [organization]  Optional parameter to specify the organization name if forking into an organization.
  * @apiExample {js} ex:
 github.repos.fork({ ... });
@@ -4525,8 +4525,8 @@ github.repos.fork({ ... });
  * @apiDescription Get a repo for a user.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.repos.get({ ... });
  */
@@ -4542,7 +4542,7 @@ github.repos.get({ ... });
  * @apiParam {String} [affiliation=owner,collaborator,organization_member]  Comma-separated list of values. Can include: `owner`, `collaborator`, `organization_member`.
  * @apiParam {String=all,owner,public,private,member} [type=all]  Possible values: `all`, `owner`, `public`, `private`, `member`. Default: `all`.
  * @apiParam {String=created,updated,pushed,full_name} [sort=full_name]  Possible values: `created`, `updated`, `pushed`, `full_name`. Default: `full_name`.
- * @apiParam {String=asc,desc} [direction=desc]  
+ * @apiParam {String=asc,desc} [direction=desc]
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -4556,8 +4556,8 @@ github.repos.getAll({ ... });
  * @apiDescription List commit comments for a repository.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -4571,8 +4571,8 @@ github.repos.getAllCommitComments({ ... });
  * @apiDescription Get archive link.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String=tarball,zipball} archive_format=tarball  Either tarball or zipball, Deafult: tarball.
  * @apiParam {String} [ref]  A valid Git reference. Default: the repository’s default branch (usually master).
  * @apiExample {js} ex:
@@ -4586,9 +4586,9 @@ github.repos.getArchiveLink({ ... });
  * @apiDescription Get a single release asset.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.repos.getAsset({ ... });
  */
@@ -4600,9 +4600,9 @@ github.repos.getAsset({ ... });
  * @apiDescription List assets for a release.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.repos.getAssets({ ... });
  */
@@ -4614,9 +4614,9 @@ github.repos.getAssets({ ... });
  * @apiDescription Get branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -4630,9 +4630,9 @@ github.repos.getBranch({ ... });
  * @apiDescription Get branch protection. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -4646,8 +4646,8 @@ github.repos.getBranchProtection({ ... });
  * @apiDescription List branches. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Boolean} [protected]  Set to true to only return protected branches
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
@@ -4662,7 +4662,7 @@ github.repos.getBranches({ ... });
  * @apiDescription Get a single repo by id.
  * @apiGroup repos
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.repos.getById({ ... });
  */
@@ -4674,8 +4674,8 @@ github.repos.getById({ ... });
  * @apiDescription Get the total number of clones and breakdown per day or week for the last 14 days.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -4689,8 +4689,8 @@ github.repos.getClones({ ... });
  * @apiDescription List collaborators
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String=outside,all,direct} [affiliation=all]  Filter collaborators returned by their affiliation.
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
@@ -4705,8 +4705,8 @@ github.repos.getCollaborators({ ... });
  * @apiDescription Get the combined status for a specific ref.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} ref  Ref to fetch the status for. It can be a SHA, a branch name, or a tag name.
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
@@ -4721,9 +4721,9 @@ github.repos.getCombinedStatusForRef({ ... });
  * @apiDescription Get a single commit.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} sha  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} sha
  * @apiExample {js} ex:
 github.repos.getCommit({ ... });
  */
@@ -4735,9 +4735,9 @@ github.repos.getCommit({ ... });
  * @apiDescription Get a single commit comment.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.repos.getCommitComment({ ... });
  */
@@ -4749,9 +4749,9 @@ github.repos.getCommitComment({ ... });
  * @apiDescription List comments for a single commit.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} ref  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} ref
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -4765,8 +4765,8 @@ github.repos.getCommitComments({ ... });
  * @apiDescription List commits on a repository.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} [sha]  Sha or branch to start listing commits from.
  * @apiParam {String} [path]  Only commits containing this file path will be returned.
  * @apiParam {String} [author]  GitHub login or email address by which to filter by commit author.
@@ -4785,8 +4785,8 @@ github.repos.getCommits({ ... });
  * @apiDescription Retrieve community profile metrics.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} name  
+ * @apiParam {String} owner
+ * @apiParam {String} name
  * @apiExample {js} ex:
 github.repos.getCommunityProfileMetrics({ ... });
  */
@@ -4798,8 +4798,8 @@ github.repos.getCommunityProfileMetrics({ ... });
  * @apiDescription Get the contents of a file or directory in a repository.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} path  The content path.
  * @apiParam {String} [ref]  The String name of the Commit/Branch/Tag. Defaults to master.
  * @apiExample {js} ex:
@@ -4813,8 +4813,8 @@ github.repos.getContent({ ... });
  * @apiDescription Get contributors for the specified repository.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Boolean} [anon]  Set to 1 or true to include anonymous contributors in results.
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
@@ -4829,9 +4829,9 @@ github.repos.getContributors({ ... });
  * @apiDescription Get a deploy key.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.repos.getDeployKey({ ... });
  */
@@ -4843,8 +4843,8 @@ github.repos.getDeployKey({ ... });
  * @apiDescription List deploy keys.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -4858,8 +4858,8 @@ github.repos.getDeployKeys({ ... });
  * @apiDescription Get a single Deployment. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} deployment_id  The deployment id.
  * @apiExample {js} ex:
 github.repos.getDeployment({ ... });
@@ -4872,8 +4872,8 @@ github.repos.getDeployment({ ... });
  * @apiDescription List deployment statuses. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} id  The Deployment ID to list the statuses from.
  * @apiParam {String} status_id  The Deployment Status ID.
  * @apiExample {js} ex:
@@ -4887,9 +4887,9 @@ github.repos.getDeploymentStatus({ ... });
  * @apiDescription List deployment statuses. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.repos.getDeploymentStatuses({ ... });
  */
@@ -4901,8 +4901,8 @@ github.repos.getDeploymentStatuses({ ... });
  * @apiDescription List deployments.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} [sha=none]  The short or long sha that was recorded at creation time. Default: none.
  * @apiParam {String} [ref=none]  The name of the ref. This can be a branch, tag, or sha. Default: none.
  * @apiParam {String} [task=none]  The name of the task for the deployment. e.g. deploy or deploy:migrations. Default: none.
@@ -4920,9 +4920,9 @@ github.repos.getDeployments({ ... });
  * @apiDescription Get a single download.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.repos.getDownload({ ... });
  */
@@ -4934,8 +4934,8 @@ github.repos.getDownload({ ... });
  * @apiDescription List downloads for a repository.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -4949,7 +4949,7 @@ github.repos.getDownloads({ ... });
  * @apiDescription List repositories for the specified org.
  * @apiGroup repos
  *
- * @apiParam {String} org  
+ * @apiParam {String} org
  * @apiParam {String=all,public,private,forks,sources,member} [type=all]  Possible values: `all`, `public`, `private`, `forks`, `sources`, `member`. Default: `all`.
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
@@ -4964,10 +4964,10 @@ github.repos.getForOrg({ ... });
  * @apiDescription List public repositories for the specified user.
  * @apiGroup repos
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiParam {String=all,owner,member} [type=owner]  Possible values: `all`, `owner`, `member`. Default: `owner`.
  * @apiParam {String=created,updated,pushed,full_name} [sort=full_name]  Possible values: `created`, `updated`, `pushed`, `full_name`. Default: `full_name`.
- * @apiParam {String=asc,desc} [direction=desc]  
+ * @apiParam {String=asc,desc} [direction=desc]
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -4981,8 +4981,8 @@ github.repos.getForUser({ ... });
  * @apiDescription List forks.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String=newest,oldest,stargazers} [sort=newest]  Possible values: `newest`, `oldest`, `stargazers`, default: `newest`.
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
@@ -4997,9 +4997,9 @@ github.repos.getForks({ ... });
  * @apiDescription Get single hook.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.repos.getHook({ ... });
  */
@@ -5011,8 +5011,8 @@ github.repos.getHook({ ... });
  * @apiDescription List hooks.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5026,8 +5026,8 @@ github.repos.getHooks({ ... });
  * @apiDescription List invitations for a repository.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.repos.getInvites({ ... });
  */
@@ -5039,8 +5039,8 @@ github.repos.getInvites({ ... });
  * @apiDescription Get languages for the specified repository.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5054,8 +5054,8 @@ github.repos.getLanguages({ ... });
  * @apiDescription Get latest Pages build. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.repos.getLatestPagesBuild({ ... });
  */
@@ -5067,8 +5067,8 @@ github.repos.getLatestPagesBuild({ ... });
  * @apiDescription Get the latest release.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.repos.getLatestRelease({ ... });
  */
@@ -5080,8 +5080,8 @@ github.repos.getLatestRelease({ ... });
  * @apiDescription Get information about a Pages site. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5095,9 +5095,9 @@ github.repos.getPages({ ... });
  * @apiDescription Get a specific Pages build. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.repos.getPagesBuild({ ... });
  */
@@ -5109,8 +5109,8 @@ github.repos.getPagesBuild({ ... });
  * @apiDescription List Pages builds. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5124,8 +5124,8 @@ github.repos.getPagesBuilds({ ... });
  * @apiDescription Get the top 10 popular contents over the last 14 days.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5139,9 +5139,9 @@ github.repos.getPaths({ ... });
  * @apiDescription Get admin enforcement of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5155,9 +5155,9 @@ github.repos.getProtectedBranchAdminEnforcement({ ... });
  * @apiDescription Get pull request review enforcement of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5171,9 +5171,9 @@ github.repos.getProtectedBranchPullRequestReviewEnforcement({ ... });
  * @apiDescription Get required status checks of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5187,9 +5187,9 @@ github.repos.getProtectedBranchRequiredStatusChecks({ ... });
  * @apiDescription List required status checks contexts of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5203,9 +5203,9 @@ github.repos.getProtectedBranchRequiredStatusChecksContexts({ ... });
  * @apiDescription Get restrictions of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5219,9 +5219,9 @@ github.repos.getProtectedBranchRestrictions({ ... });
  * @apiDescription List team restrictions of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5235,9 +5235,9 @@ github.repos.getProtectedBranchTeamRestrictions({ ... });
  * @apiDescription List user restrictions of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5265,8 +5265,8 @@ github.repos.getPublic({ ... });
  * @apiDescription Get the README for the given repository.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} [ref]  The name of the commit/branch/tag. Default: the repository’s default branch (usually master)
  * @apiExample {js} ex:
 github.repos.getReadme({ ... });
@@ -5279,8 +5279,8 @@ github.repos.getReadme({ ... });
  * @apiDescription Get the top 10 referrers over the last 14 days.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5294,9 +5294,9 @@ github.repos.getReferrers({ ... });
  * @apiDescription Get a single release.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.repos.getRelease({ ... });
  */
@@ -5308,8 +5308,8 @@ github.repos.getRelease({ ... });
  * @apiDescription Get a release by tag name.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} tag  String of the tag
  * @apiExample {js} ex:
 github.repos.getReleaseByTag({ ... });
@@ -5322,8 +5322,8 @@ github.repos.getReleaseByTag({ ... });
  * @apiDescription List releases for a repository.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5337,8 +5337,8 @@ github.repos.getReleases({ ... });
  * @apiDescription Get the SHA-1 of a commit reference.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} ref  String of the name of the fully qualified reference (ie: heads/master). If it doesn’t have at least one slash, it will be rejected.
  * @apiExample {js} ex:
 github.repos.getShaOfCommitRef({ ... });
@@ -5351,8 +5351,8 @@ github.repos.getShaOfCommitRef({ ... });
  * @apiDescription Get the number of additions and deletions per week.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.repos.getStatsCodeFrequency({ ... });
  */
@@ -5364,8 +5364,8 @@ github.repos.getStatsCodeFrequency({ ... });
  * @apiDescription Get the last year of commit activity data.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.repos.getStatsCommitActivity({ ... });
  */
@@ -5377,8 +5377,8 @@ github.repos.getStatsCommitActivity({ ... });
  * @apiDescription Get contributors list with additions, deletions, and commit counts.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.repos.getStatsContributors({ ... });
  */
@@ -5390,8 +5390,8 @@ github.repos.getStatsContributors({ ... });
  * @apiDescription Get the weekly commit count for the repository owner and everyone else.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.repos.getStatsParticipation({ ... });
  */
@@ -5403,8 +5403,8 @@ github.repos.getStatsParticipation({ ... });
  * @apiDescription Get the number of commits per hour in each day.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.repos.getStatsPunchCard({ ... });
  */
@@ -5416,8 +5416,8 @@ github.repos.getStatsPunchCard({ ... });
  * @apiDescription List statuses for a specfic ref.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} ref  Ref to list the statuses from. It can be a SHA, a branch name, or a tag name.
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
@@ -5432,8 +5432,8 @@ github.repos.getStatuses({ ... });
  * @apiDescription Get tags for the specified repository.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5447,8 +5447,8 @@ github.repos.getTags({ ... });
  * @apiDescription Get teams for the specified repository.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5462,8 +5462,8 @@ github.repos.getTeams({ ... });
  * @apiDescription List all topics for a repository. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5477,8 +5477,8 @@ github.repos.getTopics({ ... });
  * @apiDescription Get the total number of views and breakdown per day or week for the last 14 days.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5492,8 +5492,8 @@ github.repos.getViews({ ... });
  * @apiDescription Perform a merge.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} base  The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo.
  * @apiParam {String} head  The branch (or git ref) where your changes are implemented.
  * @apiParam {String} [commit_message]  Commit message to use for the merge commit. If omitted, a default message will be used.
@@ -5508,9 +5508,9 @@ github.repos.merge({ ... });
  * @apiDescription Ping a hook.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.repos.pingHook({ ... });
  */
@@ -5522,9 +5522,9 @@ github.repos.pingHook({ ... });
  * @apiDescription Remove branch protection. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5538,9 +5538,9 @@ github.repos.removeBranchProtection({ ... });
  * @apiDescription Remove user as a collaborator.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} username  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.repos.removeCollaborator({ ... });
  */
@@ -5552,9 +5552,9 @@ github.repos.removeCollaborator({ ... });
  * @apiDescription Remove admin enforcement of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -5568,9 +5568,9 @@ github.repos.removeProtectedBranchAdminEnforcement({ ... });
  * @apiDescription Remove pull request review enforcement of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiExample {js} ex:
 github.repos.removeProtectedBranchPullRequestReviewEnforcement({ ... });
  */
@@ -5582,9 +5582,9 @@ github.repos.removeProtectedBranchPullRequestReviewEnforcement({ ... });
  * @apiDescription Remove required status checks of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiExample {js} ex:
 github.repos.removeProtectedBranchRequiredStatusChecks({ ... });
  */
@@ -5596,9 +5596,9 @@ github.repos.removeProtectedBranchRequiredStatusChecks({ ... });
  * @apiDescription Remove required status checks contexts of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Array} contexts  An array of protected branch required status checks contexts (e.g. continuous-integration/jenkins).
  * @apiExample {js} ex:
 github.repos.removeProtectedBranchRequiredStatusChecksContexts({ ... });
@@ -5611,9 +5611,9 @@ github.repos.removeProtectedBranchRequiredStatusChecksContexts({ ... });
  * @apiDescription Remove restrictions of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiExample {js} ex:
 github.repos.removeProtectedBranchRestrictions({ ... });
  */
@@ -5625,9 +5625,9 @@ github.repos.removeProtectedBranchRestrictions({ ... });
  * @apiDescription Remove team restrictions of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Array} teams  An array of team slugs (e.g. justice-league).
  * @apiExample {js} ex:
 github.repos.removeProtectedBranchTeamRestrictions({ ... });
@@ -5640,9 +5640,9 @@ github.repos.removeProtectedBranchTeamRestrictions({ ... });
  * @apiDescription Remove user restrictions of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Array} users  An array of team slugs (e.g. justice-league).
  * @apiExample {js} ex:
 github.repos.removeProtectedBranchUserRestrictions({ ... });
@@ -5655,9 +5655,9 @@ github.repos.removeProtectedBranchUserRestrictions({ ... });
  * @apiDescription Replace required status checks contexts of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Array} contexts  An array of protected branch required status checks contexts (e.g. continuous-integration/jenkins).
  * @apiExample {js} ex:
 github.repos.replaceProtectedBranchRequiredStatusChecksContexts({ ... });
@@ -5670,9 +5670,9 @@ github.repos.replaceProtectedBranchRequiredStatusChecksContexts({ ... });
  * @apiDescription Replace team restrictions of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Array} teams  An array of team slugs (e.g. justice-league).
  * @apiExample {js} ex:
 github.repos.replaceProtectedBranchTeamRestrictions({ ... });
@@ -5685,9 +5685,9 @@ github.repos.replaceProtectedBranchTeamRestrictions({ ... });
  * @apiDescription Replace user restrictions of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Array} users  An array of team slugs (e.g. justice-league).
  * @apiExample {js} ex:
 github.repos.replaceProtectedBranchUserRestrictions({ ... });
@@ -5700,8 +5700,8 @@ github.repos.replaceProtectedBranchUserRestrictions({ ... });
  * @apiDescription Replace all topics for a repository. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {Array} names  An array of topics to add to the repository. Pass one or more topics to replace the set of existing topics. Send an empty array ([]) to clear all topics from the repository.
  * @apiExample {js} ex:
 github.repos.replaceTopics({ ... });
@@ -5714,8 +5714,8 @@ github.repos.replaceTopics({ ... });
  * @apiDescription Request a page build. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiExample {js} ex:
 github.repos.requestPageBuild({ ... });
  */
@@ -5727,9 +5727,9 @@ github.repos.requestPageBuild({ ... });
  * @apiDescription Review a user's permission level.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} username  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.repos.reviewUserPermissionLevel({ ... });
  */
@@ -5741,9 +5741,9 @@ github.repos.reviewUserPermissionLevel({ ... });
  * @apiDescription Test a [push] hook.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.repos.testHook({ ... });
  */
@@ -5755,9 +5755,9 @@ github.repos.testHook({ ... });
  * @apiDescription Update branch protection. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Json} required_status_checks  JSON object that contains the following keys: `include_admins` - Enforce required status checks for repository administrators, `strict` - Require branches to be up to date before merging, `contexts` - The list of status checks to require in order to merge into this branch. This object can have the value of `null` for disabled.
  * @apiParam {Json} restrictions  JSON object that contains the following keys: `users` - The list of user logins with push access, `teams` - The list of team slugs with push access. This object can have the value of `null` for disabled.
  * @apiParam {Boolean} enforce_admins  Enforces required status checks for repository administrators.
@@ -5776,10 +5776,10 @@ github.repos.updateBranchProtection({ ... });
  * @apiDescription Update a commit comment.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
- * @apiParam {String} body  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
+ * @apiParam {String} body
  * @apiExample {js} ex:
 github.repos.updateCommitComment({ ... });
  */
@@ -5791,15 +5791,15 @@ github.repos.updateCommitComment({ ... });
  * @apiDescription Update a file.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
  * @apiParam {String} path  The content path.
  * @apiParam {String} message  The commit message.
  * @apiParam {String} content  The updated file content, Base64 encoded.
  * @apiParam {String} sha  The blob SHA of the file being replaced.
  * @apiParam {String} [branch]  The branch name. If not provided, uses the repository’s default branch (usually master).
- * @apiParam {Json} [committer]  
- * @apiParam {Json} [author]  
+ * @apiParam {Json} [committer]
+ * @apiParam {Json} [author]
  * @apiExample {js} ex:
 github.repos.updateFile({ ... });
  */
@@ -5811,9 +5811,9 @@ github.repos.updateFile({ ... });
  * @apiDescription Update a repository invitation.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} invitation_id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} invitation_id
  * @apiParam {String=read,write,admin} [permissions]  The permissions that the associated user will have on the repository.
  * @apiExample {js} ex:
 github.repos.updateInvite({ ... });
@@ -5826,9 +5826,9 @@ github.repos.updateInvite({ ... });
  * @apiDescription Update pull request review enforcement of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Json} [dismissal_restrictions]  JSON object that contains the following keys: `users` - The list of user logins with dismissal access, `teams` - The list of team slugs with dismissal access. This object can have the value of `null` for disabled.
  * @apiParam {Boolean} [dismiss_stale_reviews]  Dismiss approved reviews automatically when a new commit is pushed.
  * @apiParam {Boolean} [require_code_owner_reviews]  Blocks merge until code owners have reviewed.
@@ -5843,9 +5843,9 @@ github.repos.updateProtectedBranchPullRequestReviewEnforcement({ ... });
  * @apiDescription Update required status checks of protected branch. (In preview period. See README.)
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} branch  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} branch
  * @apiParam {Boolean} [strict]  Require branches to be up to date before merging.
  * @apiParam {Array} [contexts]  The list of status checks to require in order to merge into this branch.
  * @apiExample {js} ex:
@@ -5859,9 +5859,9 @@ github.repos.updateProtectedBranchRequiredStatusChecks({ ... });
  * @apiDescription Upload a release asset.
  * @apiGroup repos
  *
- * @apiParam {String} owner  
- * @apiParam {String} repo  
- * @apiParam {String} id  
+ * @apiParam {String} owner
+ * @apiParam {String} repo
+ * @apiParam {String} id
  * @apiParam {String} filePath  The file path of the asset.
  * @apiParam {String} name  The file name of the asset. This should be set in a URI query parameter.
  * @apiParam {String} [label]  An alternate short description of the asset. Used in place of the filename. This should be set in a URI query parameter.
@@ -5968,7 +5968,7 @@ github.search.users({ ... });
  * @apiDescription Accept a repository invitation.
  * @apiGroup users
  *
- * @apiParam {String} invitation_id  
+ * @apiParam {String} invitation_id
  * @apiExample {js} ex:
 github.users.acceptRepoInvite({ ... });
  */
@@ -5992,8 +5992,8 @@ github.users.addEmails({ ... });
  * @apiDescription Add a single repository to an installation. (In preview period. See README.)
  * @apiGroup users
  *
- * @apiParam {String} installation_id  
- * @apiParam {String} repository_id  
+ * @apiParam {String} installation_id
+ * @apiParam {String} repository_id
  * @apiExample {js} ex:
 github.users.addRepoToInstallation({ ... });
  */
@@ -6005,7 +6005,7 @@ github.users.addRepoToInstallation({ ... });
  * @apiDescription Block a user. (In preview period. See README.)
  * @apiGroup users
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.users.blockUser({ ... });
  */
@@ -6017,7 +6017,7 @@ github.users.blockUser({ ... });
  * @apiDescription Check whether you've blocked a user. (In preview period. See README.)
  * @apiGroup users
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.users.checkBlockedUser({ ... });
  */
@@ -6029,7 +6029,7 @@ github.users.checkBlockedUser({ ... });
  * @apiDescription Check if you are following a user
  * @apiGroup users
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.users.checkFollowing({ ... });
  */
@@ -6041,8 +6041,8 @@ github.users.checkFollowing({ ... });
  * @apiDescription Check if one user follows another
  * @apiGroup users
  *
- * @apiParam {String} username  
- * @apiParam {String} target_user  
+ * @apiParam {String} username
+ * @apiParam {String} target_user
  * @apiExample {js} ex:
 github.users.checkIfOneFollowersOther({ ... });
  */
@@ -6066,8 +6066,8 @@ github.users.createGpgKey({ ... });
  * @apiDescription Create a public key
  * @apiGroup users
  *
- * @apiParam {String} title  
- * @apiParam {String} key  
+ * @apiParam {String} title
+ * @apiParam {String} key
  * @apiExample {js} ex:
 github.users.createKey({ ... });
  */
@@ -6079,7 +6079,7 @@ github.users.createKey({ ... });
  * @apiDescription Decline a repository invitation.
  * @apiGroup users
  *
- * @apiParam {String} invitation_id  
+ * @apiParam {String} invitation_id
  * @apiExample {js} ex:
 github.users.declineRepoInvite({ ... });
  */
@@ -6103,7 +6103,7 @@ github.users.deleteEmails({ ... });
  * @apiDescription Delete a GPG key. (In preview period. See README.)
  * @apiGroup users
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.users.deleteGpgKey({ ... });
  */
@@ -6115,7 +6115,7 @@ github.users.deleteGpgKey({ ... });
  * @apiDescription Delete a public key
  * @apiGroup users
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.users.deleteKey({ ... });
  */
@@ -6127,7 +6127,7 @@ github.users.deleteKey({ ... });
  * @apiDescription Demote a site administrator to an ordinary user
  * @apiGroup users
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.users.demote({ ... });
  */
@@ -6139,7 +6139,7 @@ github.users.demote({ ... });
  * @apiDescription Edit your organization membership.
  * @apiGroup users
  *
- * @apiParam {String} org  
+ * @apiParam {String} org
  * @apiParam {String=active} state  The state that the membership should be in. Only "active" will be accepted.
  * @apiExample {js} ex:
 github.users.editOrgMembership({ ... });
@@ -6152,7 +6152,7 @@ github.users.editOrgMembership({ ... });
  * @apiDescription Follow a user
  * @apiGroup users
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.users.followUser({ ... });
  */
@@ -6198,7 +6198,7 @@ github.users.getBlockedUsers({ ... });
  * @apiDescription Get a single user by GitHub ID
  * @apiGroup users
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.users.getById({ ... });
  */
@@ -6236,7 +6236,7 @@ github.users.getFollowers({ ... });
  * @apiDescription List a user's followers
  * @apiGroup users
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -6263,7 +6263,7 @@ github.users.getFollowing({ ... });
  * @apiDescription List who a user is following
  * @apiGroup users
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -6277,7 +6277,7 @@ github.users.getFollowingForUser({ ... });
  * @apiDescription Get a single user
  * @apiGroup users
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.users.getForUser({ ... });
  */
@@ -6289,7 +6289,7 @@ github.users.getForUser({ ... });
  * @apiDescription Get a single GPG key. (In preview period. See README.)
  * @apiGroup users
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.users.getGpgKey({ ... });
  */
@@ -6314,7 +6314,7 @@ github.users.getGpgKeys({ ... });
  * @apiDescription Lists the GPG keys for a user. This information is accessible by anyone. (In preview period. See README.)
  * @apiGroup users
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -6328,7 +6328,7 @@ github.users.getGpgKeysForUser({ ... });
  * @apiDescription List repositories accessible to the user for an installation. (In preview period. See README.)
  * @apiGroup users
  *
- * @apiParam {String} installation_id  
+ * @apiParam {String} installation_id
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -6355,7 +6355,7 @@ github.users.getInstallations({ ... });
  * @apiDescription Get a single public key
  * @apiGroup users
  *
- * @apiParam {String} id  
+ * @apiParam {String} id
  * @apiExample {js} ex:
 github.users.getKey({ ... });
  */
@@ -6380,7 +6380,7 @@ github.users.getKeys({ ... });
  * @apiDescription List public keys for a user
  * @apiGroup users
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiParam {Number} [page]  Page number of the results to fetch.
  * @apiParam {Number} [per_page=30]  A custom page size up to 100. Default is 30.
  * @apiExample {js} ex:
@@ -6420,7 +6420,7 @@ github.users.getMarketplaceStubbedPurchases({ ... });
  * @apiDescription Get your organization membership
  * @apiGroup users
  *
- * @apiParam {String} org  
+ * @apiParam {String} org
  * @apiExample {js} ex:
 github.users.getOrgMembership({ ... });
  */
@@ -6494,7 +6494,7 @@ github.users.getTeams({ ... });
  * @apiDescription Promote an ordinary user to a site administrator
  * @apiGroup users
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.users.promote({ ... });
  */
@@ -6506,8 +6506,8 @@ github.users.promote({ ... });
  * @apiDescription Remove a single repository from an installation. (In preview period. See README.)
  * @apiGroup users
  *
- * @apiParam {String} installation_id  
- * @apiParam {String} repository_id  
+ * @apiParam {String} installation_id
+ * @apiParam {String} repository_id
  * @apiExample {js} ex:
 github.users.removeRepoFromInstallation({ ... });
  */
@@ -6519,7 +6519,7 @@ github.users.removeRepoFromInstallation({ ... });
  * @apiDescription Suspend a user
  * @apiGroup users
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.users.suspend({ ... });
  */
@@ -6542,7 +6542,7 @@ github.users.togglePrimaryEmailVisibility({ ... });
  * @apiDescription Unblock a user. (In preview period. See README.)
  * @apiGroup users
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.users.unblockUser({ ... });
  */
@@ -6554,7 +6554,7 @@ github.users.unblockUser({ ... });
  * @apiDescription Unfollow a user
  * @apiGroup users
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.users.unfollowUser({ ... });
  */
@@ -6566,7 +6566,7 @@ github.users.unfollowUser({ ... });
  * @apiDescription Unsuspend a user
  * @apiGroup users
  *
- * @apiParam {String} username  
+ * @apiParam {String} username
  * @apiExample {js} ex:
 github.users.unsuspend({ ... });
  */
@@ -6588,4 +6588,3 @@ github.users.unsuspend({ ... });
  * @apiExample {js} ex:
 github.users.update({ ... });
  */
-

--- a/examples/addCollaborator.js
+++ b/examples/addCollaborator.js
@@ -1,21 +1,21 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.repos.addCollaborator({
-    owner: "brassafrax", // needs to be an org
-    repo: "test",
-    username: "first9890"
-}, function(err, res) {
-    console.log(err, res);
-});
+  owner: 'brassafrax', // needs to be an org
+  repo: 'test',
+  username: 'first9890'
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/addLabelsToIssue.js
+++ b/examples/addLabelsToIssue.js
@@ -1,22 +1,22 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.issues.addLabels({
-    owner: "kaizensoze",
-    repo: "test2",
-    number: "4",
-    labels: ["bug", "help wanted", "question"]
-}, function(err, res) {
-    console.log(err, res);
-});
+  owner: 'kaizensoze',
+  repo: 'test2',
+  number: '4',
+  labels: ['bug', 'help wanted', 'question']
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/createFile.js
+++ b/examples/createFile.js
@@ -1,23 +1,23 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.repos.createFile({
-    owner: "kaizensoze",
-    repo: "misc-scripts",
-    path: "blah.txt",
-    message: "blah blah",
-    content: "YmxlZXAgYmxvb3A="
-}, function(err, res) {
-    console.log(err, res);
-});
+  owner: 'kaizensoze',
+  repo: 'misc-scripts',
+  path: 'blah.txt',
+  message: 'blah blah',
+  content: 'YmxlZXAgYmxvb3A='
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/createStatus.js
+++ b/examples/createStatus.js
@@ -1,22 +1,22 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.repos.createStatus({
-    owner: "kaizensoze",
-    repo: "test2",
-    sha: "81c559e2e8551982235bc86594cd86ffb135b053",
-    state: "success",
-}, function(err, res) {
-    console.log(err, res);
-});
+  owner: 'kaizensoze',
+  repo: 'test2',
+  sha: '81c559e2e8551982235bc86594cd86ffb135b053',
+  state: 'success'
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/enterpriseUploadAsset.js
+++ b/examples/enterpriseUploadAsset.js
@@ -1,25 +1,25 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true,
-    host: "github.my-GHE-enabled-company.com",
-    pathPrefix: "/api/v3"
-});
+  debug: true,
+  host: 'github.my-GHE-enabled-company.com',
+  pathPrefix: '/api/v3'
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.repos.uploadAsset({
-    owner: "kaizensoze",
-    repo: "test2",
-    id: "4801082",
-    filePath: "/Users/joegallo/z.sh",
-    name: "z.sh"
-}, function(err, res) {
-    console.log(err, res);
-});
+  owner: 'kaizensoze',
+  repo: 'test2',
+  id: '4801082',
+  filePath: '/Users/joegallo/z.sh',
+  name: 'z.sh'
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/getContent.js
+++ b/examples/getContent.js
@@ -1,15 +1,15 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
+var Client = require('./../lib/index')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.repos.getContent({
-    owner: "mikedeboer",
-    repo: "node-github",
-    path: ""
-}, function(err, res) {
-    console.log(err, res);
-});
+  owner: 'mikedeboer',
+  repo: 'node-github',
+  path: ''
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/getFollowers.js
+++ b/examples/getFollowers.js
@@ -1,18 +1,18 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.users.getFollowers({
-}, function(err, res) {
-    console.log(err, res);
-});
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/getFollowing.js
+++ b/examples/getFollowing.js
@@ -1,18 +1,18 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.users.getFollowing({
-}, function(err, res) {
-    console.log(err, res);
-});
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/getIssuesForRepo.js
+++ b/examples/getIssuesForRepo.js
@@ -1,24 +1,24 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: false
-});
+  debug: false
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.issues.getForRepo({
-    owner: "mikedeboer",
-    repo: "node-github"
-}, function(err, res) {
-    if (err) {
-        console.log(err.toJSON());
-    } else {
-        console.log(res);
-    }
-});
+  owner: 'mikedeboer',
+  repo: 'node-github'
+}, function (err, res) {
+  if (err) {
+    console.log(err.toJSON())
+  } else {
+    console.log(res)
+  }
+})

--- a/examples/getNextPage.js
+++ b/examples/getNextPage.js
@@ -1,24 +1,26 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
-var github = new Client({});
+var github = new Client({})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.repos.getAll({
-    "affiliation": "owner,organization_member"
-}, function(err, res) {
-    if (github.hasNextPage(res)) {
-        console.log(res.data.length)
-        github.getNextPage(res, nextFunc)
-    }
-});
+  'affiliation': 'owner,organization_member'
+}, function (err, res) {
+  if (err) throw err
+  if (github.hasNextPage(res)) {
+    console.log(res.data.length)
+    github.getNextPage(res, nextFunc)
+  }
+})
 
-function nextFunc(err, res) {
-    console.log(res.data.length);
+function nextFunc (err, res) {
+  if (err) throw err
+  console.log(res.data.length)
 }

--- a/examples/getOrg.js
+++ b/examples/getOrg.js
@@ -1,19 +1,19 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.orgs.get({
-    org: "facebook"
-}, function(err, res) {
-    console.log(err, res);
-});
+  org: 'facebook'
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/getOrgPublicMembers.js
+++ b/examples/getOrgPublicMembers.js
@@ -1,19 +1,19 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.orgs.getPublicMembers({
-    org: "square"
-}, function(err, res) {
-    console.log(err, res);
-});
+  org: 'square'
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/getOutsideCollaborators.js
+++ b/examples/getOutsideCollaborators.js
@@ -1,19 +1,19 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.orgs.getOutsideCollaborators({
-    org: "facebook"
-}, function(err, res) {
-    console.log(err, res);
-});
+  org: 'facebook'
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/getPullRequestReview.js
+++ b/examples/getPullRequestReview.js
@@ -1,32 +1,32 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.pullRequests.getReviews({
-    owner: "brassafrax",
-    repo: "test",
-    number: 1
-}, function(err, res) {
-    // console.log(err, res);
-    
-    var reviewId = res[0]['id'];
-    // console.log(reviewId);
-    github.pullRequests.getReview({
-        owner: "brassafrax",
-        repo: "test",
-        number: 1,
-        id: reviewId
-    }, function(err, res) {
-        console.log(err, res);
-    });
-});
+  owner: 'brassafrax',
+  repo: 'test',
+  number: 1
+}, function (err, res) {
+  if (err) throw err
+
+  var reviewId = res[0]['id']
+  github.pullRequests.getReview({
+    owner: 'brassafrax',
+    repo: 'test',
+    number: 1,
+    id: reviewId
+  }, function (err, res) {
+    if (err) throw err
+    console.log(res)
+  })
+})

--- a/examples/getPullRequestReviews.js
+++ b/examples/getPullRequestReviews.js
@@ -1,21 +1,21 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.pullRequests.getReviews({
-    owner: "brassafrax",
-    repo: "test",
-    number: 1
-}, function(err, res) {
-    console.log(err, res);
-});
+  owner: 'brassafrax',
+  repo: 'test',
+  number: 1
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/getRawBlob.js
+++ b/examples/getRawBlob.js
@@ -1,19 +1,19 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: false,
-    headers: {
-        "Accept": "application/vnd.github.v3.raw"
-    }
-});
+  debug: false,
+  headers: {
+    'Accept': 'application/vnd.github.v3.raw'
+  }
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 // github.repos.getContent({
 //     owner: "mikedeboer",
@@ -25,9 +25,9 @@ github.authenticate({
 // });
 
 github.gitdata.getBlob({
-    owner: "mikedeboer",
-    repo: "node-github",
-    sha: "b361f529df9b49f2a6b5748b5d71b792c8383e5e"
-}, function(err, res) {
-    console.log(err, res['data']);
-});
+  owner: 'mikedeboer',
+  repo: 'node-github',
+  sha: 'b361f529df9b49f2a6b5748b5d71b792c8383e5e'
+}, function (err, res) {
+  console.log(err, res['data'])
+})

--- a/examples/getReactionsForIssue.js
+++ b/examples/getReactionsForIssue.js
@@ -1,21 +1,21 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.reactions.getForIssue({
-    owner: "mikedeboer",
-    repo: "node-github",
-    number: "365"
-}, function(err, res) {
-    console.log(err, res);
-});
+  owner: 'mikedeboer',
+  repo: 'node-github',
+  number: '365'
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/getReference.js
+++ b/examples/getReference.js
@@ -1,21 +1,21 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.gitdata.getReference({
-    owner: "kaizensoze",
-    repo: "test2",
-    ref: "heads/a#blah"
-}, function(err, res) {
-    console.log(err, res);
-});
+  owner: 'kaizensoze',
+  repo: 'test2',
+  ref: 'heads/a#blah'
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/getReferences.js
+++ b/examples/getReferences.js
@@ -1,20 +1,20 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.gitdata.getReferences({
-    owner: "mikedeboer",
-    repo: "node-github"
-}, function(err, res) {
-    console.log(err, res);
-});
+  owner: 'mikedeboer',
+  repo: 'node-github'
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/getReleaseAsset.js
+++ b/examples/getReleaseAsset.js
@@ -1,56 +1,59 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 var testRepo = {
-    owner: "aktau",
-    repo: "github-release"
-};
+  owner: 'aktau',
+  repo: 'github-release'
+}
 
 github.repos.getReleases({
+  owner: testRepo.owner,
+  repo: testRepo.repo
+}, function (err, res) {
+  if (err) throw err
+  var releases = res.data
+  if (releases.length === 0) {
+    return
+  }
+  var release = releases[0]
+  var releaseId = release.id
+  console.log(release)
+
+  github.repos.getAssets({
     owner: testRepo.owner,
-    repo: testRepo.repo
-}, function(err, res) {
-    var releases = res.data;
-    if (releases.length == 0) {
-        return;
+    repo: testRepo.repo,
+    id: releaseId
+  }, function (err, res) {
+    if (err) throw err
+    var assets = res.data
+    if (assets.length === 0) {
+      return
     }
-    var release = releases[0];
-    var releaseId = release.id;
-    console.log(release);
-    
-    github.repos.getAssets({
-        owner: testRepo.owner,
-        repo: testRepo.repo,
-        id: releaseId
-    }, function(err, res) {
-        var assets = res.data;
-        if (assets.length == 0) {
-            return;
-        }
-        var asset = assets[0];
-        var assetId = asset.id;
-        console.log(asset);
-        
-        github.repos.getAsset({
-            owner: testRepo.owner,
-            repo: testRepo.repo,
-            id: assetId,
-            // headers: {
-            //     "Accept": "application/octet-stream"
-            // }
-        }, function(err, res) {
-            console.log(res);
-        });
-    });
-});
+    var asset = assets[0]
+    var assetId = asset.id
+    console.log(asset)
+
+    github.repos.getAsset({
+      owner: testRepo.owner,
+      repo: testRepo.repo,
+      id: assetId
+      // headers: {
+      //     "Accept": "application/octet-stream"
+      // }
+    }, function (err, res) {
+      if (err) throw err
+      console.log(res)
+    })
+  })
+})

--- a/examples/getRepos.js
+++ b/examples/getRepos.js
@@ -1,19 +1,19 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.repos.getAll({
-    "affiliation": "owner,organization_member"
-}, function(err, res) {
-    console.log(err, res);
-});
+  'affiliation': 'owner,organization_member'
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/getStarred.js
+++ b/examples/getStarred.js
@@ -1,32 +1,32 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
-var github = new Client({});
+var github = new Client({})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
-var starredRepos = [];
+var starredRepos = []
 
-var req = github.activity.getStarredRepos({ per_page: 100}, getRepos);
-function getRepos(err, res) {
-    if (err) {
-        return false;
-    }
+github.activity.getStarredRepos({per_page: 100}, getRepos)
+function getRepos (err, res) {
+  if (err) {
+    return false
+  }
 
-    starredRepos = starredRepos.concat(res['data']);
-    if (github.hasNextPage(res)) {
-        github.getNextPage(res, getRepos)
-    } else {
-        outputStarredRepos();
-    }
+  starredRepos = starredRepos.concat(res['data'])
+  if (github.hasNextPage(res)) {
+    github.getNextPage(res, getRepos)
+  } else {
+    outputStarredRepos()
+  }
 }
 
-function outputStarredRepos() {
-    console.log(starredRepos.map(function(repo) { return repo['full_name']; }));
-    console.log('starred repos: ' + starredRepos.length);
+function outputStarredRepos () {
+  console.log(starredRepos.map(function (repo) { return repo['full_name'] }))
+  console.log('starred repos: ' + starredRepos.length)
 }

--- a/examples/getTimeline.js
+++ b/examples/getTimeline.js
@@ -1,21 +1,21 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.issues.getEventsTimeline({
-    owner: "mikedeboer",
-    repo: "node-github",
-    issue_number: "447"
-}, function(err, res) {
-    console.log(err, res);
-});
+  owner: 'mikedeboer',
+  repo: 'node-github',
+  issue_number: '447'
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/getUser.js
+++ b/examples/getUser.js
@@ -1,17 +1,17 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
-github.users.get({}, function(err, res) {
-    console.log(err, res);
-});
+github.users.get({}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/getUserById.js
+++ b/examples/getUserById.js
@@ -1,17 +1,17 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
-github.users.getById({ id: "429706" }, function(err, res) {
-    console.log(err, res);
-});
+github.users.getById({ id: '429706' }, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/getUserOrgs.js
+++ b/examples/getUserOrgs.js
@@ -1,26 +1,13 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
-
+var Client = require('./../lib/index')
 var github = new Client({
-    debug: true
-});
-
-// github.authenticate({
-//     type: "oauth",
-//     token: testAuth["token"]
-// });
-// 
-// github.users.getOrgs({
-//     per_page: 100
-// }, function(err, res) {
-//     console.log(err, res);
-// });
+  debug: true
+})
 
 github.orgs.getForUser({
-    username: "tj",
-    per_page: 100
-}, function(err, res) {
-    console.log(err, res);
-});
+  username: 'tj',
+  per_page: 100
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/instantiateMultipleInstances.js
+++ b/examples/instantiateMultipleInstances.js
@@ -1,6 +1,6 @@
-"use strict";
+'use strict'
 
-var Github = require("./../lib/index");
+var Github = require('./../lib/index')
 
-var g1 = new Github();
-var g2 = new Github();
+var g1 = new Github() // eslint-disable-line
+var g2 = new Github() // eslint-disable-line

--- a/examples/listOrgs.js
+++ b/examples/listOrgs.js
@@ -1,20 +1,20 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.orgs.getAll({
-    page: 5,
-    per_page: 100
-}, function(err, res) {
-    console.log(err, res);
-});
+  page: 5,
+  per_page: 100
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/lockIssue.js
+++ b/examples/lockIssue.js
@@ -1,21 +1,21 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.issues.lock({
-    owner: "kaizensoze",
-    repo: "test2",
-    number: 3
-}, function(err, res) {
-    console.log(err, res);
-});
+  owner: 'kaizensoze',
+  repo: 'test2',
+  number: 3
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/netrcAuth.js
+++ b/examples/netrcAuth.js
@@ -1,18 +1,15 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
-
+var Client = require('./../lib/index')
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "netrc"
-});
+  type: 'netrc'
+})
 
 github.repos.getAll({
-}, function(err, res) {
-    console.log(err, res);
-});
-
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/paginationCustomHeaders.js
+++ b/examples/paginationCustomHeaders.js
@@ -1,42 +1,44 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 var customHeaders = {
-    "User-Agent": "blah"
-};
+  'User-Agent': 'blah'
+}
 
 github.issues.getForRepo({
-    owner: "mikedeboer",
-    repo: "node-github",
-    headers: customHeaders
-}, function(err, res) {
-    showIssueIds(res);
-    console.log('END of PAGE 1');
-    
-    if (github.hasNextPage(res)) {
-        github.getNextPage(res, customHeaders, function(err, res) {
-            showIssueIds(res);
-        });
-    }
-});
+  owner: 'mikedeboer',
+  repo: 'node-github',
+  headers: customHeaders
+}, function (err, res) {
+  if (err) throw err
+  showIssueIds(res)
+  console.log('END of PAGE 1')
 
-function showIssueIds(res) {
-    for (var i = 0; i <= res.length; i++) {
-        if (typeof res[i] !== 'undefined') {
-            var url = res[i].url;
-            var issueId = url.substr(url.lastIndexOf('/') + 1);
-            console.log(issueId);
-        }
+  if (github.hasNextPage(res)) {
+    github.getNextPage(res, customHeaders, function (err, res) {
+      if (err) throw err
+      showIssueIds(res)
+    })
+  }
+})
+
+function showIssueIds (res) {
+  for (var i = 0; i <= res.length; i++) {
+    if (typeof res[i] !== 'undefined') {
+      var url = res[i].url
+      var issueId = url.substr(url.lastIndexOf('/') + 1)
+      console.log(issueId)
     }
+  }
 }

--- a/examples/removeAssigneesFromIssue.js
+++ b/examples/removeAssigneesFromIssue.js
@@ -1,22 +1,22 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.issues.removeAssigneesFromIssue({
-    owner: "kaizensoze",
-    repo: "test2",
-    number: "4",
-    body: { "assignees": ["first9890"] }
-}, function(err, res) {
-    console.log(err, res);
-});
+  owner: 'kaizensoze',
+  repo: 'test2',
+  number: '4',
+  body: { 'assignees': ['first9890'] }
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/renderMarkdown.js
+++ b/examples/renderMarkdown.js
@@ -1,19 +1,19 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: false
-});
+  debug: false
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.misc.renderMarkdown({
-    "text": "Hello world github/linguist#1 **cool**, and #1!"
-}, function(err, res) {
-    console.log(err, res["data"]);
-});
+  'text': 'Hello world github/linguist#1 **cool**, and #1!'
+}, function (err, res) {
+  console.log(err, res['data'])
+})

--- a/examples/reopenClosedIssue.js
+++ b/examples/reopenClosedIssue.js
@@ -1,22 +1,22 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.issues.edit({
-    owner: "kaizensoze",
-    repo: "test2",
-    number: 2,
-    state: "open"
-}, function(err, res) {
-    console.log(err, res);
-});
+  owner: 'kaizensoze',
+  repo: 'test2',
+  number: 2,
+  state: 'open'
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/searchIssues.js
+++ b/examples/searchIssues.js
@@ -1,19 +1,19 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.search.issues({
-    q: "bazinga"
-}, function(err, res) {
-    console.log(err, res);
-});
+  q: 'bazinga'
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/searchMostStarredRepos.js
+++ b/examples/searchMostStarredRepos.js
@@ -1,26 +1,27 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
     // debug: true
-});
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.search.repos({
-    q: "stars:>=20000",
-    sort: "stars",
-    order: "desc"
-}, function(err, res) {
-    for (var itemKey in res['items']) {
-        var item = res['items'][itemKey];
-        var url = item['html_url'];
-        var star_count = item['stargazers_count'];
-        console.log(url + " (" + star_count + ")");
-    }
-});
+  q: 'stars:>=20000',
+  sort: 'stars',
+  order: 'desc'
+}, function (err, res) {
+  if (err) throw err
+  for (var itemKey in res['items']) {
+    var item = res['items'][itemKey]
+    var url = item['html_url']
+    var starCount = item['stargazers_count']
+    console.log(url + ' (' + starCount + ')')
+  }
+})

--- a/examples/testPromise.js
+++ b/examples/testPromise.js
@@ -1,19 +1,19 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var Promise = require("bluebird");  // npm install bluebird
+var Client = require('./../lib/index')
+var Promise = require('bluebird')  // npm install bluebird
 
 var github = new Client({
-    debug: false,
-    Promise: Promise
-});
+  debug: false,
+  Promise: Promise
+})
 
 github.orgs.getAll({
-    page: 5,
-    per_page: 100
-}).then(function(res) {
-    console.log(res);
-    return github.users.getById({ id: "429706" });
-}).then(function(res) {
-   console.log(res);
-});
+  page: 5,
+  per_page: 100
+}).then(function (res) {
+  console.log(res)
+  return github.users.getById({ id: '429706' })
+}).then(function (res) {
+  console.log(res)
+})

--- a/examples/testPromiseGetNextPage.js
+++ b/examples/testPromiseGetNextPage.js
@@ -1,26 +1,26 @@
-var Client = require("./../lib/index");
+var Client = require('./../lib/index')
 
 var gh = new Client({
   Promise: require('bluebird')
-});
+})
 
-function getAllOrgRepos(orgName) {
-  var repos = [];
+function getAllOrgRepos (orgName) {
+  var repos = []
 
-  function pager(res) {
-    repos = repos.concat(res);
+  function pager (res) {
+    repos = repos.concat(res)
     if (gh.hasNextPage(res)) {
       return gh.getNextPage(res)
-        .then(pager);
+        .then(pager)
     }
-    return repos;
+    return repos
   }
 
   return gh.repos.getForOrg({ org: orgName })
-    .then(pager);
+    .then(pager)
 }
 
 getAllOrgRepos('organization')
-  .then(function(orgRepos) {
-    console.log(orgRepos);
-  });
+  .then(function (orgRepos) {
+    console.log(orgRepos)
+  })

--- a/examples/testPromiseQ.js
+++ b/examples/testPromiseQ.js
@@ -1,13 +1,13 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var Q = require("q");  // npm install q
+var Client = require('./../lib/index')
+var Q = require('q')  // npm install q
 
 var github = new Client({
-    debug: false,
-    Promise: Q.Promise
-});
+  debug: false,
+  Promise: Q.Promise
+})
 
-github.users.getById({ id: '5057219' }).then(function(res) {
-    console.log(res);
-});
+github.users.getById({ id: '5057219' }).then(function (res) {
+  console.log(res)
+})

--- a/examples/updateBranchProtection.js
+++ b/examples/updateBranchProtection.js
@@ -1,23 +1,23 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.repos.updateBranchProtection({
-    owner: "kaizensoze",
-    repo: "test2",
-    branch: "a",
-    required_status_checks: null,
-    restrictions: null
-}, function(err, res) {
-    console.log(err, res);
-});
+  owner: 'kaizensoze',
+  repo: 'test2',
+  branch: 'a',
+  required_status_checks: null,
+  restrictions: null
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/updateLabel.js
+++ b/examples/updateLabel.js
@@ -1,23 +1,23 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.issues.updateLabel({
-    owner: "kaizensoze",
-    repo: "test2",
-    oldname: "labelA",
-    name: "labelB",
-    color: "0052cc"
-}, function(err, res) {
-    console.log(err, res);
-});
+  owner: 'kaizensoze',
+  repo: 'test2',
+  oldname: 'labelA',
+  name: 'labelB',
+  color: '0052cc'
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/examples/updateReference.js
+++ b/examples/updateReference.js
@@ -1,23 +1,23 @@
-"use strict";
+'use strict'
 
-var Client = require("./../lib/index");
-var testAuth = require("./../testAuth.json");
+var Client = require('./../lib/index')
+var testAuth = require('./../testAuth.json')
 
 var github = new Client({
-    debug: true
-});
+  debug: true
+})
 
 github.authenticate({
-    type: "oauth",
-    token: testAuth["token"]
-});
+  type: 'oauth',
+  token: testAuth['token']
+})
 
 github.gitdata.updateReference({
-    owner: "kaizensoze",
-    repo: "test2",
-    ref: "heads/master",
-    sha: "81c559e2e8551982235bc86594cd86ffb135b053",
+  owner: 'kaizensoze',
+  repo: 'test2',
+  ref: 'heads/master',
+  sha: '81c559e2e8551982235bc86594cd86ffb135b053'
     // force: true
-}, function(err, res) {
-    console.log(err, res);
-});
+}, function (err, res) {
+  console.log(err, res)
+})

--- a/lib/error.js
+++ b/lib/error.js
@@ -9,112 +9,109 @@
  *  Author: Mike de Boer <mike@c9.io>
  **/
 
-var Util = require("util");
+var Util = require('util')
 
-exports.HttpError = function(message, code, headers) {
-    Error.call(this, message);
-    //Error.captureStackTrace(this, arguments.callee);
-    this.message = message;
-    this.code = code;
-    this.status = statusCodes[code];
-    this.headers = headers;
-};
+exports.HttpError = function (message, code, headers) {
+  Error.call(this, message)
+    // Error.captureStackTrace(this, arguments.callee);
+  this.message = message
+  this.code = code
+  this.status = statusCodes[code]
+  this.headers = headers
+}
 Util.inherits(exports.HttpError, Error);
 
-(function() {
+(function () {
     /**
      *  HttpError#toString() -> String
      *
      *  Returns the stringified version of the error (i.e. the message).
      **/
-    this.toString = function() {
-        return this.message;
-    };
+  this.toString = function () {
+    return this.message
+  }
 
     /**
      *  HttpError#toJSON() -> Object
      *
      *  Returns a JSON object representation of the error.
      **/
-    this.toJSON = function() {
-        return {
-            code: this.code,
-            status: this.status,
-            message: this.message
-        };
-    };
-
-}).call(exports.HttpError.prototype);
-
+  this.toJSON = function () {
+    return {
+      code: this.code,
+      status: this.status,
+      message: this.message
+    }
+  }
+}).call(exports.HttpError.prototype)
 
 var statusCodes = {
-    400: "Bad Request",
-    401: "Unauthorized",
-    402: "Payment Required",
-    403: "Forbidden",
-    404: "Not Found",
-    405: "Method Not Allowed",
-    406: "Not Acceptable",
-    407: "Proxy Authentication Required",
-    408: "Request Timeout",
-    409: "Conflict",
-    410: "Gone",
-    411: "Length Required",
-    412: "Precondition Failed",
-    413: "Request Entity Too Large",
-    414: "Request-URI Too Long",
-    415: "Unsupported Media Type",
-    416: "Requested Range Not Satisfiable",
-    417: "Expectation Failed",
-    420: "Enhance Your Calm",
-    422: "Unprocessable Entity",
-    423: "Locked",
-    424: "Failed Dependency",
-    425: "Unordered Collection",
-    426: "Upgrade Required",
-    428: "Precondition Required",
-    429: "Too Many Requests",
-    431: "Request Header Fields Too Large",
-    444: "No Response",
-    449: "Retry With",
-    499: "Client Closed Request",
-    500: "Internal Server Error",
-    501: "Not Implemented",
-    502: "Bad Gateway",
-    503: "Service Unavailable",
-    504: "Gateway Timeout",
-    505: "HTTP Version Not Supported",
-    506: "Variant Also Negotiates",
-    507: "Insufficient Storage",
-    508: "Loop Detected",
-    509: "Bandwidth Limit Exceeded",
-    510: "Not Extended",
-    511: "Network Authentication Required"
-};
+  400: 'Bad Request',
+  401: 'Unauthorized',
+  402: 'Payment Required',
+  403: 'Forbidden',
+  404: 'Not Found',
+  405: 'Method Not Allowed',
+  406: 'Not Acceptable',
+  407: 'Proxy Authentication Required',
+  408: 'Request Timeout',
+  409: 'Conflict',
+  410: 'Gone',
+  411: 'Length Required',
+  412: 'Precondition Failed',
+  413: 'Request Entity Too Large',
+  414: 'Request-URI Too Long',
+  415: 'Unsupported Media Type',
+  416: 'Requested Range Not Satisfiable',
+  417: 'Expectation Failed',
+  420: 'Enhance Your Calm',
+  422: 'Unprocessable Entity',
+  423: 'Locked',
+  424: 'Failed Dependency',
+  425: 'Unordered Collection',
+  426: 'Upgrade Required',
+  428: 'Precondition Required',
+  429: 'Too Many Requests',
+  431: 'Request Header Fields Too Large',
+  444: 'No Response',
+  449: 'Retry With',
+  499: 'Client Closed Request',
+  500: 'Internal Server Error',
+  501: 'Not Implemented',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+  504: 'Gateway Timeout',
+  505: 'HTTP Version Not Supported',
+  506: 'Variant Also Negotiates',
+  507: 'Insufficient Storage',
+  508: 'Loop Detected',
+  509: 'Bandwidth Limit Exceeded',
+  510: 'Not Extended',
+  511: 'Network Authentication Required'
+}
 
 // XXX: Remove?
 for (var status in statusCodes) {
-    var defaultMsg = statusCodes[status];
+  var defaultMsg = statusCodes[status]
 
-    var error = (function(defaultMsg, status) {
-        return function(msg) {
-            this.defaultMessage = defaultMsg;
-            exports.HttpError.call(this, msg || status + ": " + defaultMsg, status);
+  var error = (function (defaultMsg, status) {
+    return function (msg) {
+      this.defaultMessage = defaultMsg
+      exports.HttpError.call(this, msg || status + ': ' + defaultMsg, status)
 
-            if (status >= 500)
-                Error.captureStackTrace(this, arguments.callee);
-        };
-    })(defaultMsg, status);
+      if (status >= 500) { Error.captureStackTrace(this, arguments.callee) } // eslint-disable-line
+    }
+  })(defaultMsg, status)
 
-    Util.inherits(error, exports.HttpError);
+  Util.inherits(error, exports.HttpError)
 
-    var className = toCamelCase(defaultMsg);
-    exports[className] = error;
-    exports[status] = error;
+  var className = toCamelCase(defaultMsg)
+  exports[className] = error
+  exports[status] = error
 }
 
-function toCamelCase(str) {
-    return str.toLowerCase().replace(/(?:(^.)|(\s+.))/g, function(match) {
-        return match.charAt(match.length-1).toUpperCase();
-    });
+function toCamelCase (str) {
+  return str.toLowerCase().replace(/(?:(^.)|(\s+.))/g, function (match) {
+    return match.charAt(match.length - 1).toUpperCase()
+  })
 }

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -10,181 +10,179 @@
  *  Author: Mike de Boer <mike@c9.io>
  **/
 
-"use strict";
+'use strict'
 
-var fs = require("fs");
-var Path = require("path");
-var Url = require("url");
-var Util = require("./util");
-var npmPackageJSON = require("../package.json");
+var fs = require('fs')
+var Path = require('path')
+var Util = require('./util')
+var npmPackageJSON = require('../package.json')
 
-var TestSectionTpl = fs.readFileSync(__dirname + "/../templates/test_section.js.tpl", "utf8");
-var TestHandlerTpl = fs.readFileSync(__dirname + "/../templates/test_handler.js.tpl", "utf8");
+var TestSectionTpl = fs.readFileSync(Path.join(__dirname, '/../templates/test_section.js.tpl'), 'utf8')
+var TestHandlerTpl = fs.readFileSync(Path.join(__dirname, '/../templates/test_handler.js.tpl'), 'utf8')
 
-var main = module.exports = function() {
+var main = module.exports = function () {
     // check routes path
-    var routesPath = Path.join(__dirname, "routes.json");
-    var routes = JSON.parse(fs.readFileSync(routesPath, "utf8"));
-    if (!routes.defines) {
-        Util.log("No routes defined.", "fatal");
-        process.exit(1);
+  var routesPath = Path.join(__dirname, 'routes.json')
+  var routes = JSON.parse(fs.readFileSync(routesPath, 'utf8'))
+  if (!routes.defines) {
+    Util.log('No routes defined.', 'fatal')
+    process.exit(1)
+  }
+
+  Util.log('Generating...')
+
+  var defines = routes.defines
+  delete routes.defines
+  var sections = {}
+  var testSections = {}
+  var apidocs = '' // eslint-disable-line
+
+  function prepareApi (struct, baseType) {
+    if (!baseType) {
+      baseType = ''
     }
 
-    Util.log("Generating...");
-
-    var defines = routes.defines;
-    delete routes.defines;
-    var sections = {};
-    var testSections = {};
-    var apidocs = "";
-
-    function prepareApi(struct, baseType) {
-        if (!baseType) {
-            baseType = "";
-        }
-
-        Object.keys(struct).sort().forEach(function(routePart) {
-            var block = struct[routePart];
-            if (!block) {
-                return;
-            }
-            var messageType = baseType + "/" + routePart;
-            if (block.url && block.params) {
+    Object.keys(struct).sort().forEach(function (routePart) {
+      var block = struct[routePart]
+      if (!block) {
+        return
+      }
+      var messageType = baseType + '/' + routePart
+      if (block.url && block.params) {
                 // we ended up at an API definition part!
-                var parts = messageType.split("/");
-                var section = Util.toCamelCase(parts[1]);
-                if (!block.method) {
-                    throw new Error("No HTTP method specified for " + messageType +
-                        "in section " + section);
-                }
+        var parts = messageType.split('/')
+        var section = Util.toCamelCase(parts[1])
+        if (!block.method) {
+          throw new Error('No HTTP method specified for ' + messageType +
+                        'in section ' + section)
+        }
 
                 // add the handler to the sections
-                if (!sections[section]) {
-                    sections[section] = [];
-                }
+        if (!sections[section]) {
+          sections[section] = []
+        }
 
-                parts.splice(0, 2);
-                var funcName = Util.toCamelCase(parts.join("-"));
-                apidocs += createComment(section, funcName, block);
+        parts.splice(0, 2)
+        var funcName = Util.toCamelCase(parts.join('-'))
+        apidocs += createComment(section, funcName, block)
 
                 // add test to the testSections
-                if (!testSections[section]) {
-                    testSections[section] = [];
-                }
-                testSections[section].push(TestHandlerTpl
-                    .replace("<%name%>", block.method + " " + block.url + " (" + funcName + ")")
-                    .replace("<%funcName%>", section + "." + funcName)
-                    .replace("<%params%>", getParams(block.params, "            "))
-                );
-            }
-            else {
+        if (!testSections[section]) {
+          testSections[section] = []
+        }
+        testSections[section].push(TestHandlerTpl
+                    .replace('<%name%>', block.method + ' ' + block.url + ' (' + funcName + ')')
+                    .replace('<%funcName%>', section + '.' + funcName)
+                    .replace('<%params%>', getParams(block.params, '            '))
+                )
+      } else {
                 // recurse into this block next:
-                prepareApi(block, messageType);
-            }
-        });
-    }
+        prepareApi(block, messageType)
+      }
+    })
+  }
 
-    function createComment(section, funcName, block) {
-        var method = block['method'].toLowerCase();
-        var url = block['url'];
-        var funcDisplayName = funcName;
+  function createComment (section, funcName, block) {
+    var method = block['method'].toLowerCase()
+    var url = block['url']
+    var funcDisplayName = funcName
 
-        var apiVersion = npmPackageJSON['version'];
+    var apiVersion = npmPackageJSON['version']
 
-        var commentLines = [
-            "/**",
-            " * @api {" + method + "} " + url + " " + funcName,
-            " * @apiVersion " + apiVersion,
-            " * @apiName " + funcDisplayName,
-            " * @apiDescription " + block['description'],
-            " * @apiGroup " + section,
-            " *"
-        ];
+    var commentLines = [
+      '/**',
+      ' * @api {' + method + '} ' + url + ' ' + funcName,
+      ' * @apiVersion ' + apiVersion,
+      ' * @apiName ' + funcDisplayName,
+      ' * @apiDescription ' + block['description'],
+      ' * @apiGroup ' + section,
+      ' *'
+    ]
 
-        var paramsObj = block['params'];
+    var paramsObj = block['params']
 
         // sort params so Required come before Optional
-        var paramKeys = Object.keys(paramsObj);
-        paramKeys.sort(function(paramA, paramB) {
-            var cleanParamA = paramA.replace(/^\$/, "");
-            var cleanParamB = paramB.replace(/^\$/, "");
+    var paramKeys = Object.keys(paramsObj)
+    paramKeys.sort(function (paramA, paramB) {
+      var cleanParamA = paramA.replace(/^\$/, '')
+      var cleanParamB = paramB.replace(/^\$/, '')
 
-            var paramInfoA = paramsObj[paramA] || defines['params'][cleanParamA];
-            var paramInfoB = paramsObj[paramB] || defines['params'][cleanParamB];
+      var paramInfoA = paramsObj[paramA] || defines['params'][cleanParamA]
+      var paramInfoB = paramsObj[paramB] || defines['params'][cleanParamB]
 
-            var paramRequiredA = paramInfoA['required'];
-            var paramRequiredB = paramInfoB['required'];
+      var paramRequiredA = paramInfoA['required']
+      var paramRequiredB = paramInfoB['required']
 
-            if (paramRequiredA && !paramRequiredB) return -1;
-            if (!paramRequiredA && paramRequiredB) return 1;
-            return 0;
-        });
+      if (paramRequiredA && !paramRequiredB) return -1
+      if (!paramRequiredA && paramRequiredB) return 1
+      return 0
+    })
 
-        paramKeys.forEach(function(param) {
-            var cleanParam = param.replace(/^\$/, "");
-            var paramInfo = paramsObj[param] || defines['params'][cleanParam];
+    paramKeys.forEach(function (param) {
+      var cleanParam = param.replace(/^\$/, '')
+      var paramInfo = paramsObj[param] || defines['params'][cleanParam]
 
-            var paramRequired = paramInfo['required'];
-            var paramType = paramInfo['type'];
-            var paramDescription = paramInfo['description'];
-            var paramDefaultVal = paramInfo['default'];
+      var paramRequired = paramInfo['required']
+      var paramType = paramInfo['type']
+      var paramDescription = paramInfo['description']
+      var paramDefaultVal = paramInfo['default']
 
-            var paramLabel = cleanParam;
+      var paramLabel = cleanParam
 
             // add default value if there is one
-            if (typeof paramDefaultVal !== "undefined") {
-                paramLabel += '=' + paramDefaultVal
-            }
+      if (typeof paramDefaultVal !== 'undefined') {
+        paramLabel += '=' + paramDefaultVal
+      }
 
             // show param as either required or optional
-            if (!paramRequired) {
-                paramLabel = "[" + paramLabel + "]";
-            }
+      if (!paramRequired) {
+        paramLabel = '[' + paramLabel + ']'
+      }
 
-            var allowedValues = '';
-            if (paramInfo['enum']) {
-                allowedValues = '=' + paramInfo['enum'].map(function(val) {
-                  return val; //"\"" + val + "\"";
-                }).join(',');
-            }
+      var allowedValues = ''
+      if (paramInfo['enum']) {
+        allowedValues = '=' + paramInfo['enum'].map(function (val) {
+          return val // "\"" + val + "\"";
+        }).join(',')
+      }
 
-            commentLines.push(" * @apiParam {" + paramType + allowedValues + "} " + paramLabel + "  " + paramDescription);
-        });
+      commentLines.push(' * @apiParam {' + paramType + allowedValues + '} ' + paramLabel + '  ' + paramDescription)
+    })
 
-        commentLines.push(" * @apiExample {js} ex:\ngithub." + section + "." + funcName + "({ ... });");
+    commentLines.push(' * @apiExample {js} ex:\ngithub.' + section + '.' + funcName + '({ ... });')
 
-        return commentLines.join("\n") + "\n */\n\n";
+    return commentLines.join('\n') + '\n */\n\n'
+  }
+
+  function getParams (paramsStruct, indent) {
+    var params = Object.keys(paramsStruct)
+    if (!params.length) {
+      return '{}'
     }
-
-    function getParams(paramsStruct, indent) {
-        var params = Object.keys(paramsStruct);
-        if (!params.length) {
-            return "{}";
+    var values = []
+    var paramName, def
+    for (var i = 0, l = params.length; i < l; ++i) {
+      paramName = params[i]
+      if (paramName.charAt(0) === '$') {
+        paramName = paramName.substr(1)
+        if (!defines.params[paramName]) {
+          Util.log("Invalid variable parameter name substitution; param '" +
+                        paramName + "' not found in defines block", 'fatal')
+          process.exit(1)
+        } else {
+          def = defines.params[paramName]
         }
-        var values = [];
-        var paramName, def;
-        for (var i = 0, l = params.length; i < l; ++i) {
-            paramName = params[i];
-            if (paramName.charAt(0) == "$") {
-                paramName = paramName.substr(1);
-                if (!defines.params[paramName]) {
-                    Util.log("Invalid variable parameter name substitution; param '" +
-                        paramName + "' not found in defines block", "fatal");
-                    process.exit(1);
-                } else {
-                    def = defines.params[paramName];
-                }
-            } else {
-                def = paramsStruct[paramName];
-            }
+      } else {
+        def = paramsStruct[paramName]
+      }
 
-            values.push(indent + "    " + paramName + ": \"" + def.type + "\"");
-        }
-        return "{\n" + values.join(",\n") + "\n" + indent + "}";
+      values.push(indent + '    ' + paramName + ': "' + def.type + '"')
     }
+    return '{\n' + values.join(',\n') + '\n' + indent + '}'
+  }
 
-    Util.log("Converting routes to functions");
-    prepareApi(routes);
+  Util.log('Converting routes to functions')
+  prepareApi(routes)
 
     // XXX: Doc generation is a little manual due to some customizations with
     //      JSON APIs so leave commented out and uncomment when generating new
@@ -192,22 +190,22 @@ var main = module.exports = function() {
     // var apidocsPath = Path.join(__dirname, "/../doc", "apidoc.js");
     // fs.writeFileSync(apidocsPath, apidocs);
 
-    Object.keys(sections).forEach(function(section) {
-        Util.log("Writing test file for " + section);
+  Object.keys(sections).forEach(function (section) {
+    Util.log('Writing test file for ' + section)
 
-        var def = testSections[section];
-        var body = TestSectionTpl
-            .replace("<%version%>", "3.0.0")
+    var def = testSections[section]
+    var body = TestSectionTpl
+            .replace('<%version%>', '3.0.0')
             .replace(/<%sectionName%>/g, section)
-            .replace(/<%sectionAuthType%>/g, section == "installations" ? "integration" : "oauth")
-            .replace("<%testBody%>", def.join("\n\n"));
-        var path = Path.join(__dirname, "/../test", section + "Test.js");
+            .replace(/<%sectionAuthType%>/g, section === 'installations' ? 'integration' : 'oauth')
+            .replace('<%testBody%>', def.join('\n\n'))
+    var path = Path.join(__dirname, '/../test', section + 'Test.js')
 
-        fs.writeFileSync(path, body, "utf8");
-    });
+    fs.writeFileSync(path, body, 'utf8')
+  })
 
-    require('./generateFlowTypes.js');
-    require('./generateTypeScriptTypes.js');
-};
+  require('./generateFlowTypes.js')
+  require('./generateTypeScriptTypes.js')
+}
 
-main();
+main()

--- a/lib/generateFlowTypes.js
+++ b/lib/generateFlowTypes.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-module.exports = require("./generateTypes")("Flow", "index.js.flow.tpl", "index.js.flow");
+module.exports = require('./generateTypes')('Flow', 'index.js.flow.tpl', 'index.js.flow')

--- a/lib/generateTypeScriptTypes.js
+++ b/lib/generateTypeScriptTypes.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-module.exports = require("./generateTypes")("TypeScript", "index.d.ts.tpl", "index.d.ts");
+module.exports = require('./generateTypes')('TypeScript', 'index.d.ts.tpl', 'index.d.ts')

--- a/lib/generateTypes.js
+++ b/lib/generateTypes.js
@@ -10,165 +10,165 @@
  *    Author: Mike de Boer <mike@c9.io>
  **/
 
-"use strict";
+'use strict'
 
-var fs = require("fs");
-var Path = require("path");
-var Util = require("./util");
-var Mustache = require("mustache");
+var fs = require('fs')
+var Path = require('path')
+var Util = require('./util')
+var Mustache = require('mustache')
 
 var typeMap = {
-    Json: "string",
-    String: "string",
-    Number: "number",
-    Boolean: "boolean",
-};
+  Json: 'string',
+  String: 'string',
+  Number: 'number',
+  Boolean: 'boolean'
+}
 
 // XXX: maybe a better idea to update routes.json to include array value types.
-function replaceArrayTypes(type, name) {
-    switch (name) {
-        case "scopes":
-        case "add_scopes":
-        case "remove_scopes":
-        case "parents":
-        case "assignees":
-        case "repositories":
-        case "repo_names":
-        case "events":
-        case "add_events":
-        case "remove_events":
-        case "contexts":
-        case "required_contexts":
-        case "maintainers":
-        case "reviewers":
-        case "team_reviewers":
-        case "comments":
-        case "labels":
-        case "teams":
-        case "users":
-        case "names":
-        case "emails":
-            if (type === "Array") {
-                return "string[]";
-            }
-    }
-    return type;
+function replaceArrayTypes (type, name) {
+  switch (name) {
+    case 'scopes':
+    case 'add_scopes':
+    case 'remove_scopes':
+    case 'parents':
+    case 'assignees':
+    case 'repositories':
+    case 'repo_names':
+    case 'events':
+    case 'add_events':
+    case 'remove_events':
+    case 'contexts':
+    case 'required_contexts':
+    case 'maintainers':
+    case 'reviewers':
+    case 'team_reviewers':
+    case 'comments':
+    case 'labels':
+    case 'teams':
+    case 'users':
+    case 'names':
+    case 'emails':
+      if (type === 'Array') {
+        return 'string[]'
+      }
+  }
+  return type
 }
 
-function paramData(key, definition) {
-    if (definition === null) {
-        return {};
-    }
+function paramData (key, definition) {
+  if (definition === null) {
+    return {}
+  }
 
-    var typeName = typeMap[definition.type] || definition.type;
-    var type = replaceArrayTypes(typeName, key);
-    var enums = definition.enum ?
-        definition.enum.map(JSON.stringify).join("|")
-        : null;
+  var typeName = typeMap[definition.type] || definition.type
+  var type = replaceArrayTypes(typeName, key)
+  var enums = definition.enum
+        ? definition.enum.map(JSON.stringify).join('|')
+        : null
 
-    return {
-        name: pascalcase(key),
-        key: key,
-        required: definition.required,
-        type: enums ? enums : type,
-    };
+  return {
+    name: pascalcase(key),
+    key: key,
+    required: definition.required,
+    type: enums || type
+  }
 }
 
-function capitalize(string) {
-    return string.charAt(0).toUpperCase().concat(string.slice(1));
+function capitalize (string) {
+  return string.charAt(0).toUpperCase().concat(string.slice(1))
 }
 
-function camelcase(string) {
-    return string.replace(/(?:-|_)([a-z])/g, function (_, character) {
-        return capitalize(character);
-    });
+function camelcase (string) {
+  return string.replace(/(?:-|_)([a-z])/g, function (_, character) {
+    return capitalize(character)
+  })
 }
 
-function pascalcase(string) {
-    return capitalize(camelcase(string));
+function pascalcase (string) {
+  return capitalize(camelcase(string))
 }
 
-function isGlobalParam(name) {
-    return name.charAt(0) === "$";
+function isGlobalParam (name) {
+  return name.charAt(0) === '$'
 }
 
-function isLocalParam(name) {
-    return !isGlobalParam(name);
+function isLocalParam (name) {
+  return !isGlobalParam(name)
 }
 
-function entries(object) {
-    return Object.keys(object).map(function (key) {
-        return [key, object[key]];
-    });
+function entries (object) {
+  return Object.keys(object).map(function (key) {
+    return [key, object[key]]
+  })
 }
 
-function combineParamData(params, entry) {
-    return params.concat(paramData.apply(null, entry));
+function combineParamData (params, entry) {
+  return params.concat(paramData.apply(null, entry))
 }
 
-var main = module.exports = function(languageName, templateFile, outputFile) {
-    var templatePath = Path.join(__dirname, "..", "templates", templateFile);
-    var template = fs.readFileSync(templatePath, "utf8");
+module.exports = function (languageName, templateFile, outputFile) {
+  var templatePath = Path.join(__dirname, '..', 'templates', templateFile)
+  var template = fs.readFileSync(templatePath, 'utf8')
 
     // check routes path
-    var routesPath = Path.join(__dirname, "routes.json");
-    var routes = JSON.parse(fs.readFileSync(routesPath, "utf8"));
-    if (!routes.defines) {
-        Util.log("No routes defined.", "fatal");
-        process.exit(1);
-    }
+  var routesPath = Path.join(__dirname, 'routes.json')
+  var routes = JSON.parse(fs.readFileSync(routesPath, 'utf8'))
+  if (!routes.defines) {
+    Util.log('No routes defined.', 'fatal')
+    process.exit(1)
+  }
 
-    var defines = routes.defines;
-    var requestHeaders = defines["request-headers"];
-    delete routes.defines;
+  var defines = routes.defines
+  var requestHeaders = defines['request-headers']
+  delete routes.defines
 
-    Util.log("Generating " + languageName + " types...");
+  Util.log('Generating ' + languageName + ' types...')
 
-    var params = entries(defines.params).reduce(combineParamData, []);
+  var params = entries(defines.params).reduce(combineParamData, [])
 
-    var namespaces = Object.keys(routes).reduce(function (namespaces, namespace) {
-        var methods = entries(routes[namespace]).reduce(function (methods, entry) {
-            var unionTypeNames = Object.keys(entry[1].params)
+  var namespaces = Object.keys(routes).reduce(function (namespaces, namespace) {
+    var methods = entries(routes[namespace]).reduce(function (methods, entry) {
+      var unionTypeNames = Object.keys(entry[1].params)
                 .filter(isGlobalParam)
                 .reduce(function (params, name) {
-                    return params.concat(pascalcase(name.slice(1)));
-                }, []);
+                  return params.concat(pascalcase(name.slice(1)))
+                }, [])
 
-            var ownParams = entries(entry[1].params)
-                .filter(function (entry) { return isLocalParam(entry[0]); })
-                .reduce(combineParamData, []);
+      var ownParams = entries(entry[1].params)
+                .filter(function (entry) { return isLocalParam(entry[0]) })
+                .reduce(combineParamData, [])
 
-            var hasParams = unionTypeNames.length > 0 || ownParams.length > 0;
+      var hasParams = unionTypeNames.length > 0 || ownParams.length > 0
 
-            var paramTypeName = "";
-            if (!hasParams) {
-                paramTypeName = pascalcase("EmptyParams");
-            } else {
-                paramTypeName = pascalcase(namespace + "-" + entry[0] + "Params");
-            }
+      var paramTypeName = ''
+      if (!hasParams) {
+        paramTypeName = pascalcase('EmptyParams')
+      } else {
+        paramTypeName = pascalcase(namespace + '-' + entry[0] + 'Params')
+      }
 
-            return methods.concat({
-                method: camelcase(entry[0]),
-                paramTypeName: paramTypeName,
-                unionTypeNames: unionTypeNames.length > 0 && unionTypeNames,
-                ownParams: ownParams.length > 0 && { params: ownParams },
-                exclude: !hasParams
-            });
-        }, []);
+      return methods.concat({
+        method: camelcase(entry[0]),
+        paramTypeName: paramTypeName,
+        unionTypeNames: unionTypeNames.length > 0 && unionTypeNames,
+        ownParams: ownParams.length > 0 && { params: ownParams },
+        exclude: !hasParams
+      })
+    }, [])
 
-        return namespaces.concat({
-            namespace: camelcase(namespace),
-            methods: methods,
-        });
-    }, []);
+    return namespaces.concat({
+      namespace: camelcase(namespace),
+      methods: methods
+    })
+  }, [])
 
-    var body = Mustache.render(template, {
-        requestHeaders: requestHeaders.map(JSON.stringify),
-        params: params,
-        namespaces: namespaces,
-    });
+  var body = Mustache.render(template, {
+    requestHeaders: requestHeaders.map(JSON.stringify),
+    params: params,
+    namespaces: namespaces
+  })
 
-    Util.log("Writing " + languageName + " declarations file");
+  Util.log('Writing ' + languageName + ' declarations file')
 
-    fs.writeFileSync(Path.join(__dirname, outputFile), body, "utf8");
-};
+  fs.writeFileSync(Path.join(__dirname, outputFile), body, 'utf8')
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,14 @@
-"use strict";
+'use strict'
 
-var error = require("./error");
-var fs = require("fs");
-var HttpsProxyAgent = require('https-proxy-agent');
-var mime = require("mime");
-var netrc = require("netrc");
-var Util = require("./util");
-var Url = require("url");
-var Promise = require("./promise");
+var error = require('./error')
+var fs = require('fs')
+var Path = require('path')
+var HttpsProxyAgent = require('https-proxy-agent')
+var mime = require('mime')
+var netrc = require('netrc')
+var Util = require('./util')
+var Url = require('url')
+var Promise = require('./promise')
 
 /** section: github
  * class Client
@@ -71,42 +72,42 @@ var Promise = require("./promise");
  *          ...
  *      }
  **/
-var Client = module.exports = function(config) {
-    if (!(this instanceof Client)) {
-        return new Client(config);
-    }
+var Client = module.exports = function (config) {
+  if (!(this instanceof Client)) {
+    return new Client(config)
+  }
 
-    config = config || {}
-    config.headers = config.headers || {};
-    this.config = config;
-    this.debug = Util.isTrue(config.debug);
-    this.Promise = config.Promise || config.promise || Promise;
+  config = config || {}
+  config.headers = config.headers || {}
+  this.config = config
+  this.debug = Util.isTrue(config.debug)
+  this.Promise = config.Promise || config.promise || Promise
 
-    this.routes = JSON.parse(fs.readFileSync(__dirname + "/routes.json", "utf8"));
+  this.routes = JSON.parse(fs.readFileSync(Path.join(__dirname, '/routes.json'), 'utf8'))
 
-    var pathPrefix = "";
+  var pathPrefix = ''
     // Check if a prefix is passed in the config and strip any leading or trailing slashes from it.
-    if (typeof config.pathPrefix == "string") {
-        pathPrefix = "/" + config.pathPrefix.replace(/(^[\/]+|[\/]+$)/g, "");
-        this.config.pathPrefix = pathPrefix;
-    }
+  if (typeof config.pathPrefix === 'string') {
+    pathPrefix = '/' + config.pathPrefix.replace(/(^[/]+|[/]+$)/g, '')
+    this.config.pathPrefix = pathPrefix
+  }
 
     // store mapping of accept header to preview api endpoints
-    var mediaHash  = this.routes.defines.acceptTree;
-    var mediaTypes = {};
+  var mediaHash = this.routes.defines.acceptTree
+  var mediaTypes = {}
 
-    for (var accept in mediaHash) {
-        for (var route in mediaHash[accept]) {
-            mediaTypes[mediaHash[accept][route]] = accept;
-        }
+  for (var accept in mediaHash) {
+    for (var route in mediaHash[accept]) {
+      mediaTypes[mediaHash[accept][route]] = accept
     }
+  }
 
-    this.acceptUrls = mediaTypes;
+  this.acceptUrls = mediaTypes
 
-    this.setupRoutes();
+  this.setupRoutes()
 };
 
-(function() {
+(function () {
     /**
      *  Client#setupRoutes() -> null
      *
@@ -134,176 +135,168 @@ var Client = module.exports = function(config) {
      *  Note: Query escaping for usage with SQL products is something that can be
      *  implemented additionally by adding an additional parameter type.
      **/
-    this.setupRoutes = function() {
-        var self = this;
-        var routes = this.routes;
-        var defines = routes.defines;
-        this.constants = defines.constants;
-        this.requestHeaders = defines["request-headers"].map(function(header) {
-            return header.toLowerCase();
-        });
-        this.responseHeaders = defines["response-headers"].map(function(header) {
-            return header.toLowerCase();
-        });
-        delete routes.defines;
+  this.setupRoutes = function () {
+    var self = this
+    var routes = this.routes
+    var defines = routes.defines
+    this.constants = defines.constants
+    this.requestHeaders = defines['request-headers'].map(function (header) {
+      return header.toLowerCase()
+    })
+    this.responseHeaders = defines['response-headers'].map(function (header) {
+      return header.toLowerCase()
+    })
+    delete routes.defines
 
-        function trim(s) {
-            if (typeof s != "string") {
-                return s;
-            }
-            return s.replace(/^[\s\t\r\n]+/, "").replace(/[\s\t\r\n]+$/, "");
+    function parseParams (msg, paramsStruct) {
+      var params = Object.keys(paramsStruct)
+      var paramName, def, value, type
+      for (var i = 0, l = params.length; i < l; ++i) {
+        paramName = params[i]
+        if (paramName.charAt(0) === '$') {
+          paramName = paramName.substr(1)
+          if (!defines.params[paramName]) {
+            throw new error.BadRequest("Invalid variable parameter name substitution; param '" +
+                            paramName + "' not found in defines block", 'fatal')
+          } else {
+            def = paramsStruct[paramName] = defines.params[paramName]
+            delete paramsStruct['$' + paramName]
+          }
+        } else {
+          def = paramsStruct[paramName]
         }
 
-        function parseParams(msg, paramsStruct) {
-            var params = Object.keys(paramsStruct);
-            var paramName, def, value, type;
-            for (var i = 0, l = params.length; i < l; ++i) {
-                paramName = params[i];
-                if (paramName.charAt(0) == "$") {
-                    paramName = paramName.substr(1);
-                    if (!defines.params[paramName]) {
-                        throw new error.BadRequest("Invalid variable parameter name substitution; param '" +
-                            paramName + "' not found in defines block", "fatal");
-                    } else {
-                        def = paramsStruct[paramName] = defines.params[paramName];
-                        delete paramsStruct["$" + paramName];
-                    }
-                } else {
-                    def = paramsStruct[paramName];
-                }
-
-                value = msg[paramName];
-                if (typeof value != "boolean" && !value) {
+        value = msg[paramName]
+        if (typeof value !== 'boolean' && !value) {
                     // we don't need validation for undefined parameter values
                     // that are not required.
-                    if (!def.required ||
-                        (def["allow-empty"] && value === "") ||
-                        (def["allow-null"] && value === null)) {
-                        continue;
-                    }
-                    throw new error.BadRequest("Empty value for parameter '" +
-                        paramName + "': " + value);
-                }
+          if (!def.required ||
+                        (def['allow-empty'] && value === '') ||
+                        (def['allow-null'] && value === null)) {
+            continue
+          }
+          throw new error.BadRequest("Empty value for parameter '" +
+                        paramName + "': " + value)
+        }
 
                 // validate the value and type of parameter:
-                if (def.validation) {
-                    if (!new RegExp(def.validation).test(value)) {
-                        throw new error.BadRequest("Invalid value for parameter '" +
-                            paramName + "': " + value);
-                    }
-                }
-
-                if (def.type) {
-                    type = def.type.toLowerCase();
-                    if (type == "number") {
-                        value = parseInt(value, 10);
-                        if (isNaN(value)) {
-                            throw new error.BadRequest("Invalid value for parameter '" +
-                                paramName + "': " + msg[paramName] + " is NaN");
-                        }
-                    } else if (type == "float") {
-                        value = parseFloat(value);
-                        if (isNaN(value)) {
-                            throw new error.BadRequest("Invalid value for parameter '" +
-                                paramName + "': " + msg[paramName] + " is NaN");
-                        }
-                    } else if (type == "json") {
-                        if (typeof value == "string") {
-                            try {
-                                value = JSON.parse(value);
-                            } catch(ex) {
-                                throw new error.BadRequest("JSON parse error of value for parameter '" +
-                                    paramName + "': " + value);
-                            }
-                        }
-                    } else if (type == "date") {
-                        value = new Date(value);
-                    }
-                }
-                msg[paramName] = value;
-            }
+        if (def.validation) {
+          if (!new RegExp(def.validation).test(value)) {
+            throw new error.BadRequest("Invalid value for parameter '" +
+                            paramName + "': " + value)
+          }
         }
 
-        function prepareApi(struct, baseType) {
-            if (!baseType) {
-                baseType = "";
+        if (def.type) {
+          type = def.type.toLowerCase()
+          if (type === 'number') {
+            value = parseInt(value, 10)
+            if (isNaN(value)) {
+              throw new error.BadRequest("Invalid value for parameter '" +
+                                paramName + "': " + msg[paramName] + ' is NaN')
             }
-            Object.keys(struct).forEach(function(routePart) {
-                var block = struct[routePart];
-                if (!block) {
-                    return;
-                }
-                var messageType = baseType + "/" + routePart;
-                if (block.url && block.params) {
-                    // we ended up at an API definition part!
-                    var endPoint = messageType.replace(/^[\/]+/g, "");
-                    var parts = messageType.split("/");
-                    var section = Util.toCamelCase(parts[1].toLowerCase());
-                    parts.splice(0, 2);
-                    var funcName = Util.toCamelCase(parts.join("-"));
+          } else if (type === 'float') {
+            value = parseFloat(value)
+            if (isNaN(value)) {
+              throw new error.BadRequest("Invalid value for parameter '" +
+                                paramName + "': " + msg[paramName] + ' is NaN')
+            }
+          } else if (type === 'json') {
+            if (typeof value === 'string') {
+              try {
+                value = JSON.parse(value)
+              } catch (ex) {
+                throw new error.BadRequest("JSON parse error of value for parameter '" +
+                                    paramName + "': " + value)
+              }
+            }
+          } else if (type === 'date') {
+            value = new Date(value)
+          }
+        }
+        msg[paramName] = value
+      }
+    }
 
-                    if (!self[section]) {
-                        self[section] = {};
+    function prepareApi (struct, baseType) {
+      if (!baseType) {
+        baseType = ''
+      }
+      Object.keys(struct).forEach(function (routePart) {
+        var block = struct[routePart]
+        if (!block) {
+          return
+        }
+        var messageType = baseType + '/' + routePart
+        if (block.url && block.params) {
+                    // we ended up at an API definition part!
+          var parts = messageType.split('/')
+          var section = Util.toCamelCase(parts[1].toLowerCase())
+          parts.splice(0, 2)
+          var funcName = Util.toCamelCase(parts.join('-'))
+
+          if (!self[section]) {
+            self[section] = {}
                         // add a utility function 'getFooApi()', which returns the
                         // section to which functions are attached.
-                        self[Util.toCamelCase("get-" + section + "-api")] = function() {
-                            return self[section];
-                        };
-                    }
+            self[Util.toCamelCase('get-' + section + '-api')] = function () {
+              return self[section]
+            }
+          }
 
-                    self[section][funcName] = function(msg, callback) {
-                        if (block.deprecated) {
-                          const caller = (new Error()).stack.split('\n')[2];
-                          console.warn('DEPRECATED: ' + block.deprecated);
-                          console.warn(caller);
-                        }
+          self[section][funcName] = function (msg, callback) {
+            if (block.deprecated) {
+              const caller = (new Error()).stack.split('\n')[2]
+              console.warn('DEPRECATED: ' + block.deprecated)
+              console.warn(caller)
+            }
 
-                        try {
-                            parseParams(msg, block.params);
-                        } catch (ex) {
+            try {
+              parseParams(msg, block.params)
+            } catch (ex) {
                             // when the message was sent to the client, we can
                             // reply with the error directly.
-                            self.sendError(ex, block, msg, callback);
-                            if (self.debug) {
-                                Util.log(ex.message, "fatal");
-                            }
+              self.sendError(ex, block, msg, callback)
+              if (self.debug) {
+                Util.log(ex.message, 'fatal')
+              }
 
-                            if (self.Promise && typeof callback !== 'function') {
-                                return self.Promise.reject(ex)
-                            }
+              if (self.Promise && typeof callback !== 'function') {
+                return self.Promise.reject(ex)
+              }
 
                             // on error, there's no need to continue.
-                            return;
-                        }
+              return
+            }
 
-                        if (!callback) {
-                            if (self.Promise) {
-                                return new self.Promise(function(resolve,reject) {
-                                    var cb = function(err, obj) {
-                                        if (err) {
-                                            reject(err);
-                                        } else {
-                                            resolve(obj);
-                                        }
-                                    };
-                                    self.handler(msg, JSON.parse(JSON.stringify(block)), cb);
-                                });
-                            } else {
-                                throw new Error('neither a callback or global promise implementation was provided');
-                            }
-                        } else {
-                            self.handler(msg, JSON.parse(JSON.stringify(block)), callback);
-                        }
-                    };
-                } else {
+            if (!callback) {
+              if (self.Promise) {
+                return new self.Promise(function (resolve, reject) {
+                  var cb = function (err, obj) {
+                    if (err) {
+                      reject(err)
+                    } else {
+                      resolve(obj)
+                    }
+                  }
+                  self.handler(msg, JSON.parse(JSON.stringify(block)), cb)
+                })
+              } else {
+                throw new Error('neither a callback or global promise implementation was provided')
+              }
+            } else {
+              self.handler(msg, JSON.parse(JSON.stringify(block)), callback)
+            }
+          }
+        } else {
                     // recurse into this block next:
-                    prepareApi(block, messageType);
-                }
-            });
+          prepareApi(block, messageType)
         }
+      })
+    }
 
-        prepareApi(routes);
-    };
+    prepareApi(routes)
+  }
 
     /**
      *  Client#authenticate(options) -> null
@@ -349,46 +342,46 @@ var Client = module.exports = function(config) {
      *          token: "jwt",
      *      });
      **/
-    this.authenticate = function(options) {
-        if (!options) {
-            this.auth = false;
-            return;
-        }
-        if (!options.type || "basic|oauth|client|token|integration|netrc".indexOf(options.type) === -1) {
-            throw new Error("Invalid authentication type, must be 'basic', 'integration', 'oauth', 'client' or 'netrc'");
-        }
-        if (options.type == "basic" && (!options.username || !options.password)) {
-            throw new Error("Basic authentication requires both a username and password to be set");
-        }
-        if (options.type == "oauth") {
-            if (!options.token && !(options.key && options.secret)) {
-                throw new Error("OAuth2 authentication requires a token or key & secret to be set");
-            }
-        }
-        if ((options.type == "token" || options.type == "integration") && !options.token) {
-            throw new Error("Token authentication requires a token to be set");
-        }
+  this.authenticate = function (options) {
+    if (!options) {
+      this.auth = false
+      return
+    }
+    if (!options.type || 'basic|oauth|client|token|integration|netrc'.indexOf(options.type) === -1) {
+      throw new Error("Invalid authentication type, must be 'basic', 'integration', 'oauth', 'client' or 'netrc'")
+    }
+    if (options.type === 'basic' && (!options.username || !options.password)) {
+      throw new Error('Basic authentication requires both a username and password to be set')
+    }
+    if (options.type === 'oauth') {
+      if (!options.token && !(options.key && options.secret)) {
+        throw new Error('OAuth2 authentication requires a token or key & secret to be set')
+      }
+    }
+    if ((options.type === 'token' || options.type === 'integration') && !options.token) {
+      throw new Error('Token authentication requires a token to be set')
+    }
 
-        this.auth = options;
-    };
+    this.auth = options
+  }
 
-    function getPageLinks(link) {
-        if (typeof link == "object" && (link.link || link.meta.link)) {
-            link = link.link || link.meta.link;
-        }
+  function getPageLinks (link) {
+    if (typeof link === 'object' && (link.link || link.meta.link)) {
+      link = link.link || link.meta.link
+    }
 
-        var links = {};
-        if (typeof link != "string") {
-            return links;
-        }
+    var links = {}
+    if (typeof link !== 'string') {
+      return links
+    }
 
         // link format:
         // '<https://api.github.com/users/aseemk/followers?page=2>; rel="next", <https://api.github.com/users/aseemk/followers?page=2>; rel="last"'
-        link.replace(/<([^>]*)>;\s*rel="([\w]*)\"/g, function(m, uri, type) {
-            links[type] = uri;
-        });
-        return links;
-    }
+    link.replace(/<([^>]*)>;\s*rel="([\w]*)"/g, function (m, uri, type) {
+      links[type] = uri
+    })
+    return links
+  }
 
     /**
      *  Client#hasNextPage(link) -> null
@@ -396,9 +389,9 @@ var Client = module.exports = function(config) {
      *
      *  Check if a request result contains a link to the next page
      **/
-    this.hasNextPage = function(link) {
-        return getPageLinks(link).next;
-    };
+  this.hasNextPage = function (link) {
+    return getPageLinks(link).next
+  }
 
     /**
      *  Client#hasPreviousPage(link) -> null
@@ -406,9 +399,9 @@ var Client = module.exports = function(config) {
      *
      *  Check if a request result contains a link to the previous page
      **/
-    this.hasPreviousPage = function(link) {
-        return getPageLinks(link).prev;
-    };
+  this.hasPreviousPage = function (link) {
+    return getPageLinks(link).prev
+  }
 
     /**
      *  Client#hasLastPage(link) -> null
@@ -416,9 +409,9 @@ var Client = module.exports = function(config) {
      *
      *  Check if a request result contains a link to the last page
      **/
-    this.hasLastPage = function(link) {
-        return getPageLinks(link).last;
-    };
+  this.hasLastPage = function (link) {
+    return getPageLinks(link).last
+  }
 
     /**
      *  Client#hasFirstPage(link) -> null
@@ -426,50 +419,50 @@ var Client = module.exports = function(config) {
      *
      *  Check if a request result contains a link to the first page
      **/
-    this.hasFirstPage = function(link) {
-        return getPageLinks(link).first;
-    };
+  this.hasFirstPage = function (link) {
+    return getPageLinks(link).first
+  }
 
-    function getPage(link, which, headers, callback) {
-        var self = this;
-        var url = getPageLinks(link)[which];
-        if (!url) {
-            var urlErr = new error.NotFound("No " + which + " page found");
-            return self.Promise && !callback ? self.Promise.reject(urlErr) : callback(urlErr);
-        }
-
-        var parsedUrl = Url.parse(url, true);
-
-        var msg = Object.create(parsedUrl.query);
-        if (headers != null) {
-            msg.headers = headers;
-        }
-
-        var block = {
-            url: parsedUrl.pathname,
-            method: "GET",
-            params: parsedUrl.query
-        };
-
-        if (!callback) {
-            if (self.Promise) {
-                return new self.Promise(function(resolve,reject) {
-                    var cb = function(err, obj) {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve(obj);
-                        }
-                    };
-                    self.handler(msg, JSON.parse(JSON.stringify(block)), cb);
-                });
-            } else {
-                throw new Error('neither a callback or global promise implementation was provided');
-            }
-        } else {
-            self.handler(msg, JSON.parse(JSON.stringify(block)), callback);
-        }
+  function getPage (link, which, headers, callback) {
+    var self = this
+    var url = getPageLinks(link)[which]
+    if (!url) {
+      var urlErr = new error.NotFound('No ' + which + ' page found')
+      return self.Promise && !callback ? self.Promise.reject(urlErr) : callback(urlErr)
     }
+
+    var parsedUrl = Url.parse(url, true)
+
+    var msg = Object.create(parsedUrl.query)
+    if (headers !== null) {
+      msg.headers = headers
+    }
+
+    var block = {
+      url: parsedUrl.pathname,
+      method: 'GET',
+      params: parsedUrl.query
+    }
+
+    if (!callback) {
+      if (self.Promise) {
+        return new self.Promise(function (resolve, reject) {
+          var cb = function (err, obj) {
+            if (err) {
+              reject(err)
+            } else {
+              resolve(obj)
+            }
+          }
+          self.handler(msg, JSON.parse(JSON.stringify(block)), cb)
+        })
+      } else {
+        throw new Error('neither a callback or global promise implementation was provided')
+      }
+    } else {
+      self.handler(msg, JSON.parse(JSON.stringify(block)), callback)
+    }
+  }
 
     /**
      *  Client#getNextPage(link, callback) -> null
@@ -479,14 +472,14 @@ var Client = module.exports = function(config) {
      *
      *  Get the next page, based on the contents of the `Link` header
      **/
-    this.getNextPage = function(link, headers, callback) {
-        if (typeof headers == 'function') {
-            callback = headers;
-            headers = null;
-        }
-        headers = applyAcceptHeader(link, headers);
-        return getPage.call(this, link, "next", headers, callback);
-    };
+  this.getNextPage = function (link, headers, callback) {
+    if (typeof headers === 'function') {
+      callback = headers
+      headers = null
+    }
+    headers = applyAcceptHeader(link, headers)
+    return getPage.call(this, link, 'next', headers, callback)
+  }
 
     /**
      *  Client#getPreviousPage(link, callback) -> null
@@ -496,14 +489,14 @@ var Client = module.exports = function(config) {
      *
      *  Get the previous page, based on the contents of the `Link` header
      **/
-    this.getPreviousPage = function(link, headers, callback) {
-        if (typeof headers == 'function') {
-            callback = headers;
-            headers = null;
-        }
-        headers = applyAcceptHeader(link, headers);
-        return getPage.call(this, link, "prev", headers, callback);
-    };
+  this.getPreviousPage = function (link, headers, callback) {
+    if (typeof headers === 'function') {
+      callback = headers
+      headers = null
+    }
+    headers = applyAcceptHeader(link, headers)
+    return getPage.call(this, link, 'prev', headers, callback)
+  }
 
     /**
      *  Client#getLastPage(link, callback) -> null
@@ -513,14 +506,14 @@ var Client = module.exports = function(config) {
      *
      *  Get the last page, based on the contents of the `Link` header
      **/
-    this.getLastPage = function(link, headers, callback) {
-        if (typeof headers == 'function') {
-            callback = headers;
-            headers = null;
-        }
-        headers = applyAcceptHeader(link, headers);
-        return getPage.call(this, link, "last", headers, callback);
-    };
+  this.getLastPage = function (link, headers, callback) {
+    if (typeof headers === 'function') {
+      callback = headers
+      headers = null
+    }
+    headers = applyAcceptHeader(link, headers)
+    return getPage.call(this, link, 'last', headers, callback)
+  }
 
     /**
      *  Client#getFirstPage(link, callback) -> null
@@ -530,102 +523,102 @@ var Client = module.exports = function(config) {
      *
      *  Get the first page, based on the contents of the `Link` header
      **/
-    this.getFirstPage = function(link, headers, callback) {
-        if (typeof headers == 'function') {
-            callback = headers;
-            headers = null;
-        }
-        headers = applyAcceptHeader(link, headers);
-        return getPage.call(this, link, "first", headers, callback);
-    };
+  this.getFirstPage = function (link, headers, callback) {
+    if (typeof headers === 'function') {
+      callback = headers
+      headers = null
+    }
+    headers = applyAcceptHeader(link, headers)
+    return getPage.call(this, link, 'first', headers, callback)
+  }
 
-    function applyAcceptHeader(res, headers) {
-        var previous = res.meta && res.meta['x-github-media-type'];
-        if (!previous || (headers && headers.accept)) {
-            return headers;
-        }
-        headers = headers || {};
-        headers.accept = 'application/vnd.' + previous.replace('; format=', '+');
-        return headers;
+  function applyAcceptHeader (res, headers) {
+    var previous = res.meta && res.meta['x-github-media-type']
+    if (!previous || (headers && headers.accept)) {
+      return headers
+    }
+    headers = headers || {}
+    headers.accept = 'application/vnd.' + previous.replace('; format=', '+')
+    return headers
+  }
+
+  function getRequestFormat (hasBody, block) {
+    if (hasBody) {
+      return block.requestFormat || this.constants.requestFormat
+    }
+    return 'query'
+  }
+
+  function getQueryAndUrl (msg, def, format, config) {
+    var url = def.url
+    if (config.pathPrefix && url.indexOf(config.pathPrefix) !== 0) {
+      url = config.pathPrefix + def.url
+    }
+    var ret = {}
+    if (!def || !def.params) {
+      ret.url = url
+      return ret
     }
 
-    function getRequestFormat(hasBody, block) {
-        if (hasBody) {
-            return block.requestFormat || this.constants.requestFormat;
-        }
-        return "query";
-    }
+    Object.keys(def.params).forEach(function (paramName) {
+      paramName = paramName.replace(/^[$]+/, '')
+      if (!(paramName in msg)) {
+        return
+      }
 
-    function getQueryAndUrl(msg, def, format, config) {
-        var url = def.url;
-        if (config.pathPrefix && url.indexOf(config.pathPrefix) !== 0) {
-            url = config.pathPrefix + def.url;
-        }
-        var ret = {};
-        if (!def || !def.params) {
-            ret.url = url;
-            return ret;
-        }
-
-        Object.keys(def.params).forEach(function(paramName) {
-            paramName = paramName.replace(/^[$]+/, "");
-            if (!(paramName in msg)) {
-                return;
-            }
-
-            var isUrlParam = url.indexOf(":" + paramName) !== -1;
-            var valFormat = isUrlParam || format != "json" ? "query" : format;
-            var val;
-            if (valFormat != "json") {
-                if (typeof msg[paramName] == "object") {
-                    try {
-                        msg[paramName] = JSON.stringify(msg[paramName]);
-                        val = encodeURIComponent(msg[paramName]);
-                    } catch (ex) {
-                        return Util.log("httpSend: Error while converting object to JSON: "
-                            + (ex.message || ex), "error");
-                    }
-                } else if (def.params[paramName] && def.params[paramName].combined) {
+      var isUrlParam = url.indexOf(':' + paramName) !== -1
+      var valFormat = isUrlParam || format !== 'json' ? 'query' : format
+      var val
+      if (valFormat !== 'json') {
+        if (typeof msg[paramName] === 'object') {
+          try {
+            msg[paramName] = JSON.stringify(msg[paramName])
+            val = encodeURIComponent(msg[paramName])
+          } catch (ex) {
+            return Util.log('httpSend: Error while converting object to JSON: ' +
+                            (ex.message || ex), 'error')
+          }
+        } else if (def.params[paramName] && def.params[paramName].combined) {
                     // Check if this is a combined (search) string.
-                    val = msg[paramName].split(/[\s\t\r\n]*\+[\s\t\r\n]*/)
-                                        .map(function(part) {
-                                            return encodeURIComponent(part);
+          val = msg[paramName].split(/[\s\t\r\n]*\+[\s\t\r\n]*/)
+                                        .map(function (part) {
+                                          return encodeURIComponent(part)
                                         })
-                                        .join("+");
-                } else {
+                                        .join('+')
+        } else {
                     // the ref param is a path so we don't want to [fully] encode it but we do want to encode the # if there is one
                     // (see https://github.com/mikedeboer/node-github/issues/499#issuecomment-280093040)
-                    if (paramName === 'ref') {
-                        val = msg[paramName].replace(/#/g, '%23');
-                    } else {
-                        val = encodeURIComponent(msg[paramName]);
-                    }
-                }
-            } else {
-                val = msg[paramName];
-            }
+          if (paramName === 'ref') {
+            val = msg[paramName].replace(/#/g, '%23')
+          } else {
+            val = encodeURIComponent(msg[paramName])
+          }
+        }
+      } else {
+        val = msg[paramName]
+      }
 
-            if (isUrlParam) {
-                url = url.replace(":" + paramName, val);
-            } else {
-                if (format == "json" && def.params[paramName].sendValueAsBody) {
-                    ret.query = val;
-                } else if (format == "json") {
-                    if (!ret.query) {
-                      ret.query = {}
-                    }
-                    ret.query[paramName] = val;
-                } else if (format != "raw") {
-                    if (!ret.query) {
-                      ret.query = []
-                    }
-                    ret.query.push(paramName + "=" + val);
-                }
-            }
-        });
-        ret.url = url;
-        return ret;
-    }
+      if (isUrlParam) {
+        url = url.replace(':' + paramName, val)
+      } else {
+        if (format === 'json' && def.params[paramName].sendValueAsBody) {
+          ret.query = val
+        } else if (format === 'json') {
+          if (!ret.query) {
+            ret.query = {}
+          }
+          ret.query[paramName] = val
+        } else if (format !== 'raw') {
+          if (!ret.query) {
+            ret.query = []
+          }
+          ret.query.push(paramName + '=' + val)
+        }
+      }
+    })
+    ret.url = url
+    return ret
+  }
 
     /**
      *  Client#httpSend(msg, block, callback) -> null
@@ -638,278 +631,280 @@ var Client = module.exports = function(config) {
      *
      *  Send an HTTP request to the server and pass the result to a callback.
      **/
-    this.httpSend = function(msg, block, callback) {
-        var self = this;
-        var method = block.method.toLowerCase();
-        var hasFileBody = block.hasFileBody;
-        var hasBody = !hasFileBody && (typeof(msg.body) !== "undefined" || "head|get|delete".indexOf(method) === -1);
-        var format = getRequestFormat.call(this, hasBody, block);
-        var protocol = this.config.protocol || this.constants.protocol || "http";
-        var port = this.config.port || (protocol == "https" ? 443 : 80);
-        var host = block.host || this.config.host || this.constants.host;
+  this.httpSend = function (msg, block, callback) {
+    var self = this
+    var method = block.method.toLowerCase()
+    var hasFileBody = block.hasFileBody
+    var hasBody = !hasFileBody && (typeof (msg.body) !== 'undefined' || 'head|get|delete'.indexOf(method) === -1)
+    var format = getRequestFormat.call(this, hasBody, block)
+    var protocol = this.config.protocol || this.constants.protocol || 'http'
+    var port = this.config.port || (protocol === 'https' ? 443 : 80)
+    var host = block.host || this.config.host || this.constants.host
 
         // Edge case for github enterprise uploadAsset:
         // 1) In public api, host changes to uploads.github.com. In enterprise, the host remains the same.
         // 2) In enterprise, the pathPrefix changes from: /api/v3 to /api/uploads.
-        if ((this.config.host && this.config.host !== this.constants.host)
-            && (block.host && block.host === "uploads.github.com")) {  // enterprise uploadAsset
-            host = this.config.host;
-            this.config.pathPrefix = "/api/uploads";
+    if ((this.config.host && this.config.host !== this.constants.host) &&
+            (block.host && block.host === 'uploads.github.com')) {  // enterprise uploadAsset
+      host = this.config.host
+      this.config.pathPrefix = '/api/uploads'
+    }
+
+    var obj = getQueryAndUrl(msg, block, format, self.config)
+    var query = obj.query
+    var url = this.config.url ? this.config.url + obj.url : obj.url
+    var path = url
+    if (!hasBody && query && query.length) {
+      path += '?' + query.join('&')
+    }
+
+    var proxyUrl
+    var agent
+    if (this.config.proxy !== undefined) {
+      proxyUrl = this.config.proxy
+    } else {
+      proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY
+    }
+    if (proxyUrl) {
+      agent = new HttpsProxyAgent(proxyUrl)
+    }
+
+    var ca = this.config.ca
+
+    var headers = {
+      'host': host,
+      'content-length': '0'
+    }
+    if (hasBody) {
+      if (format === 'json') {
+        query = JSON.stringify(query)
+      } else if (format !== 'raw') {
+        query = query.join('&')
+      }
+      headers['content-length'] = Buffer.byteLength(query || '', 'utf8')
+      headers['content-type'] = format === 'json'
+                ? 'application/json; charset=utf-8'
+                : format === 'raw'
+                    ? 'text/plain; charset=utf-8'
+                    : 'application/x-www-form-urlencoded; charset=utf-8'
+    }
+    if (this.auth) {
+      var basic
+      switch (this.auth.type) {
+        case 'oauth':
+          if (this.auth.token) {
+            path += (path.indexOf('?') === -1 ? '?' : '&') +
+                            'access_token=' + encodeURIComponent(this.auth.token)
+          } else {
+            path += (path.indexOf('?') === -1 ? '?' : '&') +
+                            'client_id=' + encodeURIComponent(this.auth.key) +
+                            '&client_secret=' + encodeURIComponent(this.auth.secret)
+          }
+          break
+        case 'token':
+          headers['Authorization'] = 'token ' + this.auth.token
+          break
+        case 'integration':
+          headers['Authorization'] = 'Bearer ' + this.auth.token
+          headers['accept'] = 'application/vnd.github.machine-man-preview+json'
+          break
+        case 'basic':
+          basic = Buffer.from(this.auth.username + ':' + this.auth.password, 'ascii').toString('base64')
+          headers['Authorization'] = 'Basic ' + basic
+          break
+        case 'netrc':
+          var auth = netrc()[host]
+          if (!auth) {
+            throw new Error("~/.netrc authentication type chosen but no credentials found for '" + host + "'")
+          }
+          basic = Buffer.from(auth.login + ':' + auth.password, 'ascii').toString('base64')
+          headers['Authorization'] = 'Basic ' + basic
+          break
+        default:
+          break
+      }
+    }
+
+    function callCallback (err, result) {
+      if (callback) {
+        var cb = callback
+        callback = undefined
+        cb(err, result)
+      }
+    }
+
+    function addCustomHeaders (customHeaders) {
+      Object.keys(customHeaders).forEach(function (header) {
+        var headerLC = header.toLowerCase()
+        if (self.requestHeaders.indexOf(headerLC) === -1) {
+          return
         }
+        headers[headerLC] = customHeaders[header]
+      })
+    }
+    addCustomHeaders(Util.extend(msg.headers || {}, this.config.headers))
 
-        var obj = getQueryAndUrl(msg, block, format, self.config);
-        var query = obj.query;
-        var url = this.config.url ? this.config.url + obj.url : obj.url;
-        var path = url;
-        if (!hasBody && query && query.length) {
-            path += "?" + query.join("&");
+    if (!headers['user-agent']) {
+      headers['user-agent'] = 'NodeJS HTTP Client'
+    }
+
+    if (!('accept' in headers)) {
+      headers['accept'] = this.acceptUrls[block.url] || this.config.requestMedia || this.constants.requestMedia
+    }
+
+    var options = {
+      host: host,
+      port: port,
+      path: path,
+      method: method,
+      headers: headers,
+      ca: ca,
+      family: this.config.family
+    }
+
+    if (agent) {
+      options.agent = agent
+    }
+
+    if (this.config.rejectUnauthorized !== undefined) {
+      options.rejectUnauthorized = this.config.rejectUnauthorized
+    }
+
+    if (this.debug) {
+      console.log('REQUEST: ', options)
+    }
+
+    function httpSendRequest () {
+      var reqModule
+      // Verbosity for WebPack compliance
+      if (self.config.followRedirects === false) {
+        reqModule = protocol === 'http' ? require('http') : require('https')
+      } else {
+        reqModule = protocol === 'http' ? require('follow-redirects/http') : require('follow-redirects/https')
+      }
+
+      var req = reqModule.request(options, function (res) {
+        if (self.debug) {
+          console.log('STATUS: ' + res.statusCode)
+          console.log('HEADERS: ' + JSON.stringify(res.headers))
         }
+        res.setEncoding('utf8')
+        var data = ''
+        res.on('data', function (chunk) {
+          data += chunk
+        })
+        res.on('error', function (err) {
+          callCallback(err)
+        })
+        res.on('end', function () {
+          if (res.statusCode >= 400 || res.statusCode < 10) {
+            callCallback(new error.HttpError(data, res.statusCode, res.headers))
+          } else {
+            res.data = data
+            callCallback(null, res)
+          }
+        })
+      })
 
-        var proxyUrl;
-        var agent = undefined;
-        if (this.config.proxy !== undefined) {
-            proxyUrl = this.config.proxy;
-        } else {
-            proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+      var timeout = (block.timeout !== undefined) ? block.timeout : self.config.timeout
+      if (timeout) {
+        req.setTimeout(timeout)
+      }
+
+      req.on('error', function (e) {
+        if (self.debug) {
+          console.log('problem with request: ' + e.message)
         }
-        if (proxyUrl) {
-            agent = new HttpsProxyAgent(proxyUrl);
+        callCallback(e.message)
+      })
+
+      req.on('timeout', function () {
+        if (self.debug) {
+          console.log('problem with request: timed out')
         }
-
-        var ca = this.config.ca;
-
-        var headers = {
-            "host": host,
-            "content-length": "0"
-        };
-        if (hasBody) {
-            if (format == "json") {
-                query = JSON.stringify(query);
-            } else if (format != "raw") {
-                query = query.join("&");
-            }
-            headers["content-length"] = Buffer.byteLength(query || '', "utf8");
-            headers["content-type"] = format == "json"
-                ? "application/json; charset=utf-8"
-                : format == "raw"
-                    ? "text/plain; charset=utf-8"
-                    : "application/x-www-form-urlencoded; charset=utf-8";
-        }
-        if (this.auth) {
-            var basic;
-            switch (this.auth.type) {
-                case "oauth":
-                    if (this.auth.token) {
-                        path += (path.indexOf("?") === -1 ? "?" : "&") +
-                            "access_token=" + encodeURIComponent(this.auth.token);
-                    } else {
-                        path += (path.indexOf("?") === -1 ? "?" : "&") +
-                            "client_id=" + encodeURIComponent(this.auth.key) +
-                            "&client_secret=" + encodeURIComponent(this.auth.secret);
-                    }
-                    break;
-                case "token":
-                    headers["Authorization"] = "token " + this.auth.token;
-                    break;
-                case "integration":
-                    headers["Authorization"] = "Bearer " + this.auth.token;
-                    headers["accept"] = "application/vnd.github.machine-man-preview+json"
-                    break;
-                case "basic":
-                    basic = new Buffer(this.auth.username + ":" + this.auth.password, "ascii").toString("base64");
-                    headers["Authorization"] = "Basic " + basic;
-                    break;
-                case "netrc":
-                    var auth = netrc()[host];
-                    if (!auth) {
-                        throw new Error("~/.netrc authentication type chosen but no credentials found for '" + host + "'");
-                    }
-                    basic = new Buffer(auth.login + ":" + auth.password, "ascii").toString("base64");
-                    headers["Authorization"] = "Basic " + basic;
-                default:
-                    break;
-            }
-        }
-
-        function callCallback(err, result) {
-            if (callback) {
-                var cb = callback;
-                callback = undefined;
-                cb(err, result);
-            }
-        }
-
-        function addCustomHeaders(customHeaders) {
-            Object.keys(customHeaders).forEach(function(header) {
-                var headerLC = header.toLowerCase();
-                if (self.requestHeaders.indexOf(headerLC) == -1) {
-                    return;
-                }
-                headers[headerLC] = customHeaders[header];
-            });
-        }
-        addCustomHeaders(Util.extend(msg.headers || {}, this.config.headers));
-
-        if (!headers["user-agent"]) {
-            headers["user-agent"] = "NodeJS HTTP Client";
-        }
-
-        if (!("accept" in headers)) {
-            headers["accept"] = this.acceptUrls[block.url] || this.config.requestMedia || this.constants.requestMedia;
-        }
-
-        var options = {
-            host: host,
-            port: port,
-            path: path,
-            method: method,
-            headers: headers,
-            ca: ca,
-            family: this.config.family
-        };
-
-        if (agent) {
-            options.agent = agent;
-        }
-
-        if (this.config.rejectUnauthorized !== undefined) {
-            options.rejectUnauthorized = this.config.rejectUnauthorized;
-        }
-
-        if (this.debug) {
-            console.log("REQUEST: ", options);
-        }
-
-        function httpSendRequest() {
-            // Verbosity for WebPack compliance
-            if (self.config.followRedirects === false) {
-                var reqModule = protocol == 'http' ? require('http') : require('https')
-            } else {
-                var reqModule = protocol == 'http' ? require('follow-redirects/http') : require('follow-redirects/https')
-            }
-
-            var req = reqModule.request(options, function(res) {
-                if (self.debug) {
-                    console.log("STATUS: " + res.statusCode);
-                    console.log("HEADERS: " + JSON.stringify(res.headers));
-                }
-                res.setEncoding("utf8");
-                var data = "";
-                res.on("data", function(chunk) {
-                    data += chunk;
-                });
-                res.on("error", function(err) {
-                    callCallback(err);
-                });
-                res.on("end", function() {
-                    if (res.statusCode >= 400 && res.statusCode < 600 || res.statusCode < 10) {
-                        callCallback(new error.HttpError(data, res.statusCode, res.headers));
-                    } else {
-                        res.data = data;
-                        callCallback(null, res);
-                    }
-                });
-            });
-
-            var timeout = (block.timeout !== undefined) ? block.timeout : self.config.timeout;
-            if (timeout) {
-                req.setTimeout(timeout);
-            }
-
-            req.on("error", function(e) {
-                if (self.debug) {
-                    console.log("problem with request: " + e.message);
-                }
-                callCallback(e.message);
-            });
-
-            req.on("timeout", function() {
-                if (self.debug) {
-                    console.log("problem with request: timed out");
-                }
-                req.abort();
-                callCallback(new error.GatewayTimeout());
-            });
+        req.abort()
+        callCallback(new error.GatewayTimeout())
+      })
 
             // write data to request body
-            if (hasBody && query && query.length) {
-                if (self.debug) {
-                    console.log("REQUEST BODY: " + query + "\n");
-                }
-                req.write(query + "\n");
-            }
+      if (hasBody && query && query.length) {
+        if (self.debug) {
+          console.log('REQUEST BODY: ' + query + '\n')
+        }
+        req.write(query + '\n')
+      }
 
-            if (block.hasFileBody) {
-              var stream = fs.createReadStream(msg.filePath);
-              stream.pipe(req);
-            } else {
-              req.end();
-            }
-        };
+      if (block.hasFileBody) {
+        var stream = fs.createReadStream(msg.filePath)
+        stream.pipe(req)
+      } else {
+        req.end()
+      }
+    };
 
-        if (hasFileBody) {
-            fs.stat(msg.filePath, function(err, stat) {
-                if (err) {
-                    callCallback(err);
-                } else {
-                    headers["content-length"] = stat.size;
-                    headers["content-type"] = mime.lookup(msg.name);
-                    httpSendRequest();
-                }
-            });
+    if (hasFileBody) {
+      fs.stat(msg.filePath, function (err, stat) {
+        if (err) {
+          callCallback(err)
         } else {
-            httpSendRequest();
+          headers['content-length'] = stat.size
+          headers['content-type'] = mime.lookup(msg.name)
+          httpSendRequest()
         }
-    };
-
-    this.sendError = function(err, block, msg, callback) {
-        if (this.debug) {
-            Util.log(err, block, msg, "error");
-        }
-        if (typeof err == "string") {
-            err = new error.InternalServerError(err);
-        }
-        if (callback && typeof(callback) === "function") {
-            callback(err);
-        }
-    };
-
-    this.handler = function(msg, block, callback) {
-        var self = this;
-        this.httpSend(msg, block, function(err, res) {
-            if (err) {
-                return self.sendError(err, msg, null, callback);
-            }
-
-            var ret;
-            try {
-                var data = res.data;
-
-                var contentType = res.headers["content-type"];
-                if (contentType && contentType.indexOf("application/json") !== -1) {
-                    data = res.data && JSON.parse(res.data);
-                }
-                ret = {data: data};
-            } catch (ex) {
-                if (callback) {
-                    callback(new error.InternalServerError(ex.message), res);
-                }
-                return;
-            }
-
-            if (!ret) {
-                ret = {};
-            }
-            ret.meta = {};
-            self.responseHeaders.forEach(function(header) {
-                if (res.headers[header]) {
-                    ret.meta[header] = res.headers[header];
-                }
-            });
-
-            if (callback) {
-                callback(null, ret);
-            }
-        });
+      })
+    } else {
+      httpSendRequest()
     }
-}).call(Client.prototype);
+  }
+
+  this.sendError = function (err, block, msg, callback) {
+    if (this.debug) {
+      Util.log(err, block, msg, 'error')
+    }
+    if (typeof err === 'string') {
+      err = new error.InternalServerError(err)
+    }
+    if (callback && typeof (callback) === 'function') {
+      callback(err)
+    }
+  }
+
+  this.handler = function (msg, block, callback) {
+    var self = this
+    this.httpSend(msg, block, function (err, res) {
+      if (err) {
+        return self.sendError(err, msg, null, callback)
+      }
+
+      var ret
+      try {
+        var data = res.data
+
+        var contentType = res.headers['content-type']
+        if (contentType && contentType.indexOf('application/json') !== -1) {
+          data = res.data && JSON.parse(res.data)
+        }
+        ret = {data: data}
+      } catch (ex) {
+        if (callback) {
+          callback(new error.InternalServerError(ex.message), res)
+        }
+        return
+      }
+
+      if (!ret) {
+        ret = {}
+      }
+      ret.meta = {}
+      self.responseHeaders.forEach(function (header) {
+        if (res.headers[header]) {
+          ret.meta[header] = res.headers[header]
+        }
+      })
+
+      if (callback) {
+        callback(null, ret)
+      }
+    })
+  }
+}).call(Client.prototype)

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,17 +1,19 @@
-"use strict";
+'use strict'
 
-var Promise = global.Promise || null;
+var Promise = global.Promise || null
 
+/* eslint-disable no-new */
 if (isFunction(Promise)) {
-    new Promise(function(resolver) {
-        if (!isFunction(resolver)) {
-            Promise = null;
-        }
-    });
+  new Promise(function (resolve) {
+    if (!isFunction(resolve)) {
+      Promise = null
+    }
+  })
 }
+/* eslint-enable no-new */
 
-module.exports = Promise;
+module.exports = Promise
 
-function isFunction(x) {
-    return typeof x === "function";
+function isFunction (x) {
+  return typeof x === 'function'
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -9,7 +9,7 @@
  *  Author: Mike de Boer <mike@c9.io>
  **/
 
-var Util = require("util");
+var Util = require('util')
 
 /**
  *  Util#extend(dest, src, noOverwrite) -> Object
@@ -21,14 +21,14 @@ var Util = require("util");
  *  `noOverwrite` argument is set to to `true`, the value of a property in `src`
  *  will not be overwritten if it already exists.
  **/
-exports.extend = function(dest, src, noOverwrite) {
-    for (var prop in src) {
-        if (!noOverwrite || typeof dest[prop] == "undefined") {
-            dest[prop] = src[prop];
-        }
+exports.extend = function (dest, src, noOverwrite) {
+  for (var prop in src) {
+    if (!noOverwrite || typeof dest[prop] === 'undefined') {
+      dest[prop] = src[prop]
     }
-    return dest;
-};
+  }
+  return dest
+}
 
 /**
  *  Util#escapeRegExp(str) -> String
@@ -37,9 +37,9 @@ exports.extend = function(dest, src, noOverwrite) {
  *  Escapes characters inside a string that will an error when it is used as part
  *  of a regex upon instantiation like in `new RegExp("[0-9" + str + "]")`
  **/
-exports.escapeRegExp = function(str) {
-    return str.replace(/([.*+?^${}()|[\]\/\\])/g, '\\$1');
-};
+exports.escapeRegExp = function (str) {
+  return str.replace(/([.*+?^${}()|[\]/\\])/g, '\\$1')
+}
 
 /**
  *  Util#toCamelCase(str, [upper]) -> String
@@ -54,15 +54,15 @@ exports.escapeRegExp = function(str) {
  *      Util.toCamelCase("why U no-work"); // returns 'whyUNoWork'
  *      Util.toCamelCase("I U no-work", true); // returns 'WhyUNoWork'
  **/
-exports.toCamelCase = function(str, upper) {
-    str = str.toLowerCase().replace(/(?:(^.)|(\s+.)|(-.))/g, function(match) {
-        return match.charAt(match.length - 1).toUpperCase();
-    });
-    if (upper) {
-        return str;
-    }
-    return str.charAt(0).toLowerCase() + str.substr(1);
-};
+exports.toCamelCase = function (str, upper) {
+  str = str.toLowerCase().replace(/(?:(^.)|(\s+.)|(-.))/g, function (match) {
+    return match.charAt(match.length - 1).toUpperCase()
+  })
+  if (upper) {
+    return str
+  }
+  return str.charAt(0).toLowerCase() + str.substr(1)
+}
 
 /**
  *  Util#isTrue(c) -> Boolean
@@ -75,9 +75,9 @@ exports.toCamelCase = function(str, upper) {
  *
  *  Determines whether a string is true in the html attribute sense.
  **/
-exports.isTrue = function(c){
-    return (c === true || c === "true" || c === "on" || typeof c == "number" && c > 0 || c === "1");
-};
+exports.isTrue = function (c) {
+  return (c === true || c === 'true' || c === 'on' || (typeof c === 'number' && c > 0) || c === '1')
+}
 
 /**
  *  Util#isFalse(c) -> Boolean
@@ -90,17 +90,17 @@ exports.isTrue = function(c){
  *
  *  Determines whether a string is false in the html attribute sense.
  **/
-exports.isFalse = function(c){
-    return (c === false || c === "false" || c === "off" || c === 0 || c === "0");
-};
+exports.isFalse = function (c) {
+  return (c === false || c === 'false' || c === 'off' || c === 0 || c === '0')
+}
 
 var levels = {
-    "info":  ["\u001b[90m", "\u001b[39m"], // grey
-    "error": ["\u001b[31m", "\u001b[39m"], // red
-    "fatal": ["\u001b[35m", "\u001b[39m"], // magenta
-    "exit":  ["\u001b[36m", "\u001b[39m"]  // cyan
-};
-var _slice = Array.prototype.slice;
+  'info': ['\u001b[90m', '\u001b[39m'], // grey
+  'error': ['\u001b[31m', '\u001b[39m'], // red
+  'fatal': ['\u001b[35m', '\u001b[39m'], // magenta
+  'exit': ['\u001b[36m', '\u001b[39m']  // cyan
+}
+var _slice = Array.prototype.slice
 
 /**
  *  Util#log(arg1, [arg2], [type]) -> null
@@ -123,21 +123,21 @@ var _slice = Array.prototype.slice;
  * final argument. If the type can not be found, this last/ final argument will be
  * regarded as yet another message.
  **/
-exports.log = function() {
-    var args = _slice.call(arguments);
-    var lastArg = args[args.length - 1];
+exports.log = function () {
+  var args = _slice.call(arguments)
+  var lastArg = args[args.length - 1]
 
-    var level = levels[lastArg] ? args.pop() : "info";
-    if (!args.length) {
-        return;
-    }
+  var level = levels[lastArg] ? args.pop() : 'info'
+  if (!args.length) {
+    return
+  }
 
-    var msg = args.map(function(arg) {
-        return typeof arg != "string" ? Util.inspect(arg) : arg;
-    }).join(" ");
-    var pfx = levels[level][0] + "[" + level + "]" + levels[level][1];
+  var msg = args.map(function (arg) {
+    return typeof arg !== 'string' ? Util.inspect(arg) : arg
+  }).join(' ')
+  var pfx = levels[level][0] + '[' + level + ']' + levels[level][1]
 
-    msg.split("\n").forEach(function(line) {
-        console.log(pfx + " " + line);
-    });
-};
+  msg.split('\n').forEach(function (line) {
+    console.log(pfx + ' ' + line)
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,29 @@
         "negotiator": "0.6.1"
       }
     },
+    "acorn": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
     "agent-base": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
@@ -39,6 +62,34 @@
         "semver": "5.0.3"
       }
     },
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
+    },
+    "ajv-keywords": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
     "ansi-styles": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
@@ -46,6 +97,15 @@
       "dev": true,
       "requires": {
         "color-convert": "1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -90,6 +150,21 @@
       "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
       "dev": true
     },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
@@ -97,11 +172,74 @@
       "dev": true,
       "optional": true
     },
+    "array.prototype.find": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
+      "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.8.2"
+      }
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
     "assertion-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
+    },
+    "async": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -180,6 +318,21 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
     "chai": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
@@ -211,6 +364,12 @@
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
     "cli-color": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz",
@@ -220,6 +379,39 @@
       "requires": {
         "es5-ext": "0.8.2"
       }
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
+    },
+    "cli-spinners": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
+      "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY=",
+      "dev": true
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.0",
@@ -249,6 +441,49 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
     "content-disposition": {
@@ -295,6 +530,27 @@
         "which": "1.3.0"
       }
     },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.35"
+      },
+      "dependencies": {
+        "es5-ext": {
+          "version": "0.10.35",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
+          "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+          "dev": true,
+          "requires": {
+            "es6-iterator": "2.0.1",
+            "es6-symbol": "3.1.1"
+          }
+        }
+      }
+    },
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
@@ -302,6 +558,12 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "debug-log": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+      "dev": true
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -318,6 +580,12 @@
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
     "define-properties": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
@@ -326,6 +594,35 @@
       "requires": {
         "foreach": "2.0.5",
         "object-keys": "1.0.11"
+      }
+    },
+    "deglob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.0.tgz",
+      "integrity": "sha1-TUSr4W7zLHebSXK9FBqAMlApoUo=",
+      "dev": true,
+      "requires": {
+        "find-root": "1.1.0",
+        "glob": "7.1.2",
+        "ignore": "3.3.5",
+        "pkg-config": "1.1.1",
+        "run-parallel": "1.1.6",
+        "uniq": "1.0.1"
+      }
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
       }
     },
     "depd": {
@@ -354,6 +651,16 @@
       "optional": true,
       "requires": {
         "heap": "0.2.6"
+      }
+    },
+    "doctrine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
       }
     },
     "dotenv": {
@@ -444,6 +751,126 @@
       "dev": true,
       "optional": true
     },
+    "es6-iterator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-symbol": "3.1.1"
+      },
+      "dependencies": {
+        "es5-ext": {
+          "version": "0.10.35",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
+          "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+          "dev": true,
+          "requires": {
+            "es6-iterator": "2.0.1",
+            "es6-symbol": "3.1.1"
+          }
+        }
+      }
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.1",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      },
+      "dependencies": {
+        "es5-ext": {
+          "version": "0.10.35",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
+          "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+          "dev": true,
+          "requires": {
+            "es6-iterator": "2.0.1",
+            "es6-symbol": "3.1.1"
+          }
+        }
+      }
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      },
+      "dependencies": {
+        "es5-ext": {
+          "version": "0.10.35",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
+          "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+          "dev": true,
+          "requires": {
+            "es6-iterator": "2.0.1",
+            "es6-symbol": "3.1.1"
+          }
+        }
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35"
+      },
+      "dependencies": {
+        "es5-ext": {
+          "version": "0.10.35",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
+          "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+          "dev": true,
+          "requires": {
+            "es6-iterator": "2.0.1",
+            "es6-symbol": "3.1.1"
+          }
+        }
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      },
+      "dependencies": {
+        "es5-ext": {
+          "version": "0.10.35",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
+          "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+          "dev": true,
+          "requires": {
+            "es6-iterator": "2.0.1",
+            "es6-symbol": "3.1.1"
+          }
+        }
+      }
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -456,11 +883,283 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "escope": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
+    },
+    "eslint": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.8",
+        "doctrine": "2.0.0",
+        "escope": "3.6.0",
+        "espree": "3.5.1",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.5",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.16.1",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.10.0",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.7.8",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-config-standard": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz",
+      "integrity": "sha1-wGHk0GbzedwXzVYsZOgZtN1FRZE=",
+      "dev": true
+    },
+    "eslint-config-standard-jsx": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.2.tgz",
+      "integrity": "sha512-F8fRh2WFnTek7dZH9ZaE0PCBwdVGkwVWZmizla/DDNOmg7Tx6B/IlK5+oYpiX29jpu73LszeJj5i1axEZv6VMw==",
+      "dev": true
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
+      "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "object-assign": "4.1.1",
+        "resolve": "1.4.0"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "pkg-dir": "1.0.0"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz",
+      "integrity": "sha1-crowb60wXWfEgWNIpGmaQimsi04=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1",
+        "contains-path": "0.1.0",
+        "debug": "2.6.8",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "0.2.3",
+        "eslint-module-utils": "2.1.1",
+        "has": "1.0.1",
+        "lodash.cond": "4.5.2",
+        "minimatch": "3.0.4",
+        "pkg-up": "1.0.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-4.2.3.tgz",
+      "integrity": "sha512-vIUQPuwbVYdz/CYnlTLsJrRy7iXHQjdEe5wz0XhhdTym3IInM/zZLlPf9nZ2mThsH0QcsieCOWs2vOeCy/22LQ==",
+      "dev": true,
+      "requires": {
+        "ignore": "3.3.5",
+        "minimatch": "3.0.4",
+        "object-assign": "4.1.1",
+        "resolve": "1.4.0",
+        "semver": "5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz",
+      "integrity": "sha1-ePu2/+BHIBYnVp6FpsU3OvKmj8o=",
+      "dev": true
+    },
+    "eslint-plugin-react": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
+      "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
+      "dev": true,
+      "requires": {
+        "array.prototype.find": "2.0.4",
+        "doctrine": "1.5.0",
+        "has": "1.0.1",
+        "jsx-ast-utils": "1.4.1",
+        "object.assign": "4.0.4"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-standard": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
+      "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
+      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+      "dev": true,
+      "requires": {
+        "acorn": "5.1.2",
+        "acorn-jsx": "3.0.1"
+      }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35"
+      },
+      "dependencies": {
+        "es5-ext": {
+          "version": "0.10.35",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
+          "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+          "dev": true,
+          "requires": {
+            "es6-iterator": "2.0.1",
+            "es6-symbol": "3.1.1"
+          }
+        }
+      }
     },
     "event-stream": {
       "version": "3.3.4",
@@ -483,6 +1182,12 @@
       "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
       "dev": true,
       "optional": true
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
@@ -579,6 +1284,32 @@
         }
       }
     },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
+      }
+    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -626,6 +1357,34 @@
             "ms": "2.0.0"
           }
         }
+      }
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
       }
     },
     "follow-redirects": {
@@ -691,10 +1450,31 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
       "dev": true
     },
     "glob": {
@@ -702,7 +1482,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -771,6 +1550,26 @@
         }
       }
     },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -796,6 +1595,15 @@
       "dev": true,
       "requires": {
         "function-bind": "1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
       }
     },
     "has-flag": {
@@ -883,6 +1691,18 @@
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
     },
+    "ignore": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -897,6 +1717,60 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.2.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.4",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "interpret": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
+      "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
       "dev": true
     },
     "ipaddr.js": {
@@ -970,6 +1844,15 @@
       "dev": true,
       "optional": true
     },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
     "is-glob": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
@@ -980,6 +1863,18 @@
         "is-extglob": "2.1.1"
       }
     },
+    "is-my-json-valid": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -988,6 +1883,30 @@
       "optional": true,
       "requires": {
         "kind-of": "3.2.2"
+      }
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
       }
     },
     "is-posix-bracket": {
@@ -1004,6 +1923,12 @@
       "dev": true,
       "optional": true
     },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -1011,6 +1936,15 @@
       "dev": true,
       "requires": {
         "has": "1.0.1"
+      }
+    },
+    "is-resolvable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
       }
     },
     "is-symbol": {
@@ -1023,8 +1957,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -1042,6 +1975,22 @@
         "isarray": "1.0.0"
       }
     },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
+    },
     "json-diff": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.5.2.tgz",
@@ -1052,6 +2001,15 @@
         "cli-color": "0.1.7",
         "difflib": "0.2.4",
         "dreamopt": "0.6.0"
+      }
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -1072,6 +2030,18 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "jsx-ast-utils": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
+      "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -1079,6 +2049,16 @@
       "dev": true,
       "requires": {
         "is-buffer": "1.1.5"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "load-json-file": {
@@ -1091,6 +2071,24 @@
         "parse-json": "2.2.0",
         "pify": "2.3.0",
         "strip-bom": "3.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
       }
     },
     "lodash": {
@@ -1133,6 +2131,12 @@
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
+    "lodash.cond": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
+      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
+      "dev": true
+    },
     "lodash.create": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
@@ -1143,6 +2147,12 @@
         "lodash._basecreate": "3.0.3",
         "lodash._isiterateecall": "3.0.9"
       }
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -1165,6 +2175,48 @@
         "lodash._getnative": "3.9.1",
         "lodash.isarguments": "3.1.0",
         "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.range": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.range/-/lodash.range-3.2.0.tgz",
+      "integrity": "sha1-9GHliPZmg/fq3q3lE+OKaaVloV0=",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "lru-cache": {
@@ -1279,6 +2331,12 @@
         "mime-db": "1.30.0"
       }
     },
+    "mimic-fn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -1363,6 +2421,18 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz",
       "integrity": "sha1-QCj3d4sXcIpImTCm5SrDvKDaQdA=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "negotiator": {
@@ -1475,11 +2545,34 @@
         "string.prototype.padend": "3.0.0"
       }
     },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true
+    },
+    "object.assign": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
+      "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.1",
+        "object-keys": "1.0.11"
+      }
     },
     "object.omit": {
       "version": "2.0.1",
@@ -1508,6 +2601,114 @@
       "dev": true,
       "requires": {
         "wrappy": "1.0.2"
+      }
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "ora": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-1.3.0.tgz",
+      "integrity": "sha1-gAeN0rkqk0r2ajrXKluRBpTt5Ro=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "2.1.0",
+        "cli-spinners": "1.1.0",
+        "log-symbols": "1.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "2.0.0"
+          }
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "2.0.1",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+      "dev": true
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "1.1.0"
       }
     },
     "parse-glob": {
@@ -1556,10 +2757,31 @@
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
       "dev": true
     },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "path-to-regexp": {
@@ -1599,12 +2821,101 @@
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "pkg-conf": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.0.0.tgz",
+      "integrity": "sha1-BxyHZQQDvM+5xif1h1G/5HwGcnk=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0",
+        "load-json-file": "2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
+      }
+    },
+    "pkg-config": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
+      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
+      "dev": true,
+      "requires": {
+        "debug-log": "1.0.1",
+        "find-root": "1.1.0",
+        "xtend": "4.0.1"
+      }
+    },
+    "pkg-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      }
+    },
+    "pkg-up": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
+      "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      }
+    },
+    "pluralize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true,
       "optional": true
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true
     },
     "propagate": {
       "version": "0.4.0",
@@ -1739,6 +3050,26 @@
         }
       }
     },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.4.0"
+      }
+    },
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
@@ -1769,6 +3100,16 @@
       "dev": true,
       "optional": true
     },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
+    },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -1776,12 +3117,66 @@
       "dev": true,
       "optional": true
     },
+    "resolve": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "run-async": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
+      }
+    },
+    "run-parallel": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
+      "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk=",
+      "dev": true
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "semver": {
       "version": "5.0.3",
@@ -1873,6 +3268,29 @@
         "jsonify": "0.0.0"
       }
     },
+    "shelljs": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.0.4",
+        "rechoir": "0.6.2"
+      }
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
@@ -1903,6 +3321,79 @@
         "through": "2.3.8"
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "standard": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-10.0.3.tgz",
+      "integrity": "sha512-JURZ+85ExKLQULckDFijdX5WHzN6RC7fgiZNSV4jFQVo+3tPoQGHyBrGekye/yf0aOfb4210EM5qPNlc2cRh4w==",
+      "dev": true,
+      "requires": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-config-standard-jsx": "4.0.2",
+        "eslint-plugin-import": "2.2.0",
+        "eslint-plugin-node": "4.2.3",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-react": "6.10.3",
+        "eslint-plugin-standard": "3.0.1",
+        "standard-engine": "7.0.0"
+      }
+    },
+    "standard-engine": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-7.0.0.tgz",
+      "integrity": "sha1-67d7nI/CyBZf+jU72Rug3/Qa9pA=",
+      "dev": true,
+      "requires": {
+        "deglob": "2.1.0",
+        "get-stdin": "5.0.1",
+        "minimist": "1.2.0",
+        "pkg-conf": "2.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "standard-markdown": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/standard-markdown/-/standard-markdown-4.0.2.tgz",
+      "integrity": "sha512-h+WTmoGN0qmse8I1VX8VD6V5JeVLXZOPQltvxQP9FfSpSl6RmKYMLTUQ2j/QhdmsdxQKDqulZF/Bf8oEnttIQA==",
+      "dev": true,
+      "requires": {
+        "async": "2.5.0",
+        "commander": "2.9.0",
+        "globby": "6.1.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.range": "3.2.0",
+        "ora": "1.3.0",
+        "standard": "10.0.3"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        }
+      }
+    },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -1923,6 +3414,17 @@
       "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
       "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8="
     },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
     "string.prototype.padend": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
@@ -1940,10 +3442,25 @@
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "supports-color": {
@@ -1955,11 +3472,106 @@
         "has-flag": "2.0.0"
       }
     },
+    "table": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "tryit": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "type-detect": {
       "version": "4.0.3",
@@ -1977,10 +3589,37 @@
         "mime-types": "2.1.17"
       }
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "utils-merge": {
@@ -2027,13 +3666,27 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -32,11 +32,14 @@
     "chai": "^4.1.2",
     "mocha": "^3.5.3",
     "mustache": "^2.2.1",
-    "npm-run-all": "^4.1.1"
+    "npm-run-all": "^4.1.1",
+    "standard": "^10.0.3",
+    "standard-markdown": "^4.0.2"
   },
   "main": "lib",
   "types": "lib/index.d.ts",
   "scripts": {
+    "pretest": "standard && standard-markdown",
     "test": "mocha test/**/*-test.js",
     "build": "npm-run-all build:*",
     "build:flow": "node lib/generateFlowTypes",


### PR DESCRIPTION
This PR updates the codebase to use [standard](http://ghub.io/standard)-style JavaScript.

Notes:

- Added `standard` and `standard-markdown` which lints js snippets in markdown files.
- Added linting as part of `npm test` script to maintain consistency moving forward.
- Auto-fixed a bunch of stuff with `standard --fix`
- Hand-fixed the rest.
- Sprinkled `eslint-disable` in a handful of places to avoid breaking anything.

cc @gr2m @bkeepers @feross