### PR TITLE
adds users.getInstallationRepos() to accept tree

### DIFF
--- a/lib/definitions.json
+++ b/lib/definitions.json
@@ -524,6 +524,7 @@
             "/apps/:app_slug",
             "/app/installations/:installation_id",
             "/user/installations",
+            "/user/installations/:installation_id/repositories",
             "/user/installations/:installation_id/repositories/:repository_id"
         ],
         "application/vnd.github.drax-preview+json": [


### PR DESCRIPTION
I'm currently getting the following error when trying to use `client.users.getInstallationRepos({ installation_id: id })`:

```
{"message":"If you would like to help us test the Integrations API during its preview period, you must specify a custom media type in the 'Accept' header. Please see the docs for full details.","documentation_url":"https://developer.github.com/v3"}
```

this patch adds the route to the accept tree so that the right `Accept` header is used.