### PR TITLE
@next npm badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,11 @@ jobs:
         - sleep 3 # give server some time to start
         - npm run test
     - node_js: 9
+      env: Node 9, coverage upload
       script:
         - npm run start-fixtures-server &
         - sleep 3 # give server some time to start
         - npm run test
-        # coverage
         - npm run coverage:upload
     - node_js: lts/*
       env: browser tests

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-# rest.js
+# rest.js [![@latest](https://img.shields.io/npm/v/@octokit/rest.svg)](https://www.npmjs.com/package/@octokit/rest) [![@next](https://img.shields.io/npm/v/@octokit/rest/next.svg?label=@next)](https://www.npmjs.com/package/@octokit/rest)
 
 > GitHub REST API client for Node.js
 
 [![Build Status](https://travis-ci.org/octokit/rest.js.svg?branch=master)](https://travis-ci.org/octokit/rest.js)
 [![Coverage Status](https://coveralls.io/repos/github/octokit/rest.js/badge.svg)](https://coveralls.io/github/octokit/rest.js)
 [![Greenkeeper](https://badges.greenkeeper.io/octokit/rest.js.svg)](https://greenkeeper.io/)
-[![npm](https://img.shields.io/npm/v/@octokit/rest.svg)](https://www.npmjs.com/package/@octokit/rest)
 
 ## Usage
 


### PR DESCRIPTION
`@octokit/rest` is now published using the @next dist-tag by default. Adding the label to the readme usually avoids the "can you please publish to npm" issues for versions that are already published, but behind the @next dist-tag (`npm install @octokit/rest@next`)