### PR TITLE
Update types to reflect baseUrl changes

### DIFF
--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -38,14 +38,38 @@ declare namespace Github {
     requestMedia?: string;
     agent?: http.Agent;
 
-    /** deprecated */
+    /**
+     * @deprecated in version 15.0.0
+     */
     proxy?: string;
+    /**
+     * @deprecated in version 15.0.0
+     */
     ca?: string;
+    /**
+     * @deprecated in version 15.0.0
+     */
     rejectUnauthorized?: boolean;
+    /**
+     * @deprecated in version 15.0.0
+     */
     family?: number;
+
+    /**
+     * @deprecated in version 15.2.0
+     */
     host?: string;
+    /**
+     * @deprecated in version 15.2.0
+     */
     pathPrefix?: string;
+    /**
+     * @deprecated in version 15.2.0
+     */
     protocol?: string;
+    /**
+     * @deprecated in version 15.2.0
+     */
     port?: number;
   }
 

--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -32,11 +32,8 @@ declare namespace Github {
   }
 
   export interface Options {
+    baseUrl?: string;
     timeout?: number;
-    host?: string;
-    pathPrefix?: string;
-    protocol?: string;
-    port?: number;
     proxy?: string;
     ca?: string;
     headers?: {[header: string]: any};

--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -34,13 +34,19 @@ declare namespace Github {
   export interface Options {
     baseUrl?: string;
     timeout?: number;
-    proxy?: string;
-    ca?: string;
     headers?: {[header: string]: any};
     requestMedia?: string;
+    agent?: http.Agent;
+
+    /** deprecated */
+    proxy?: string;
+    ca?: string;
     rejectUnauthorized?: boolean;
     family?: number;
-    agent?: http.Agent;
+    host?: string;
+    pathPrefix?: string;
+    protocol?: string;
+    port?: number;
   }
 
   export interface AuthBasic  {

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -1,17 +1,39 @@
 import * as Octokit from '../'
+import {Agent} from 'http'
+const http = require('http');
 
 // ************************************************************
 // THIS CODE IS NOT EXECUTED. IT IS JUST FOR TYPECHECKING
 // ************************************************************
 
-// Test the TypeScript definition.
 export default async function() {
-  // ************************************************************
-  // THIS CODE IS NOT EXECUTED. IT IS JUST FOR TYPECHECKING
-  // ************************************************************
-  new Octokit() // Check empty constructor
-  const octo = new Octokit({}) // Check that all arguments are optional
-  const repo = await octo.repos.get({owner: 'octokit', repo: 'rest.js'})
+  // Check empty constructor
+  new Octokit()
+
+  // Check that all arguments are optional
+  new Octokit({})
+
+  // for all supported options
+  const octokit = new Octokit({
+    timeout: 0,
+    requestMedia: 'application/vnd.github.v3+json',
+    headers: {
+      'user-agent': 'octokit/rest.js v1.2.3'
+    },
+    baseUrl: 'https://api.github.com',
+    agent: new Agent({ keepAlive: true }),
+
+    // deprecated options (see deprecations-test.js)
+    protocol: 'https',
+    port: 433,
+    pathPrefix: '',
+    proxy: '',
+    ca: '',
+    rejectUnauthorized: false,
+    family: 6
+  })
+
+  const repo = await octokit.repos.get({owner: 'octokit', repo: 'rest.js'})
   // Check Response
   repo.data
   repo.meta.link


### PR DESCRIPTION
@gr2m @philschatz I think this is the change you need to the type definitions to reflect the deprecations in https://github.com/octokit/rest.js/pull/807

See https://github.com/octokit/rest.js/pull/732#issuecomment-373554225 for more context on where I ran into this.
