### PR TITLE
Fix typo in authentication example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ octokit.authenticate({
 octokit.authenticate({
   type: 'oauth',
   key: 'client_id',
-  secret: 'client_secert'
+  secret: 'client_secret'
 })
 
 // token (https://github.com/settings/tokens)


### PR DESCRIPTION
This fixes `client_secert` to `client_secret` in the readme.