### PR TITLE
Fixed: Routes.json validation rules for columns and cards moves.

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -3292,9 +3292,9 @@
                 "position": {
                     "type": "String",
                     "required": true,
-                    "validation": "^(top|bottom|after:\\d)$",
+                    "validation": "^(top|bottom|after:\\d+)$",
                     "invalidmsg": "",
-                    "description": "Can be one of top, bottom, or after:<column-id>, where <column-id> is the id value of a column in the same project."
+                    "description": "Can be one of top, bottom, or after:<card-id>, where <card-id> is the id value of a card in the same project."
                 },
                 "column_id": {
                     "type": "String",
@@ -3356,7 +3356,7 @@
                 "position": {
                     "type": "String",
                     "required": true,
-                    "validation": "^(first|last|after:\\d)$",
+                    "validation": "^(first|last|after:\\d+)$",
                     "invalidmsg": "",
                     "description": "Can be one of first, last, or after:<column-id>, where <column-id> is the id value of a column in the same project."
                 }


### PR DESCRIPTION
- fixed routes.json validation for project cards and columns
- "move-project-card" description typo

```
github.projects.moveProjectCard({ position: 'after:3456', id: 1234, column_id: 100200  });
```

Did not work. It was issue with RegEx 
- `\\d` -> `\\d+`
- `^(top|bottom|after:\\d)$` -> `^(top|bottom|after:\\d+)$`.