### PR TITLE
fix: correct parameters for pull request creation

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -4998,12 +4998,10 @@
 	},
 	"body": {
 	  "type": "string",
-	  "required": false,
 	  "description": "The contents of the pull request."
 	},
 	"maintainer_can_modify": {
 	  "type": "boolean",
-	  "required": false,
 	  "description": "Indicates whether maintainers can modify the pull request."
 	}
       },

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -4990,7 +4990,22 @@
           "type": "string",
           "required": true,
           "description": "The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo."
-        }
+        },
+	"title": {
+	  "type": "string",
+	  "required": true,
+	  "description": "The title of the pull request."
+	},
+	"body": {
+	  "type": "string",
+	  "required": false,
+	  "description": "The contents of the pull request."
+	},
+	"maintainer_can_modify": {
+	  "type": "boolean",
+	  "required": false,
+	  "description": "Indicates whether maintainers can modify the pull request."
+	}
       },
       "description": "Create a pull request"
     },


### PR DESCRIPTION
The current implementation does not work because it does not pass a `title` which is required. This quick fix makes the client behave as described in the [API documentation](https://developer.github.com/v3/pulls/#create-a-pull-request).