### PR TITLE
adapt for mime@2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -848,7 +848,7 @@ var Client = module.exports = function (config) {
           callCallback(err)
         } else {
           headers['content-length'] = stat.size
-          headers['content-type'] = mime.lookup(msg.name)
+          headers['content-type'] = mime.getType(msg.name)
           httpSendRequest()
         }
       })


### PR DESCRIPTION
mime.lookup() is now mime.getType(). Closes #625.

I have a test locally that confirms the fix, the test is part of another upcoming PR for #624