### PR TITLE
For getPageLinks(link), when link is undefined or null it will throw …

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -350,7 +350,7 @@ var Client = module.exports = function (config) {
   }
 
   function getPageLinks (link) {
-    link = link.link || link.meta.link || ''
+    link = (link && link.link) || (link && link.meta && link.meta.link) || ''
 
     var links = {}
 


### PR DESCRIPTION
…error.

This breaks at least two of my services. I think many other people have the same problem.