### PR TITLE
Respect NO_PROXY environment variable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var HttpsProxyAgent = require('https-proxy-agent')
+var getProxyForUrl = require('proxy-from-env').getProxyForUrl
 var toCamelCase = require('lodash/camelCase')
 var urlTemplate = require('url-template')
 
@@ -619,7 +620,7 @@ var Client = module.exports = function (config) {
     if (this.config.proxy !== undefined) {
       proxyUrl = this.config.proxy
     } else {
-      proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY
+      proxyUrl = getProxyForUrl(url)
     }
 
     // proxy options will be removed: https://github.com/octokit/node-github/issues/656

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dotenv": "^4.0.0",
     "https-proxy-agent": "^2.1.0",
     "lodash": "^4.17.4",
+    "proxy-from-env": "^1.0.0",
     "url-template": "^2.0.8"
   },
   "devDependencies": {

--- a/test/integration/params-validations-test.js
+++ b/test/integration/params-validations-test.js
@@ -26,7 +26,8 @@ describe('params validations', () => {
 
   it('request error', () => {
     const github = new GitHub({
-      host: 'nope'
+      host: '127.0.0.1',
+      port: 8 // officially unassigned port. See https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers
     })
 
     return github.orgs.get({org: 'foo'})
@@ -34,7 +35,7 @@ describe('params validations', () => {
     .catch(error => {
       error.toJSON().should.deep.equal({
         code: '500',
-        message: 'getaddrinfo ENOTFOUND nope nope:443',
+        message: 'connect ECONNREFUSED 127.0.0.1:8',
         status: 'Internal Server Error'
       })
     })


### PR DESCRIPTION
This PR is addressing the same issue as #557, but delegates the logic to the well-tested [proxy-from-env](https://github.com/Rob--W/proxy-from-env) library.

I think this should be released as a patch that simply fixes an issue with the current support for environment variables.

I've also included a small fix to the tests. For some reason, `nope` on my MacOS High Sierra system resolves to one of my external IP addresses, which makes the test non-deterministic. I've changed it to attempt to connect to `127.0.0.1:8` which will reliably refuse a connection. Intriguingly, this is also a good test of the proxy handling.

closes #557