### PR TITLE
Update webpack, remove Workaround for uglifyjs-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,7 @@
     "standard-markdown": "^4.0.2",
     "string-to-arraybuffer": "^1.0.0",
     "typescript": "^2.6.2",
-    "uglifyjs-webpack-plugin": "1.2.0",
-    "webpack": "^4.0.0-beta.1",
+    "webpack": "^4.0.0-beta.2",
     "webpack-bundle-analyzer": "^2.10.0",
     "webpack-cli": "^2.0.4"
   },


### PR DESCRIPTION
Workaround for uglifyjs-webpack-plugin is no longer required https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/241#event-1490219150

closes #756