### PR TITLE
FIX: Update README.md to reference correct https port

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const octokit = require('@octokit/rest')({
   host: 'api.github.com',
   pathPrefix: '',
   protocol: 'https',
-  port: 433,
+  port: 443,
 
   // advanced request options
   // see https://nodejs.org/api/http.html


### PR DESCRIPTION
I feel like port 433 in the constructor is a typo & it just wasted a bit of my time wondering why syntax I swear was correct was timing out in my FaaS provider.

Hopefully this addresses it.