### PR TITLE
fix: correct typo in test/integration/lock-issue-test.js

### DIFF
--- a/test/integration/lock-issue-test.js
+++ b/test/integration/lock-issue-test.js
@@ -9,7 +9,7 @@ const it = mocha.it
 chai.should()
 
 describe('api.github.com', () => {
-  it('github.isues.{lock,unlock}()', () => {
+  it('github.issues.{lock,unlock}()', () => {
     const GitHubMock = fixtures.mock('api.github.com/lock-issue')
 
     const github = new GitHub()


### PR DESCRIPTION
Fixes https://github.com/octokit/node-github/issues/685 . :v:

`cc`: maintainers of `octokit/node-github` 👋  

