### PR TITLE
Add missing params to pullRequest.createComment

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -5604,6 +5604,18 @@
         "body": {
           "type": "string",
           "required": true
+        },
+        "commit_id": {
+          "type": "string",
+          "required": true
+        },
+        "path": {
+          "type": "string",
+          "required": true
+        },
+        "position": {
+          "type": "number",
+          "required": true
         }
       },
       "description": "Create a comment"


### PR DESCRIPTION
3 required parameters were missing from the definition of pullRequest.createComment.

Fixes #746