### PR TITLE
routes.json: add child team list route

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -2886,6 +2886,16 @@
             },
             "description": "List team members"
         },
+        "get-child-teams": {
+            "url": "/teams/:id/teams",
+            "method": "GET",
+            "params": {
+                "$id": null,
+                "$page": null,
+                "$per_page": null
+            },
+            "description": "List child teams"
+        },
         "get-team-membership": {
             "url": "/teams/:id/memberships/:username",
             "method": "GET",


### PR DESCRIPTION
Hello 👋! 

I was looking do some work with the GitHub API with regards to child teams, and I noticed that this route (thus, the accompanying method) seemed to be missing! 

It's present in the hellcat preview definition [here](https://github.com/octokit/node-github/blob/1e07daf8f7774d02cdd2b3dd8a01eaebd9694f3d/lib/definitions.json#L533), so it should work with just these changes.

This is my first contribution to this project, so I'm not sure what the culture is around testing and examples? Let me know if there's anything else that needs to be done to get this merge-ready 😄. 