### PR TITLE
github.repos.uploadAsset(): adapt to specification

### DIFF
--- a/lib/definitions.json
+++ b/lib/definitions.json
@@ -456,6 +456,27 @@
             "validation": "",
             "invalidmsg": "",
             "description": "Logins for Users to assign to this issue. NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise."
+        },
+        "url": {
+            "type": "String",
+            "required": true,
+            "validation": "",
+            "invalidmsg": "",
+            "description": "Dynamic URL for release asset uploads returned by the release’s API response."
+        },
+        "contentType": {
+            "type": "String",
+            "required": true,
+            "validation": "",
+            "invalidmsg": "",
+            "description": "The content type of a release asset upload."
+        },
+        "contentLength": {
+            "type": "Number",
+            "required": true,
+            "validation": "",
+            "invalidmsg": "",
+            "description": "Size of release asset upload in bytes."
         }
     },
     "acceptTree": {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,8 @@
 'use strict'
 
-var fs = require('fs')
-
 var HttpsProxyAgent = require('https-proxy-agent')
-var mime = require('mime')
 var toCamelCase = require('lodash/camelCase')
+var urlTemplate = require('url-template')
 
 var error = require('./error')
 var Url = require('url')
@@ -547,9 +545,20 @@ var Client = module.exports = function (config) {
 
   function getQueryAndUrl (msg, def, format, config) {
     var url = def.url
+
+    if (msg.url) {
+      url = Url.parse(urlTemplate.parse(msg.url).expand(msg), true)
+
+      return {
+        url: url.path,
+        host: url.host
+      }
+    }
+
     if (config.pathPrefix && url.indexOf(config.pathPrefix) !== 0) {
       url = config.pathPrefix + def.url
     }
+
     var ret = {}
     if (!def || !def.params) {
       ret.url = url
@@ -557,11 +566,6 @@ var Client = module.exports = function (config) {
     }
 
     Object.keys(def.params).forEach(function (paramName) {
-      // do not send filePath as query argument
-      if (paramName === 'filePath') {
-        return
-      }
-
       paramName = paramName.replace(/^[$]+/, '')
       if (!(paramName in msg)) {
         return
@@ -618,6 +622,7 @@ var Client = module.exports = function (config) {
       }
     })
     ret.url = url
+
     return ret
   }
 
@@ -636,24 +641,15 @@ var Client = module.exports = function (config) {
     var self = this
     var method = block.method.toLowerCase()
     var hasFileBody = block.hasFileBody
-    var hasBody = !hasFileBody && (typeof (msg.body) !== 'undefined' || 'head|get|delete'.indexOf(method) === -1)
+    var hasBody = typeof (msg.body) !== 'undefined' || 'head|get|delete'.indexOf(method) === -1
     var format = getRequestFormat.call(this, hasBody, block)
     var protocol = this.config.protocol || DEFINITIONS.constants.protocol || 'http'
     var port = this.config.port || (protocol === 'https' ? 443 : 80)
-    var host = block.host || this.config.host || DEFINITIONS.constants.host
+    var host = this.config.host || DEFINITIONS.constants.host
 
-        // Edge case for github enterprise uploadAsset:
-        // 1) In public api, host changes to uploads.github.com. In enterprise, the host remains the same.
-        // 2) In enterprise, the pathPrefix changes from: /api/v3 to /api/uploads.
-    if ((this.config.host && this.config.host !== DEFINITIONS.constants.host) &&
-            (block.host && block.host === 'uploads.github.com')) {  // enterprise uploadAsset
-      host = this.config.host
-      this.config.pathPrefix = '/api/uploads'
-    }
-
-    var obj = getQueryAndUrl(msg, block, format, self.config)
-    var query = obj.query
-    var url = this.config.url ? this.config.url + obj.url : obj.url
+    var queryAndUrl = getQueryAndUrl(msg, block, format, self.config)
+    var query = queryAndUrl.query
+    var url = this.config.url ? this.config.url + queryAndUrl.url : queryAndUrl.url
     var path = url
     if (!hasBody && query && query.length) {
       path += '?' + query.join('&')
@@ -672,11 +668,14 @@ var Client = module.exports = function (config) {
 
     var ca = this.config.ca
 
-    var headers = {
-      'host': host,
-      'content-length': '0'
-    }
-    if (hasBody) {
+    var headers = {}
+
+    if (hasFileBody) {
+      headers['content-length'] = msg.contentLength
+      headers['content-type'] = msg.contentType
+      delete msg.contentLength
+      delete msg.contentType
+    } else if (hasBody) {
       if (format === 'json') {
         query = JSON.stringify(query)
       } else if (format !== 'raw') {
@@ -689,6 +688,7 @@ var Client = module.exports = function (config) {
                     ? 'text/plain; charset=utf-8'
                     : 'application/x-www-form-urlencoded; charset=utf-8'
     }
+
     if (this.auth) {
       var basic
       switch (this.auth.type) {
@@ -735,6 +735,7 @@ var Client = module.exports = function (config) {
         headers[headerLC] = customHeaders[header]
       })
     }
+
     addCustomHeaders(Object.assign(msg.headers || {}, this.config.headers))
 
     if (!headers['user-agent']) {
@@ -745,8 +746,10 @@ var Client = module.exports = function (config) {
       headers['accept'] = this.acceptUrls[block.url] || this.config.requestMedia || DEFINITIONS.constants.requestMedia
     }
 
+    headers.host = queryAndUrl.host || host
+
     var options = {
-      host: host,
+      host: headers.host,
       port: port,
       path: path,
       method: method,
@@ -827,27 +830,14 @@ var Client = module.exports = function (config) {
         req.write(query + '\n')
       }
 
-      if (block.hasFileBody) {
-        var stream = fs.createReadStream(msg.filePath)
-        stream.pipe(req)
-      } else {
-        req.end()
+      if (hasFileBody) {
+        req.write(Buffer.from(msg.file))
       }
+
+      req.end()
     };
 
-    if (hasFileBody) {
-      fs.stat(msg.filePath, function (err, stat) {
-        if (err) {
-          callCallback(err)
-        } else {
-          headers['content-length'] = stat.size
-          headers['content-type'] = mime.getType(msg.name)
-          httpSendRequest()
-        }
-      })
-    } else {
-      httpSendRequest()
-    }
+    httpSendRequest()
   }
 
   this.sendError = function (err, block, msg, callback) {

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -6055,21 +6055,42 @@
             "description": "List assets for a release."
         },
         "upload-asset": {
-            "url": "/repos/:owner/:repo/releases/:id/assets",
+            "url": "/:url",
             "method": "POST",
-            "host": "uploads.github.com",
             "hasFileBody": true,
+            "headers": {
+              "Content-Type": ":contentType",
+              "Content-Length": ":contentLength"
+            },
             "timeout": 0,
             "params": {
-                "$owner": null,
-                "$repo": null,
-                "$id": null,
-                "filePath": {
+                "$url": {
                     "type": "String",
                     "required": true,
                     "validation": "",
                     "invalidmsg": "",
-                    "description": "The file path of the asset."
+                    "description": "This endpoint makes use of a Hypermedia relation (https://developer.github.com/v3/#hypermedia) to determine which URL to access. This endpoint is provided by a URI template in the release's API response (https://developer.github.com/v3/repos/releases/#get-a-single-release). You need to use an HTTP client which supports SNI (https://en.wikipedia.org/wiki/Server_Name_Indication) to make calls to this endpoint."
+                },
+                "file": {
+                    "type": "Object",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "A file read stream, a String or a Buffer."
+                },
+                "$contentType": {
+                    "type": "String",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "The content type of the asset. This should be set in the Header. Example: 'application/zip'. For a list of acceptable types, refer this list of media types (https://www.iana.org/assignments/media-types/media-types.xhtml)"
+                },
+                "$contentLength": {
+                    "type": "Number",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "File size in bytes."
                 },
                 "name": {
                     "type": "String",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dotenv": "^4.0.0",
     "https-proxy-agent": "^2.1.0",
     "lodash": "^4.17.4",
-    "mime": "^2.0.3"
+    "url-template": "^2.0.8"
   },
   "devDependencies": {
     "@octokit/fixtures": "^5.2.0",

--- a/test/integration/release-assets-test.js
+++ b/test/integration/release-assets-test.js
@@ -1,5 +1,3 @@
-const pathResolve = require('path').resolve
-
 const chai = require('chai')
 const fixtures = require('@octokit/fixtures')
 
@@ -23,7 +21,7 @@ describe('api.github.com', () => {
       token: '0000000000000000000000000000000000000001'
     })
 
-    githubUserA.repos.getReleaseByTag({
+    return githubUserA.repos.getReleaseByTag({
       owner: 'octokit-fixture-org',
       repo: 'release-assets',
       tag: 'v1.0.0'
@@ -33,10 +31,10 @@ describe('api.github.com', () => {
       releaseId = result.data.id
 
       return githubUserA.repos.uploadAsset({
-        owner: 'octokit-fixture-org',
-        repo: 'release-assets',
-        id: releaseId,
-        filePath: pathResolve(__dirname, 'test-upload.txt'),
+        url: result.data.upload_url,
+        file: 'Hello, world!\n',
+        contentType: 'text/plain',
+        contentLength: 14,
         name: 'test-upload.txt',
         label: 'test'
       })

--- a/test/integration/test-upload.txt
+++ b/test/integration/test-upload.txt
@@ -1,1 +1,0 @@
-Hello, world!


### PR DESCRIPTION
### Breaking change

The current implementation has the upload URL hard coded, while the specification says that it has to be received from the Release API endpoint:
https://developer.github.com/v3/repos/releases/#upload-a-release-asset

The new implementation also requires `contentType` as well as `contentLength`. The latter is not documented, but is required. The `filePath` option has been replaced with a `file` option which can be either a read stream, a buffer or a string.

Altogether, uploading an asset before worked like this:

```js
github.repos.getReleaseByTag({
  owner: 'octokit-fixture-org',
  repo: 'release-assets',
  tag: 'v1.0.0'
})

.then(result => {
  return github.repos.uploadAsset({
    owner: 'octokit-fixture-org',
    repo: 'release-assets',
    id: result.data.id,
    filePath: pathResolve(__dirname, 'test-upload.txt'),
    name: 'test-upload.txt',
    label: 'test'
  })
})
```

Now it looks like this

```js
github.repos.getReleaseByTag({
  owner: 'octokit-fixture-org',
  repo: 'release-assets',
  tag: 'v1.0.0'
})

.then(result => {
  return github.repos.uploadAsset({
    url: result.data.upload_url,
    file: 'Hello, world!\n',
    contentType: 'text/plain',
    contentLength: 14,
    name: 'test-upload.txt',
    label: 'test'
  })
})
```

If you prefer a higher-level release asset upload library, have a look at https://github.com/gr2m/octokit-release-asset-upload