### PR TITLE
fix: CLI debug instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ github.authorization.create({
 
 ## DEBUG
 
-Set `DEBUG=node-github` for additional debug logs.
+Set `DEBUG=node-github*` for additional debug logs.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ github.authorization.create({
 
 ## DEBUG
 
-Set `DEBUG=node-github:*` for additional debug logs.
+Set `DEBUG=node-github` for additional debug logs.
 
 ## Tests
 


### PR DESCRIPTION
It seems the debug topic is always `node-github`, so the colon causes this not to match anything.