### PR TITLE
Runs the index.d.ts though the typescript compiler on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ stages:
 
 jobs:
   include:
-    # test stage: run Node in all maintained versions. Run coverage only in the last
+    # test stage: run Node in all maintained versions. Run unique checks only in the last
     - node_js: 4
     - node_js: 6
     - node_js: 8
@@ -25,6 +25,8 @@ jobs:
       script:
         - npm run test
         - npm run coverage:upload
+        - npm run build:ts
+        - npm run validate:dts
     # release stage: run semantic release & update the docs
     - stage: release
       node_js: lts/*

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "postbuild:docs": "apidoc -i doc/ -o doc/",
     "build:flow": "node scripts/generate-flow-types",
     "build:ts": "node scripts/generate-typescript-types",
+    "validate:dts": "npx --package typescript tsc index.d.ts",
     "deploy-docs": "gh-pages-with-token -d doc",
     "semantic-release": "semantic-release"
   },


### PR DESCRIPTION
Runs the typescript compiler through the generated types on CI, so you will find out when it breaks - this should fail without a rebase on top of #703 