### PR TITLE
fix deprecation warning

### DIFF
--- a/lib/parse-client-options.js
+++ b/lib/parse-client-options.js
@@ -23,19 +23,19 @@ function parseOptions (userOptions) {
   }
 
   if ('protocol' in userOptions) {
-    console.warn('DEPRECATED: protocol option is no longer supported. All redirects are followed correctly')
+    console.warn('DEPRECATED: protocol option is no longer supported')
   }
 
   if ('host' in userOptions) {
-    console.warn('DEPRECATED: host option is no longer supported. All redirects are followed correctly')
+    console.warn('DEPRECATED: host option is no longer supported')
   }
 
   if ('port' in userOptions) {
-    console.warn('DEPRECATED: port option is no longer supported. All redirects are followed correctly')
+    console.warn('DEPRECATED: port option is no longer supported')
   }
 
   if ('pathPrefix' in userOptions) {
-    console.warn('DEPRECATED: pathPrefix option is no longer supported. All redirects are followed correctly')
+    console.warn('DEPRECATED: pathPrefix option is no longer supported')
   }
 
   if ('Promise' in userOptions) {


### PR DESCRIPTION
for `protocol`, `bost`, `port` and `pathPrefix`. The "All redirects..." part slipped in by accident :)