### PR TITLE
fix: 660 remove github.search.email()

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -9590,18 +9590,6 @@
         }
       },
       "description": "Search users."
-    },
-    "email": {
-      "url": "/legacy/user/email/:email",
-      "method": "GET",
-      "params": {
-        "email": {
-          "type": "string",
-          "required": true,
-          "description": "The email address"
-        }
-      },
-      "description": "Search against public email addresses."
     }
   },
   "users": {


### PR DESCRIPTION
Fixes #660 

No longer supported.

Simply removed the `email` object from routes.json, do let me know if there are any iterations to be made. @gr2m :)