### PR TITLE
Several fixes for custom errors

### DIFF
--- a/lib/plugins/endpoint-methods/validate.js
+++ b/lib/plugins/endpoint-methods/validate.js
@@ -3,7 +3,7 @@
 module.exports = validate
 
 const set = require('lodash/set')
-const errors = require('../../request/errors')
+const HttpError = require('../../request/http-error')
 
 function validate (endpointParams, options) {
   Object.keys(endpointParams).forEach(parameterName => {
@@ -24,26 +24,26 @@ function validate (endpointParams, options) {
 
     if ((parameter.required && !paramIsPresent) ||
         (parameter['allow-null'] === false && paramIsNull)) {
-      throw new errors.BadRequest(`Empty value for parameter '${parameterName}': ${value}`)
+      throw new HttpError(`Empty value for parameter '${parameterName}': ${value}`, 400)
     }
 
     if (parameter.enum) {
       if (parameter.enum.indexOf(value) === -1) {
-        throw new errors.BadRequest(`Invalid value for parameter '${parameterName}': ${value}`)
+        throw new HttpError(`Invalid value for parameter '${parameterName}': ${value}`, 400)
       }
     }
 
     if (parameter.validation) {
       const regex = new RegExp(parameter.validation)
       if (!regex.test(value)) {
-        throw new errors.BadRequest(`Invalid value for parameter '${parameterName}': ${value}`)
+        throw new HttpError(`Invalid value for parameter '${parameterName}': ${value}`, 400)
       }
     }
 
     if (expectedType === 'number') {
       value = parseInt(value, 10)
       if (isNaN(value)) {
-        throw new errors.BadRequest(`Invalid value for parameter '${parameterName}': ${options[parameterName]} is NaN`)
+        throw new HttpError(`Invalid value for parameter '${parameterName}': ${options[parameterName]} is NaN`, 400)
       }
     }
 
@@ -51,7 +51,7 @@ function validate (endpointParams, options) {
       try {
         value = JSON.parse(value)
       } catch (exception) {
-        throw new errors.BadRequest(`JSON parse error of value for parameter '${parameterName}': ${value}`)
+        throw new HttpError(`JSON parse error of value for parameter '${parameterName}': ${value}`, 400)
       }
     }
 

--- a/lib/plugins/pagination/get-page.js
+++ b/lib/plugins/pagination/get-page.js
@@ -1,6 +1,6 @@
 module.exports = getPage
 
-const errors = require('../../request/errors')
+const HttpError = require('../../request/http-error')
 const getPageLinks = require('./get-page-links')
 
 function getPage (octokit, link, which, headers, callback) {
@@ -12,7 +12,7 @@ function getPage (octokit, link, which, headers, callback) {
   const url = getPageLinks(link)[which]
 
   if (!url) {
-    const urlError = new errors.NotFound(`No ${which} page found`)
+    const urlError = new HttpError(`No ${which} page found`, 404)
     if (callback) {
       return callback(urlError)
     }

--- a/lib/request/errors.js
+++ b/lib/request/errors.js
@@ -31,7 +31,7 @@ exports.HttpError.prototype.toJSON = function () {
 Object.keys(STATUS_CODES).forEach(status => {
   const className = STATUS_CODES[status].replace(/\s/g, '')
   exports[className] = function (msg) {
-    exports.HttpError.call(this, msg, status)
+    exports.HttpError.call(this, msg, parseInt(status, 10))
     if (status >= 500) { Error.captureStackTrace(this, arguments.callee) } // eslint-disable-line
   }
 

--- a/lib/request/errors.js
+++ b/lib/request/errors.js
@@ -1,4 +1,4 @@
-const inherits = require('util').inherits
+'use strict'
 
 const STATUS_CODES = {
   304: 'Not Modified', // See PR #673 (https://github.com/octokit/rest.js/pull/673)
@@ -8,31 +8,35 @@ const STATUS_CODES = {
   504: 'Gateway Timeout'
 }
 
-exports.HttpError = function (message, code, headers) {
-  Error.captureStackTrace(this, this.constructor)
-  this.message = message
-  this.code = code
-  this.status = STATUS_CODES[code]
-  this.headers = headers
-}
-inherits(exports.HttpError, Error)
+module.exports.HttpError = class extends Error {
+  constructor (message, code, headers) {
+    super(message)
+    Error.captureStackTrace(this, this.constructor)
+    this.name = STATUS_CODES[code] ? STATUS_CODES[code].replace(/\s/g, '') : 'HttpError'
+    this.code = code
+    this.status = STATUS_CODES[code]
+    this.headers = headers
+  }
 
-exports.HttpError.prototype.toString = function () {
-  return this.message
-}
-exports.HttpError.prototype.toJSON = function () {
-  return {
-    code: this.code,
-    status: this.status,
-    message: this.message
+  toString () {
+    return this.message
+  }
+
+  toJSON () {
+    return {
+      code: this.code,
+      status: this.status,
+      message: this.message
+    }
   }
 }
 
 Object.keys(STATUS_CODES).forEach(status => {
   const className = STATUS_CODES[status].replace(/\s/g, '')
-  exports[className] = function (msg) {
-    exports.HttpError.call(this, msg, parseInt(status, 10))
+  module.exports[className] = class extends module.exports.HttpError {
+    constructor (message) {
+      super(message, parseInt(status, 10))
+      this.name = className
+    }
   }
-
-  inherits(exports[className], exports.HttpError)
 })

--- a/lib/request/errors.js
+++ b/lib/request/errors.js
@@ -9,7 +9,7 @@ const STATUS_CODES = {
 }
 
 exports.HttpError = function (message, code, headers) {
-  Error.call(this, message)
+  Error.captureStackTrace(this, this.constructor)
   this.message = message
   this.code = code
   this.status = STATUS_CODES[code]
@@ -32,7 +32,6 @@ Object.keys(STATUS_CODES).forEach(status => {
   const className = STATUS_CODES[status].replace(/\s/g, '')
   exports[className] = function (msg) {
     exports.HttpError.call(this, msg, parseInt(status, 10))
-    if (status >= 500) { Error.captureStackTrace(this, arguments.callee) } // eslint-disable-line
   }
 
   inherits(exports[className], exports.HttpError)

--- a/lib/request/http-error.js
+++ b/lib/request/http-error.js
@@ -8,11 +8,11 @@ const STATUS_CODES = {
   504: 'Gateway Timeout'
 }
 
-module.exports.HttpError = class extends Error {
+module.exports = class HttpError extends Error {
   constructor (message, code, headers) {
     super(message)
     Error.captureStackTrace(this, this.constructor)
-    this.name = STATUS_CODES[code] ? STATUS_CODES[code].replace(/\s/g, '') : 'HttpError'
+    this.name = 'HttpError'
     this.code = code
     this.status = STATUS_CODES[code]
     this.headers = headers
@@ -30,13 +30,3 @@ module.exports.HttpError = class extends Error {
     }
   }
 }
-
-Object.keys(STATUS_CODES).forEach(status => {
-  const className = STATUS_CODES[status].replace(/\s/g, '')
-  module.exports[className] = class extends module.exports.HttpError {
-    constructor (message) {
-      super(message, parseInt(status, 10))
-      this.name = className
-    }
-  }
-})

--- a/lib/request/request.js
+++ b/lib/request/request.js
@@ -11,7 +11,7 @@ const debug = require('debug')('octokit:rest')
 const isArrayBuffer = require('is-array-buffer')
 const isStream = require('is-stream')
 
-const errors = require('./errors')
+const HttpError = require('./http-error')
 
 function httpRequest (requestOptions) {
   requestOptions = Object.assign(
@@ -60,7 +60,7 @@ function httpRequest (requestOptions) {
 
       /* istanbul ignore next */
       response.on('error', (error) => {
-        reject(new errors.InternalServerError(error.message))
+        reject(new HttpError(error.message, 500))
       })
       response.on('end', () => {
         if (response.statusCode !== 304 && response.statusCode >= 301 && response.statusCode <= 307) {
@@ -70,7 +70,7 @@ function httpRequest (requestOptions) {
         }
 
         if (response.statusCode === 304 || response.statusCode >= 400 || response.statusCode < 10) {
-          reject(new errors.HttpError(data, response.statusCode, response.headers))
+          reject(new HttpError(data, response.statusCode, response.headers))
           return
         }
 
@@ -90,7 +90,7 @@ function httpRequest (requestOptions) {
     request.on('error', (error) => {
       if (aborted) return
       debug('REQUEST ERROR: ' + error.message)
-      reject(new errors.InternalServerError(error.message))
+      reject(new HttpError(error.message, 500))
     })
 
     if (requestOptions.timeout) {
@@ -100,7 +100,7 @@ function httpRequest (requestOptions) {
       debug('REQUEST ERROR: timed out')
       request.abort()
       aborted = true
-      reject(new errors.GatewayTimeout('Request timeout'))
+      reject(new HttpError('Request timeout', 504))
     })
 
     if (requestOptions.body) {

--- a/test/integration/params-validations-test.js
+++ b/test/integration/params-validations-test.js
@@ -17,7 +17,7 @@ describe('params validations', () => {
     .catch(error => {
       error.toString().should.equal('Empty value for parameter \'org\': undefined')
       error.toJSON().should.deep.equal({
-        code: '400',
+        code: 400,
         message: 'Empty value for parameter \'org\': undefined',
         status: 'Bad Request'
       })
@@ -34,7 +34,7 @@ describe('params validations', () => {
 
     .catch(error => {
       error.toJSON().should.deep.equal({
-        code: '500',
+        code: 500,
         message: 'connect ECONNREFUSED 127.0.0.1:8',
         status: 'Internal Server Error'
       })
@@ -48,7 +48,7 @@ describe('params validations', () => {
 
     .catch(error => {
       error.toJSON().should.deep.equal({
-        code: '400',
+        code: 400,
         message: 'Invalid value for parameter \'filter\': foo',
         status: 'Bad Request'
       })
@@ -62,7 +62,7 @@ describe('params validations', () => {
 
     .catch(error => {
       error.toJSON().should.deep.equal({
-        code: '400',
+        code: 400,
         message: 'Invalid value for parameter \'position\': foo',
         status: 'Bad Request'
       })
@@ -82,7 +82,7 @@ describe('params validations', () => {
 
     .catch(error => {
       error.toJSON().should.deep.equal({
-        code: '400',
+        code: 400,
         message: 'Invalid value for parameter \'position\': Age Ain’t Nothing is NaN',
         status: 'Bad Request'
       })
@@ -101,7 +101,7 @@ describe('params validations', () => {
 
     .catch(error => {
       error.toJSON().should.deep.equal({
-        code: '400',
+        code: 400,
         message: 'JSON parse error of value for parameter \'config\': I’m no Je-Son!',
         status: 'Bad Request'
       })

--- a/test/integration/request-errors-test.js
+++ b/test/integration/request-errors-test.js
@@ -24,6 +24,7 @@ describe('request errors', () => {
 
     .catch(error => {
       error.code.should.equal(504)
+      error.should.have.property('stack')
     })
   })
 
@@ -41,6 +42,25 @@ describe('request errors', () => {
 
     .catch(error => {
       error.code.should.equal(500)
+      error.should.have.property('stack')
+    })
+  })
+
+  it('404', () => {
+    nock('https://request-errors-test.com')
+      .get('/orgs/myorg')
+      .reply(404, 'not found')
+
+    const github = new GitHub({
+      host: 'request-errors-test.com',
+      timeout: 1000
+    })
+
+    return github.orgs.get({org: 'myorg'})
+
+    .catch(error => {
+      error.code.should.equal(404)
+      error.should.have.property('stack')
     })
   })
 })

--- a/test/integration/request-errors-test.js
+++ b/test/integration/request-errors-test.js
@@ -23,7 +23,7 @@ describe('request errors', () => {
     return github.orgs.get({org: 'myorg'})
 
     .catch(error => {
-      error.code.should.equal('504')
+      error.code.should.equal(504)
     })
   })
 
@@ -40,7 +40,7 @@ describe('request errors', () => {
     return github.orgs.get({org: 'myorg'})
 
     .catch(error => {
-      error.code.should.equal('500')
+      error.code.should.equal(500)
     })
   })
 })

--- a/test/integration/request-errors-test.js
+++ b/test/integration/request-errors-test.js
@@ -23,7 +23,7 @@ describe('request errors', () => {
     return github.orgs.get({org: 'myorg'})
 
     .catch(error => {
-      error.name.should.equal('GatewayTimeout')
+      error.name.should.equal('HttpError')
       error.code.should.equal(504)
       error.should.have.property('stack')
     })
@@ -42,7 +42,7 @@ describe('request errors', () => {
     return github.orgs.get({org: 'myorg'})
 
     .catch(error => {
-      error.name.should.equal('InternalServerError')
+      error.name.should.equal('HttpError')
       error.code.should.equal(500)
       error.should.have.property('stack')
     })
@@ -61,7 +61,7 @@ describe('request errors', () => {
     return github.orgs.get({org: 'myorg'})
 
     .catch(error => {
-      error.name.should.equal('NotFound')
+      error.name.should.equal('HttpError')
       error.code.should.equal(404)
       error.should.have.property('stack')
     })

--- a/test/integration/request-errors-test.js
+++ b/test/integration/request-errors-test.js
@@ -23,6 +23,7 @@ describe('request errors', () => {
     return github.orgs.get({org: 'myorg'})
 
     .catch(error => {
+      error.name.should.equal('GatewayTimeout')
       error.code.should.equal(504)
       error.should.have.property('stack')
     })
@@ -41,6 +42,7 @@ describe('request errors', () => {
     return github.orgs.get({org: 'myorg'})
 
     .catch(error => {
+      error.name.should.equal('InternalServerError')
       error.code.should.equal(500)
       error.should.have.property('stack')
     })
@@ -59,7 +61,27 @@ describe('request errors', () => {
     return github.orgs.get({org: 'myorg'})
 
     .catch(error => {
+      error.name.should.equal('NotFound')
       error.code.should.equal(404)
+      error.should.have.property('stack')
+    })
+  })
+
+  it('401', () => {
+    nock('https://request-errors-test.com')
+      .get('/orgs/myorg')
+      .reply(401)
+
+    const github = new GitHub({
+      host: 'request-errors-test.com',
+      timeout: 1000
+    })
+
+    return github.orgs.get({org: 'myorg'})
+
+    .catch(error => {
+      error.name.should.equal('HttpError')
+      error.code.should.equal(401)
       error.should.have.property('stack')
     })
   })

--- a/test/integration/smoke-test.js
+++ b/test/integration/smoke-test.js
@@ -122,7 +122,7 @@ describe('smoke', () => {
         github.getNextPage(result).catch(callback),
         new Promise(resolve => {
           github.getLastPage(result, { foo: 'bar' }, (error) => {
-            error.code.should.equal('404')
+            error.code.should.equal(404)
             resolve()
           })
         }),


### PR DESCRIPTION
### Set the error code as a number for all errors

`Object.keys()` return and `Array` of `String` even if the object keys are not quoted (a `property` in a JS `Object` is always a `String`). So in the following snippet when calling `exports.HttpError.call(this, msg, status)`, `status` is a `String`.

https://github.com/octokit/rest.js/blob/47204015c20ee88926f8a17276cbbc236af3bc6d/lib/request/errors.js#L31-L36

But in the following one, `response.statusCode` is a `Number`. 

https://github.com/octokit/rest.js/blob/47204015c20ee88926f8a17276cbbc236af3bc6d/lib/request/request.js#L73

As a result some errors are thrown with `code` being a `String` and some other as a `Number`.

This PR guarantee the `code` is always a `Number` for each error.

### include stacktraces for each type of error

For some reason it seems the code intent is to include the stacktrace only for Error extending `HttpError` with a `code >= 500`:
https://github.com/octokit/rest.js/blob/47204015c20ee88926f8a17276cbbc236af3bc6d/lib/request/errors.js#L35

As previously mentioned `status` will be a `String` so comparing a `String` to a `Number` will always be `false` (`status >= 500` is always `false`).

Not including the stacktrace doesn't make much sense. It's useful for debugging and several library expect the `stack` property of the errors to be defined. Overall, swallowing the stacktrace seems to be a bad practice.

In addition `arguments.callee` is [deprecated and forbidden in strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee). The library works only because `if (status >= 500) { Error.captureStackTrace(this, arguments.callee) }` is never called due to `status` being a `String`.

This PR includes the stacktrace for each type of Error and use `Error.captureStackTrace(this, this.constructor)`.

### use ES6 classes to extend Error

Per [Node documentation](https://nodejs.org/docs/latest/api/util.html#util_util_inherits_constructor_superconstructor):

> Usage of util.inherits() is discouraged. Please use the ES6 class and extends keywords to get language level inheritance support. Also note that the two styles are semantically incompatible.

In addition the `name` property was not set. It's a common practice in JS (due to lack of type) to use the `name` to detect the type of Error. As it was not set `HttpError`  and it's subclass had the name `Error`.

This PR uses ES6 classes to extend Errors and properly set the error names.
