### PR TITLE
automatically generate routes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ branches:
 
 stages:
   - test
+  - name: greenkeeper-routes-update
+    if: branch =~ ^greenkeeper/@octokit/routes
   - name: release
     if: branch = master AND type IN (push)
 
@@ -53,6 +55,16 @@ jobs:
         - npx bundlesize
         # test typescript definitions
         - npm run validate:ts
+
+    # when updating @octokit/routes, run "generate-routes" script and push
+    # new routes.json file to the pull request
+    - stage: greenkeeper-routes-update
+      node_js: lts/*
+      script:
+        - npm run generate-routes
+        - "git commit -a -m 'build: routes'"
+        - "git push 'https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG' $TRAVIS_BRANCH"
+
     # release stage: run semantic release & update the docs
     - stage: release
       node_js: lts/*

--- a/lib/plugins/endpoint-methods/index.js
+++ b/lib/plugins/endpoint-methods/index.js
@@ -1,5 +1,6 @@
 module.exports = apiPlugin
 
+const get = require('lodash/get')
 const pick = require('lodash/pick')
 
 const method = require('./method')
@@ -12,8 +13,18 @@ function apiPlugin (octokit) {
     octokit[namespaceName] = {}
 
     Object.keys(ENDPOINT_DEFAULTS[namespaceName]).forEach(apiName => {
-      const apiOptions = ENDPOINT_DEFAULTS[namespaceName][apiName]
+      let apiOptions = ENDPOINT_DEFAULTS[namespaceName][apiName]
+      let deprecated
+
+      if (apiOptions.alias) {
+        deprecated = apiOptions.deprecated
+        apiOptions = get(ENDPOINT_DEFAULTS, apiOptions.alias)
+      }
+
       const endpointDefaults = pick(apiOptions, ['method', 'url', 'headers', 'request'])
+      if (deprecated) {
+        endpointDefaults.deprecated = deprecated
+      }
 
       octokit[namespaceName][apiName] = method.bind(null, octokit, endpointDefaults, apiOptions.params)
 

--- a/lib/plugins/endpoint-methods/method.js
+++ b/lib/plugins/endpoint-methods/method.js
@@ -13,6 +13,11 @@ function apiMethod (octokit, endpointDefaults, endpointParams, options, callback
   // lowercase header names (#760)
   options.headers = mapKeys(options.headers, (value, key) => key.toLowerCase())
 
+  if (endpointDefaults.deprecated) {
+    console.warn(endpointDefaults.deprecated)
+    delete endpointDefaults.deprecated
+  }
+
   const endpointOptions = defaultsDeep(options, endpointDefaults)
 
   const promise = Promise.resolve(endpointOptions)

--- a/lib/plugins/endpoint-methods/validate.js
+++ b/lib/plugins/endpoint-methods/validate.js
@@ -3,6 +3,7 @@
 module.exports = validate
 
 const set = require('lodash/set')
+const get = require('lodash/get')
 const HttpError = require('../../request/http-error')
 
 function validate (endpointParams, options) {
@@ -30,12 +31,24 @@ function validate (endpointParams, options) {
   Object.keys(endpointParams).forEach(parameterName => {
     const parameter = endpointParams[parameterName]
     const expectedType = parameter.type
-    let value = options[parameterName]
+    let value = get(options, parameterName)
 
-    const paramIsPresent = parameterName in options
+    const paramIsPresent = typeof value !== 'undefined'
+    let parentParamIsPresent = true
     const paramIsNull = value === null
 
+    if (/\./.test(parameterName)) {
+      const parentParameterName = parameterName.replace(/\.[^.]+$/, '')
+      parentParamIsPresent = typeof get(options, parentParameterName) !== 'object'
+    }
+
     if (!parameter.required && !paramIsPresent) {
+      return
+    }
+
+    // if the parent parameter is of type object but allows null
+    // then the child parameters can be ignored
+    if (!parentParamIsPresent) {
       return
     }
 
@@ -43,15 +56,16 @@ function validate (endpointParams, options) {
       return
     }
 
-    if ((parameter.required && !paramIsPresent) ||
-        (parameter.allowNull === false && paramIsNull)) {
+    if ((parameter.allowNull === false && paramIsNull)) {
+      throw new HttpError(`'${parameterName}' cannot be null`, 400)
+    }
+
+    if (parameter.required && !paramIsPresent) {
       throw new HttpError(`Empty value for parameter '${parameterName}': ${value}`, 400)
     }
 
-    if (parameter.enum) {
-      if (parameter.enum.indexOf(value) === -1) {
-        throw new HttpError(`Invalid value for parameter '${parameterName}': ${value}`, 400)
-      }
+    if (parameter.enum && parameter.enum.indexOf(value) === -1) {
+      throw new HttpError(`Invalid value for parameter '${parameterName}': ${value}`, 400)
     }
 
     if (parameter.validation) {
@@ -62,9 +76,10 @@ function validate (endpointParams, options) {
     }
 
     if (expectedType === 'integer') {
+      const unparsedValue = value
       value = parseInt(value, 10)
       if (isNaN(value)) {
-        throw new HttpError(`Invalid value for parameter '${parameterName}': ${options[parameterName]} is NaN`, 400)
+        throw new HttpError(`Invalid value for parameter '${parameterName}': ${unparsedValue} is NaN`, 400)
       }
     }
 

--- a/lib/plugins/endpoint-methods/validate.js
+++ b/lib/plugins/endpoint-methods/validate.js
@@ -6,6 +6,27 @@ const set = require('lodash/set')
 const HttpError = require('../../request/http-error')
 
 function validate (endpointParams, options) {
+  // Alias are handled before validation, as validation rules
+  // ar set the aliased parameter. The `mapTo` property is the other way
+  // around, the final parameter name is the mapTo value, but validation
+  // rules are on parameter with the mapTo property
+  Object.keys(options).forEach(optionName => {
+    if (!endpointParams[optionName] || !endpointParams[optionName].alias) {
+      return
+    }
+
+    options[endpointParams[optionName].alias] = options[optionName]
+    delete options[optionName]
+
+    // right now all parameters with an alias property also have a deprecated
+    // property, but that might change in future, so we wrap it in the if block,
+    // but ignore if for coverage
+    /* istanbul ignore else */
+    if (endpointParams[optionName].deprecated) {
+      console.warn(`DEPRECATED: ${endpointParams[optionName].deprecated}`)
+    }
+  })
+
   Object.keys(endpointParams).forEach(parameterName => {
     const parameter = endpointParams[parameterName]
     const expectedType = parameter.type

--- a/lib/plugins/endpoint-methods/validate.js
+++ b/lib/plugins/endpoint-methods/validate.js
@@ -39,12 +39,12 @@ function validate (endpointParams, options) {
       return
     }
 
-    if (parameter['allow-null'] === true && paramIsNull) {
+    if (parameter.allowNull === true && paramIsNull) {
       return
     }
 
     if ((parameter.required && !paramIsPresent) ||
-        (parameter['allow-null'] === false && paramIsNull)) {
+        (parameter.allowNull === false && paramIsNull)) {
       throw new HttpError(`Empty value for parameter '${parameterName}': ${value}`, 400)
     }
 

--- a/lib/plugins/endpoint-methods/validate.js
+++ b/lib/plugins/endpoint-methods/validate.js
@@ -16,7 +16,7 @@ function validate (endpointParams, options) {
       return
     }
 
-    options[endpointParams[optionName].alias] = options[optionName]
+    set(options, endpointParams[optionName].alias, options[optionName])
     delete options[optionName]
 
     // right now all parameters with an alias property also have a deprecated
@@ -29,7 +29,7 @@ function validate (endpointParams, options) {
   })
 
   Object.keys(endpointParams).forEach(parameterName => {
-    const parameter = endpointParams[parameterName]
+    const parameter = get(endpointParams, parameterName)
     const expectedType = parameter.type
     let value = get(options, parameterName)
 
@@ -39,7 +39,7 @@ function validate (endpointParams, options) {
 
     if (/\./.test(parameterName)) {
       const parentParameterName = parameterName.replace(/\.[^.]+$/, '')
-      parentParamIsPresent = typeof get(options, parentParameterName) !== 'object'
+      parentParamIsPresent = parentParameterName === 'headers' || typeof get(options, parentParameterName) !== 'object'
     }
 
     if (!parameter.required && !paramIsPresent) {

--- a/lib/plugins/endpoint-methods/validate.js
+++ b/lib/plugins/endpoint-methods/validate.js
@@ -64,6 +64,16 @@ function validate (endpointParams, options) {
       throw new HttpError(`Empty value for parameter '${parameterName}': ${value}`, 400)
     }
 
+    // parse to integer before checking for enum
+    // so that string "1" will match enum with number 1
+    if (expectedType === 'integer') {
+      const unparsedValue = value
+      value = parseInt(value, 10)
+      if (isNaN(value)) {
+        throw new HttpError(`Invalid value for parameter '${parameterName}': ${unparsedValue} is NaN`, 400)
+      }
+    }
+
     if (parameter.enum && parameter.enum.indexOf(value) === -1) {
       throw new HttpError(`Invalid value for parameter '${parameterName}': ${value}`, 400)
     }
@@ -72,14 +82,6 @@ function validate (endpointParams, options) {
       const regex = new RegExp(parameter.validation)
       if (!regex.test(value)) {
         throw new HttpError(`Invalid value for parameter '${parameterName}': ${value}`, 400)
-      }
-    }
-
-    if (expectedType === 'integer') {
-      const unparsedValue = value
-      value = parseInt(value, 10)
-      if (isNaN(value)) {
-        throw new HttpError(`Invalid value for parameter '${parameterName}': ${unparsedValue} is NaN`, 400)
       }
     }
 

--- a/lib/plugins/endpoint-methods/validate.js
+++ b/lib/plugins/endpoint-methods/validate.js
@@ -68,7 +68,7 @@ function validate (endpointParams, options) {
       }
     }
 
-    if (expectedType === 'json' && typeof value === 'string') {
+    if (expectedType === 'object' && typeof value === 'string') {
       try {
         value = JSON.parse(value)
       } catch (exception) {

--- a/lib/plugins/endpoint-methods/validate.js
+++ b/lib/plugins/endpoint-methods/validate.js
@@ -61,7 +61,7 @@ function validate (endpointParams, options) {
       }
     }
 
-    if (expectedType === 'number') {
+    if (expectedType === 'integer') {
       value = parseInt(value, 10)
       if (isNaN(value)) {
         throw new HttpError(`Invalid value for parameter '${parameterName}': ${options[parameterName]} is NaN`, 400)

--- a/lib/plugins/endpoint-methods/validate.js
+++ b/lib/plugins/endpoint-methods/validate.js
@@ -67,11 +67,11 @@ function validate (endpointParams, options) {
         return
       }
 
-      if (parameter.allowNull === true && valueIsNull) {
+      if (parameter.allowNull && valueIsNull) {
         return
       }
 
-      if ((parameter.allowNull === false && valueIsNull)) {
+      if (!parameter.allowNull && valueIsNull) {
         throw new HttpError(`'${currentParameterName}' cannot be null`, 400)
       }
 

--- a/lib/plugins/endpoint-methods/validate.js
+++ b/lib/plugins/endpoint-methods/validate.js
@@ -31,69 +31,85 @@ function validate (endpointParams, options) {
   Object.keys(endpointParams).forEach(parameterName => {
     const parameter = get(endpointParams, parameterName)
     const expectedType = parameter.type
-    let value = get(options, parameterName)
-
-    const paramIsPresent = typeof value !== 'undefined'
+    let parentParameterName
+    let parentValue
     let parentParamIsPresent = true
-    const paramIsNull = value === null
+    let parentParameterIsArray = false
 
     if (/\./.test(parameterName)) {
-      const parentParameterName = parameterName.replace(/\.[^.]+$/, '')
-      parentParamIsPresent = parentParameterName === 'headers' || typeof get(options, parentParameterName) !== 'object'
-    }
-
-    if (!parameter.required && !paramIsPresent) {
-      return
-    }
-
-    // if the parent parameter is of type object but allows null
-    // then the child parameters can be ignored
-    if (!parentParamIsPresent) {
-      return
-    }
-
-    if (parameter.allowNull === true && paramIsNull) {
-      return
-    }
-
-    if ((parameter.allowNull === false && paramIsNull)) {
-      throw new HttpError(`'${parameterName}' cannot be null`, 400)
-    }
-
-    if (parameter.required && !paramIsPresent) {
-      throw new HttpError(`Empty value for parameter '${parameterName}': ${value}`, 400)
-    }
-
-    // parse to integer before checking for enum
-    // so that string "1" will match enum with number 1
-    if (expectedType === 'integer') {
-      const unparsedValue = value
-      value = parseInt(value, 10)
-      if (isNaN(value)) {
-        throw new HttpError(`Invalid value for parameter '${parameterName}': ${unparsedValue} is NaN`, 400)
+      parentParameterName = parameterName.replace(/\.[^.]+$/, '')
+      parentParameterIsArray = parentParameterName.slice(-2) === '[]'
+      if (parentParameterIsArray) {
+        parentParameterName = parentParameterName.slice(0, -2)
       }
+      parentValue = get(options, parentParameterName)
+      parentParamIsPresent = parentParameterName === 'headers' || (typeof parentValue === 'object' && parentValue !== null)
     }
 
-    if (parameter.enum && parameter.enum.indexOf(value) === -1) {
-      throw new HttpError(`Invalid value for parameter '${parameterName}': ${value}`, 400)
-    }
+    let values = parentParameterIsArray
+      ? get(options, parentParameterName).map(value => value[parameterName.split('.').pop()])
+      : [get(options, parameterName)]
 
-    if (parameter.validation) {
-      const regex = new RegExp(parameter.validation)
-      if (!regex.test(value)) {
-        throw new HttpError(`Invalid value for parameter '${parameterName}': ${value}`, 400)
+    values.forEach((value, i) => {
+      const valueIsPresent = typeof value !== 'undefined'
+      const valueIsNull = value === null
+      const currentParameterName = parentParameterIsArray
+        ? parameterName.replace(/\[\]/, `[${i}]`)
+        : parameterName
+
+      if (!parameter.required && !valueIsPresent) {
+        return
       }
-    }
 
-    if (expectedType === 'object' && typeof value === 'string') {
-      try {
-        value = JSON.parse(value)
-      } catch (exception) {
-        throw new HttpError(`JSON parse error of value for parameter '${parameterName}': ${value}`, 400)
+      // if the parent parameter is of type object but allows null
+      // then the child parameters can be ignored
+      if (!parentParamIsPresent) {
+        return
       }
-    }
 
-    set(options, parameter.mapTo || parameterName, value)
+      if (parameter.allowNull === true && valueIsNull) {
+        return
+      }
+
+      if ((parameter.allowNull === false && valueIsNull)) {
+        throw new HttpError(`'${currentParameterName}' cannot be null`, 400)
+      }
+
+      if (parameter.required && !valueIsPresent) {
+        throw new HttpError(`Empty value for parameter '${currentParameterName}': ${JSON.stringify(value)}`, 400)
+      }
+
+      // parse to integer before checking for enum
+      // so that string "1" will match enum with number 1
+      if (expectedType === 'integer') {
+        const unparsedValue = value
+        value = parseInt(value, 10)
+        if (isNaN(value)) {
+          throw new HttpError(`Invalid value for parameter '${currentParameterName}': ${JSON.stringify(unparsedValue)} is NaN`, 400)
+        }
+      }
+
+      if (parameter.enum && parameter.enum.indexOf(value) === -1) {
+        throw new HttpError(`Invalid value for parameter '${currentParameterName}': ${JSON.stringify(value)}`, 400)
+      }
+
+      if (parameter.validation) {
+        const regex = new RegExp(parameter.validation)
+        if (!regex.test(value)) {
+          throw new HttpError(`Invalid value for parameter '${currentParameterName}': ${JSON.stringify(value)}`, 400)
+        }
+      }
+
+      if (expectedType === 'object' && typeof value === 'string') {
+        try {
+          value = JSON.parse(value)
+        } catch (exception) {
+          throw new HttpError(`JSON parse error of value for parameter '${currentParameterName}': ${JSON.stringify(value)}`, 400)
+        }
+      }
+
+      set(options, parameter.mapTo || currentParameterName, value)
+    })
   })
 
   return options

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -7229,7 +7229,7 @@
       }
     },
     "getDeployment": {
-      "url": "/repos/:owner/:repo/deployments/:deployment_id",
+      "url": "/repos/:owner/:repo/deployments/:id",
       "method": "GET",
       "params": {
         "owner": {
@@ -7241,6 +7241,10 @@
           "required": true
         },
         "deployment_id": {
+          "alias": "id",
+          "deprecated": "`deployment_id` parameter has been renamed to `id`"
+        },
+        "id": {
           "type": "string",
           "required": true
         }

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -4409,13 +4409,17 @@
       }
     },
     "createProjectCard": {
-      "url": "/projects/columns/:column_id/cards",
+      "url": "/projects/columns/:id/cards",
       "method": "POST",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
       "params": {
         "column_id": {
+          "alias": "id",
+          "deprecated": "`column_id` parameter has been renamed to `id`"
+        },
+        "id": {
           "type": "string",
           "required": true
         },
@@ -4559,13 +4563,17 @@
       }
     },
     "getProjectCards": {
-      "url": "/projects/columns/:column_id/cards",
+      "url": "/projects/columns/:id/cards",
       "method": "GET",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
       "params": {
         "column_id": {
+          "alias": "id",
+          "deprecated": "`column_id` parameter has been renamed to `id`"
+        },
+        "id": {
           "type": "string",
           "required": true
         }

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -1510,7 +1510,6 @@
           "type": "string"
         },
         "encoding": {
-          "required": true,
           "type": "string"
         },
         "owner": {

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -1689,6 +1689,10 @@
     "getBlob": {
       "method": "GET",
       "params": {
+        "file_sha": {
+          "required": true,
+          "type": "string"
+        },
         "owner": {
           "required": true,
           "type": "string"
@@ -1698,15 +1702,19 @@
           "type": "string"
         },
         "sha": {
-          "required": true,
-          "type": "string"
+          "alias": "file_sha",
+          "deprecated": "`sha` parameter has been renamed to `file_sha`"
         }
       },
-      "url": "/repos/:owner/:repo/git/blobs/:sha"
+      "url": "/repos/:owner/:repo/git/blobs/:file_sha"
     },
     "getCommit": {
       "method": "GET",
       "params": {
+        "commit_sha": {
+          "required": true,
+          "type": "string"
+        },
         "owner": {
           "required": true,
           "type": "string"
@@ -1716,15 +1724,19 @@
           "type": "string"
         },
         "sha": {
-          "required": true,
-          "type": "string"
+          "alias": "commit_sha",
+          "deprecated": "`sha` parameter has been renamed to `commit_sha`"
         }
       },
-      "url": "/repos/:owner/:repo/git/commits/:sha"
+      "url": "/repos/:owner/:repo/git/commits/:commit_sha"
     },
     "getCommitSignatureVerification": {
       "method": "GET",
       "params": {
+        "commit_sha": {
+          "required": true,
+          "type": "string"
+        },
         "owner": {
           "required": true,
           "type": "string"
@@ -1734,11 +1746,11 @@
           "type": "string"
         },
         "sha": {
-          "required": true,
-          "type": "string"
+          "alias": "commit_sha",
+          "deprecated": "`sha` parameter has been renamed to `commit_sha`"
         }
       },
-      "url": "/repos/:owner/:repo/git/commits/:sha"
+      "url": "/repos/:owner/:repo/git/commits/:commit_sha"
     },
     "getReference": {
       "method": "GET",
@@ -1790,11 +1802,15 @@
           "type": "string"
         },
         "sha": {
+          "alias": "tag_sha",
+          "deprecated": "`sha` parameter has been renamed to `tag_sha`"
+        },
+        "tag_sha": {
           "required": true,
           "type": "string"
         }
       },
-      "url": "/repos/:owner/:repo/git/tags/:sha"
+      "url": "/repos/:owner/:repo/git/tags/:tag_sha"
     },
     "getTagSignatureVerification": {
       "method": "GET",
@@ -1808,11 +1824,15 @@
           "type": "string"
         },
         "sha": {
+          "alias": "tag_sha",
+          "deprecated": "`sha` parameter has been renamed to `tag_sha`"
+        },
+        "tag_sha": {
           "required": true,
           "type": "string"
         }
       },
-      "url": "/repos/:owner/:repo/git/tags/:sha"
+      "url": "/repos/:owner/:repo/git/tags/:tag_sha"
     },
     "getTags": {
       "method": "GET",
@@ -1849,11 +1869,15 @@
           "type": "string"
         },
         "sha": {
+          "alias": "tree_sha",
+          "deprecated": "`sha` parameter has been renamed to `tree_sha`"
+        },
+        "tree_sha": {
           "required": true,
           "type": "string"
         }
       },
-      "url": "/repos/:owner/:repo/git/trees/:sha"
+      "url": "/repos/:owner/:repo/git/trees/:tree_sha"
     },
     "updateReference": {
       "method": "PATCH",

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -4994,19 +4994,19 @@
           "required": true,
           "description": "The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo."
         },
-	"title": {
-	  "type": "string",
-	  "required": true,
-	  "description": "The title of the pull request."
-	},
-	"body": {
-	  "type": "string",
-	  "description": "The contents of the pull request."
-	},
-	"maintainer_can_modify": {
-	  "type": "boolean",
-	  "description": "Indicates whether maintainers can modify the pull request."
-	}
+        "title": {
+          "type": "string",
+          "required": true,
+          "description": "The title of the pull request."
+        },
+        "body": {
+          "type": "string",
+          "description": "The contents of the pull request."
+        },
+        "maintainer_can_modify": {
+          "type": "boolean",
+          "description": "Indicates whether maintainers can modify the pull request."
+        }
       },
       "description": "Create a pull request"
     },

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -1024,7 +1024,7 @@
       }
     },
     "createPreReceiveEnvironment": {
-      "url": "/admin/pre_receive_environments",
+      "url": "/admin/pre-receive-environments",
       "method": "POST",
       "headers": {
         "accept": "application/vnd.github.eye-scream-preview"
@@ -1074,7 +1074,7 @@
       }
     },
     "deletePreReceiveEnvironment": {
-      "url": "/admin/pre_receive_environments/:id",
+      "url": "/admin/pre-receive-environments/:id",
       "method": "DELETE",
       "params": {
         "id": {
@@ -1094,7 +1094,7 @@
       }
     },
     "editPreReceiveEnvironment": {
-      "url": "/admin/pre_receive_environments/:id",
+      "url": "/admin/pre-receive-environments/:id",
       "method": "PATCH",
       "params": {
         "id": {
@@ -1158,7 +1158,7 @@
       }
     },
     "getPreReceiveEnvironments": {
-      "url": "/admin/pre_receive_environments",
+      "url": "/admin/pre-receive-environments",
       "method": "GET",
       "headers": {
         "accept": "application/vnd.github.eye-scream-preview"
@@ -1240,7 +1240,7 @@
       }
     },
     "triggerPreReceiveEnvironmentDownload": {
-      "url": "/admin/pre_receive_environments/:id/downloads",
+      "url": "/admin/pre-receive-environments/:id/downloads",
       "method": "POST",
       "headers": {
         "accept": "application/vnd.github.eye-scream-preview"

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -1,286 +1,51 @@
 {
-  "authorization": {
-    "get": {
-      "url": "/authorizations/:id",
-      "method": "GET",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a single authorization."
-    },
-    "create": {
-      "url": "/authorizations",
-      "method": "POST",
-      "params": {
-        "scopes": {
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in."
-        },
-        "note": {
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for."
-        },
-        "note_url": {
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for."
-        },
-        "client_id": {
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token."
-        },
-        "client_secret": {
-          "type": "string",
-          "description": "The 40 character OAuth app client secret for which to create the token."
-        },
-        "fingerprint": {
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user."
-        }
-      },
-      "description": "Create a new authorization."
-    },
-    "update": {
-      "url": "/authorizations/:id",
-      "method": "PATCH",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "scopes": {
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in."
-        },
-        "add_scopes": {
-          "type": "string[]",
-          "description": "A list of scopes to add to this authorization."
-        },
-        "remove_scopes": {
-          "type": "string[]",
-          "description": "A list of scopes to remove from this authorization."
-        },
-        "note": {
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for."
-        },
-        "note_url": {
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for."
-        },
-        "fingerprint": {
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user."
-        }
-      },
-      "description": "Update an existing authorization."
-    },
-    "delete": {
-      "url": "/authorizations/:id",
-      "method": "DELETE",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete an authorization."
-    },
-    "check": {
-      "url": "/applications/:client_id/tokens/:access_token",
-      "method": "GET",
-      "params": {
-        "client_id": {
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token."
-        },
-        "access_token": {
-          "type": "string",
-          "required": true,
-          "description": "OAuth token"
-        }
-      },
-      "description": "Check an authorization"
-    },
-    "reset": {
-      "url": "/applications/:client_id/tokens/:access_token",
-      "method": "POST",
-      "params": {
-        "client_id": {
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token."
-        },
-        "access_token": {
-          "type": "string",
-          "required": true,
-          "description": "OAuth token"
-        }
-      },
-      "description": "Reset an authorization"
-    },
-    "revoke": {
-      "url": "/applications/:client_id/tokens/:access_token",
-      "method": "DELETE",
-      "params": {
-        "client_id": {
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token."
-        },
-        "access_token": {
-          "type": "string",
-          "required": true,
-          "description": "OAuth token"
-        }
-      },
-      "description": "Revoke an authorization for an application"
-    },
-    "getGrants": {
-      "url": "/applications/grants",
-      "method": "GET",
-      "params": {
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List your grants."
-    },
-    "getGrant": {
-      "url": "/applications/grants/:id",
-      "method": "GET",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get a single grant."
-    },
-    "deleteGrant": {
-      "url": "/applications/grants/:id",
-      "method": "DELETE",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete a grant."
-    },
-    "getAll": {
-      "url": "/authorizations",
-      "method": "GET",
-      "params": {
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List your authorizations."
-    },
-    "getOrCreateAuthorizationForApp": {
-      "url": "/authorizations/clients/:client_id",
-      "method": "PUT",
-      "params": {
-        "client_id": {
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token."
-        },
-        "client_secret": {
-          "type": "string",
-          "required": true,
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL."
-        },
-        "scopes": {
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in."
-        },
-        "note": {
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for."
-        },
-        "note_url": {
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for."
-        },
-        "fingerprint": {
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user."
-        }
-      },
-      "description": "Get or create an authorization for a specific app."
-    },
-    "getOrCreateAuthorizationForAppAndFingerprint": {
-      "url": "/authorizations/clients/:client_id/:fingerprint",
-      "method": "PUT",
-      "params": {
-        "client_id": {
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token."
-        },
-        "fingerprint": {
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user."
-        },
-        "client_secret": {
-          "type": "string",
-          "required": true,
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL."
-        },
-        "scopes": {
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in."
-        },
-        "note": {
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for."
-        },
-        "note_url": {
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for."
-        }
-      },
-      "description": "Get or create an authorization for a specific app and fingerprint."
-    },
-    "revokeGrant": {
-      "url": "/applications/:client_id/grants/:access_token",
-      "method": "DELETE",
-      "params": {
-        "client_id": {
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token."
-        },
-        "access_token": {
-          "type": "string",
-          "required": true,
-          "description": "OAuth token"
-        }
-      },
-      "description": "Revoke a grant for an application"
-    }
-  },
   "activity": {
+    "checkNotificationThreadSubscription": {
+      "url": "/notifications/threads/:id/subscription",
+      "method": "GET",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Check to see if the current user is subscribed to a thread."
+    },
+    "checkStarringRepo": {
+      "url": "/user/starred/:owner/:repo",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Check if you are starring a repository"
+    },
+    "deleteNotificationThreadSubscription": {
+      "url": "/notifications/threads/:id/subscription",
+      "method": "DELETE",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a notification thread subscription."
+    },
     "getEvents": {
       "url": "/events",
       "method": "GET",
@@ -296,6 +61,26 @@
         }
       },
       "description": "List public events"
+    },
+    "getEventsForOrg": {
+      "url": "/orgs/:org/events",
+      "method": "GET",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List public events for an organization"
     },
     "getEventsForRepo": {
       "url": "/repos/:owner/:repo/events",
@@ -369,10 +154,34 @@
       },
       "description": "List public events for a network of repositories"
     },
-    "getEventsForOrg": {
-      "url": "/orgs/:org/events",
+    "getEventsForUser": {
+      "url": "/users/:username/events",
       "method": "GET",
       "params": {
+        "username": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List events performed by a user"
+    },
+    "getEventsForUserOrg": {
+      "url": "/users/:username/events/orgs/:org",
+      "method": "GET",
+      "params": {
+        "username": {
+          "type": "string",
+          "required": true
+        },
         "org": {
           "type": "string",
           "required": true
@@ -387,7 +196,27 @@
           "description": "A custom page size up to 100. Default is 30."
         }
       },
-      "description": "List public events for an organization"
+      "description": "List events for a user's organization"
+    },
+    "getEventsForUserPublic": {
+      "url": "/users/:username/events/public",
+      "method": "GET",
+      "params": {
+        "username": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List public events performed by a user"
     },
     "getEventsReceived": {
       "url": "/users/:username/received_events",
@@ -429,75 +258,22 @@
       },
       "description": "List public events that a user has received"
     },
-    "getEventsForUser": {
-      "url": "/users/:username/events",
-      "method": "GET",
-      "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List events performed by a user"
-    },
-    "getEventsForUserPublic": {
-      "url": "/users/:username/events/public",
-      "method": "GET",
-      "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List public events performed by a user"
-    },
-    "getEventsForUserOrg": {
-      "url": "/users/:username/events/orgs/:org",
-      "method": "GET",
-      "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        },
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List events for a user's organization"
-    },
     "getFeeds": {
       "url": "/feeds",
       "method": "GET",
       "params": {},
       "description": "Get all feeds available for the authenticated user."
+    },
+    "getNotificationThread": {
+      "url": "/notifications/threads/:id",
+      "method": "GET",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "View a single notification thread."
     },
     "getNotifications": {
       "url": "/notifications",
@@ -557,21 +333,9 @@
       },
       "description": "Get all notifications for the given user."
     },
-    "markNotificationsAsRead": {
-      "url": "/notifications",
-      "method": "PUT",
-      "params": {
-        "last_read_at": {
-          "type": "string",
-          "default": "Time.now",
-          "description": "Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. Default: Time.now"
-        }
-      },
-      "description": "Mark notifications as read for authenticated user."
-    },
-    "markNotificationsAsReadForRepo": {
-      "url": "/repos/:owner/:repo/notifications",
-      "method": "PUT",
+    "getRepoSubscription": {
+      "url": "/repos/:owner/:repo/subscription",
+      "method": "GET",
       "params": {
         "owner": {
           "type": "string",
@@ -581,76 +345,17 @@
           "type": "string",
           "required": true
         },
-        "last_read_at": {
-          "type": "string",
-          "default": "Time.now",
-          "description": "Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. Default: Time.now"
-        }
-      },
-      "description": "Mark notifications in a repo as read."
-    },
-    "getNotificationThread": {
-      "url": "/notifications/threads/:id",
-      "method": "GET",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "View a single notification thread."
-    },
-    "markNotificationThreadAsRead": {
-      "url": "/notifications/threads/:id",
-      "method": "PATCH",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Mark a notification thread as read."
-    },
-    "checkNotificationThreadSubscription": {
-      "url": "/notifications/threads/:id/subscription",
-      "method": "GET",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Check to see if the current user is subscribed to a thread."
-    },
-    "setNotificationThreadSubscription": {
-      "url": "/notifications/threads/:id/subscription",
-      "method": "PUT",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
         },
-        "subscribed": {
-          "type": "boolean",
-          "description": "Determines if notifications should be received from this thread"
-        },
-        "ignored": {
-          "type": "boolean",
-          "description": "Determines if all notifications should be blocked from this thread"
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
         }
       },
-      "description": "This lets you subscribe or unsubscribe from a conversation. Unsubscribing from a conversation mutes all future notifications (until you comment or get @mentioned once more)."
-    },
-    "deleteNotificationThreadSubscription": {
-      "url": "/notifications/threads/:id/subscription",
-      "method": "DELETE",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete a notification thread subscription."
+      "description": "Get a Repository Subscription."
     },
     "getStargazersForRepo": {
       "url": "/repos/:owner/:repo/stargazers",
@@ -678,6 +383,41 @@
         }
       },
       "description": "List Stargazers"
+    },
+    "getStarredRepos": {
+      "url": "/user/starred",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.v3.star+json"
+      },
+      "params": {
+        "sort": {
+          "type": "string",
+          "enum": [
+            "created",
+            "updated"
+          ],
+          "default": "created"
+        },
+        "direction": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "default": "desc"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List repositories being starred by the authenticated user"
     },
     "getStarredReposForUser": {
       "url": "/users/:username/starred",
@@ -718,28 +458,29 @@
       },
       "description": "List repositories being starred by a user"
     },
-    "getStarredRepos": {
-      "url": "/user/starred",
+    "getWatchedRepos": {
+      "url": "/user/subscriptions",
       "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.v3.star+json"
-      },
       "params": {
-        "sort": {
-          "type": "string",
-          "enum": [
-            "created",
-            "updated"
-          ],
-          "default": "created"
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
         },
-        "direction": {
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List repositories being watched by the authenticated user."
+    },
+    "getWatchedReposForUser": {
+      "url": "/users/:username/subscriptions",
+      "method": "GET",
+      "params": {
+        "username": {
           "type": "string",
-          "enum": [
-            "asc",
-            "desc"
-          ],
-          "default": "desc"
+          "required": true
         },
         "page": {
           "type": "number",
@@ -751,10 +492,10 @@
           "description": "A custom page size up to 100. Default is 30."
         }
       },
-      "description": "List repositories being starred by the authenticated user"
+      "description": "List repositories being watched by a user."
     },
-    "checkStarringRepo": {
-      "url": "/user/starred/:owner/:repo",
+    "getWatchersForRepo": {
+      "url": "/repos/:owner/:repo/subscribers",
       "method": "GET",
       "params": {
         "owner": {
@@ -775,7 +516,92 @@
           "description": "A custom page size up to 100. Default is 30."
         }
       },
-      "description": "Check if you are starring a repository"
+      "description": "Get watchers for repository."
+    },
+    "markNotificationThreadAsRead": {
+      "url": "/notifications/threads/:id",
+      "method": "PATCH",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Mark a notification thread as read."
+    },
+    "markNotificationsAsRead": {
+      "url": "/notifications",
+      "method": "PUT",
+      "params": {
+        "last_read_at": {
+          "type": "string",
+          "default": "Time.now",
+          "description": "Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. Default: Time.now"
+        }
+      },
+      "description": "Mark notifications as read for authenticated user."
+    },
+    "markNotificationsAsReadForRepo": {
+      "url": "/repos/:owner/:repo/notifications",
+      "method": "PUT",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "last_read_at": {
+          "type": "string",
+          "default": "Time.now",
+          "description": "Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. Default: Time.now"
+        }
+      },
+      "description": "Mark notifications in a repo as read."
+    },
+    "setNotificationThreadSubscription": {
+      "url": "/notifications/threads/:id/subscription",
+      "method": "PUT",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "subscribed": {
+          "type": "boolean",
+          "description": "Determines if notifications should be received from this thread"
+        },
+        "ignored": {
+          "type": "boolean",
+          "description": "Determines if all notifications should be blocked from this thread"
+        }
+      },
+      "description": "This lets you subscribe or unsubscribe from a conversation. Unsubscribing from a conversation mutes all future notifications (until you comment or get @mentioned once more)."
+    },
+    "setRepoSubscription": {
+      "url": "/repos/:owner/:repo/subscription",
+      "method": "PUT",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "subscribed": {
+          "type": "boolean",
+          "description": "Determines if notifications should be received from this repository."
+        },
+        "ignored": {
+          "type": "boolean",
+          "description": "Determines if all notifications should be blocked from this repository."
+        }
+      },
+      "description": "Set a Repository Subscription"
     },
     "starRepo": {
       "url": "/user/starred/:owner/:repo",
@@ -807,113 +633,6 @@
       },
       "description": "Unstar a repository"
     },
-    "getWatchersForRepo": {
-      "url": "/repos/:owner/:repo/subscribers",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get watchers for repository."
-    },
-    "getWatchedReposForUser": {
-      "url": "/users/:username/subscriptions",
-      "method": "GET",
-      "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List repositories being watched by a user."
-    },
-    "getWatchedRepos": {
-      "url": "/user/subscriptions",
-      "method": "GET",
-      "params": {
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List repositories being watched by the authenticated user."
-    },
-    "getRepoSubscription": {
-      "url": "/repos/:owner/:repo/subscription",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get a Repository Subscription."
-    },
-    "setRepoSubscription": {
-      "url": "/repos/:owner/:repo/subscription",
-      "method": "PUT",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "subscribed": {
-          "type": "boolean",
-          "description": "Determines if notifications should be received from this repository."
-        },
-        "ignored": {
-          "type": "boolean",
-          "description": "Determines if all notifications should be blocked from this repository."
-        }
-      },
-      "description": "Set a Repository Subscription"
-    },
     "unwatchRepo": {
       "url": "/repos/:owner/:repo/subscription",
       "method": "DELETE",
@@ -930,9 +649,314 @@
       "description": "Unwatch a repository."
     }
   },
-  "gists": {
+  "apps": {
+    "addRepoToInstallation": {
+      "url": "/installations/:installation_id/repositories/:repository_id",
+      "method": "PUT",
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview"
+      },
+      "params": {
+        "installation_id": {
+          "type": "string",
+          "required": true
+        },
+        "repository_id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Add a single repository to an installation. (In preview period. See README.)"
+    },
+    "checkMarketplaceListingAccount": {
+      "url": "/marketplace_listing/accounts/:id",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.valkyrie-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Check if a GitHub account is associated with any Marketplace listing. (In preview period. See README.)"
+    },
+    "checkMarketplaceListingStubbedAccount": {
+      "url": "/marketplace_listing/stubbed/accounts/:id",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.valkyrie-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Check if a stubbed GitHub account is associated with any Marketplace listing. (In preview period. See README.)"
+    },
+    "createInstallationToken": {
+      "url": "/installations/:installation_id/access_tokens",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview"
+      },
+      "params": {
+        "installation_id": {
+          "type": "string",
+          "required": true
+        },
+        "user_id": {
+          "type": "string",
+          "description": "The id of the user for whom the app is acting on behalf of."
+        }
+      },
+      "description": "Create a new installation token. (In preview period. See README.)"
+    },
     "get": {
-      "url": "/gists/:id",
+      "url": "/app",
+      "method": "GET",
+      "params": {},
+      "description": "Get the authenticated GitHub App. (In preview period. See README.)"
+    },
+    "getForSlug": {
+      "url": "/apps/:app_slug",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview"
+      },
+      "params": {
+        "app_slug": {
+          "type": "string",
+          "required": true,
+          "description": "The URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., https://github.com/settings/apps/:app_slug)."
+        }
+      },
+      "description": "Get a single GitHub App. (In preview period. See README.)"
+    },
+    "getInstallation": {
+      "url": "/app/installations/:installation_id",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview"
+      },
+      "params": {
+        "installation_id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a single installation. (In preview period. See README.)"
+    },
+    "getInstallationRepositories": {
+      "url": "/installation/repositories",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview"
+      },
+      "params": {
+        "user_id": {
+          "type": "string",
+          "description": "The integer ID of a user, to filter results to repositories that are visible to both the installation and the given user."
+        }
+      },
+      "description": "List repositories that are accessible to the authenticated installation. (In preview period. See README.)"
+    },
+    "getInstallations": {
+      "url": "/app/installations",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview"
+      },
+      "params": {
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List the app's installations. (In preview period. See README.)"
+    },
+    "getMarketplaceListingPlanAccounts": {
+      "url": "/marketplace_listing/plans/:id/accounts",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.valkyrie-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List all GitHub accounts (user or organization) on a specific plan. (In preview period. See README.)"
+    },
+    "getMarketplaceListingPlans": {
+      "url": "/marketplace_listing/plans",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.valkyrie-preview+json"
+      },
+      "params": {
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List all plans for your Marketplace listing. (In preview period. See README.)"
+    },
+    "getMarketplaceListingStubbedPlanAccounts": {
+      "url": "/marketplace_listing/stubbed/plans/:id/accounts",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.valkyrie-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List all GitHub accounts (user or organization) on a specific stubbed plan. (In preview period. See README.)"
+    },
+    "getMarketplaceListingStubbedPlans": {
+      "url": "/marketplace_listing/stubbed/plans",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.valkyrie-preview+json"
+      },
+      "params": {
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List all stubbed plans for your Marketplace listing. (In preview period. See README.)"
+    },
+    "removeRepoFromInstallation": {
+      "url": "/installations/:installation_id/repositories/:repository_id",
+      "method": "DELETE",
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview"
+      },
+      "params": {
+        "installation_id": {
+          "type": "string",
+          "required": true
+        },
+        "repository_id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Remove a single repository from an installation. (In preview period. See README.)"
+    }
+  },
+  "authorization": {
+    "check": {
+      "url": "/applications/:client_id/tokens/:access_token",
+      "method": "GET",
+      "params": {
+        "client_id": {
+          "type": "string",
+          "description": "The 20 character OAuth app client key for which to create the token."
+        },
+        "access_token": {
+          "type": "string",
+          "required": true,
+          "description": "OAuth token"
+        }
+      },
+      "description": "Check an authorization"
+    },
+    "create": {
+      "url": "/authorizations",
+      "method": "POST",
+      "params": {
+        "scopes": {
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in."
+        },
+        "note": {
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for."
+        },
+        "note_url": {
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for."
+        },
+        "client_id": {
+          "type": "string",
+          "description": "The 20 character OAuth app client key for which to create the token."
+        },
+        "client_secret": {
+          "type": "string",
+          "description": "The 40 character OAuth app client secret for which to create the token."
+        },
+        "fingerprint": {
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client ID and user."
+        }
+      },
+      "description": "Create a new authorization."
+    },
+    "delete": {
+      "url": "/authorizations/:id",
+      "method": "DELETE",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete an authorization."
+    },
+    "deleteGrant": {
+      "url": "/applications/grants/:id",
+      "method": "DELETE",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a grant."
+    },
+    "get": {
+      "url": "/authorizations/:id",
       "method": "GET",
       "params": {
         "id": {
@@ -940,7 +964,533 @@
           "required": true
         }
       },
-      "description": "Get a single gist"
+      "description": "Get a single authorization."
+    },
+    "getAll": {
+      "url": "/authorizations",
+      "method": "GET",
+      "params": {
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List your authorizations."
+    },
+    "getGrant": {
+      "url": "/applications/grants/:id",
+      "method": "GET",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Get a single grant."
+    },
+    "getGrants": {
+      "url": "/applications/grants",
+      "method": "GET",
+      "params": {
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List your grants."
+    },
+    "getOrCreateAuthorizationForApp": {
+      "url": "/authorizations/clients/:client_id",
+      "method": "PUT",
+      "params": {
+        "client_id": {
+          "type": "string",
+          "description": "The 20 character OAuth app client key for which to create the token."
+        },
+        "client_secret": {
+          "type": "string",
+          "required": true,
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL."
+        },
+        "scopes": {
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in."
+        },
+        "note": {
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for."
+        },
+        "note_url": {
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for."
+        },
+        "fingerprint": {
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client ID and user."
+        }
+      },
+      "description": "Get or create an authorization for a specific app."
+    },
+    "getOrCreateAuthorizationForAppAndFingerprint": {
+      "url": "/authorizations/clients/:client_id/:fingerprint",
+      "method": "PUT",
+      "params": {
+        "client_id": {
+          "type": "string",
+          "description": "The 20 character OAuth app client key for which to create the token."
+        },
+        "fingerprint": {
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client ID and user."
+        },
+        "client_secret": {
+          "type": "string",
+          "required": true,
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL."
+        },
+        "scopes": {
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in."
+        },
+        "note": {
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for."
+        },
+        "note_url": {
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for."
+        }
+      },
+      "description": "Get or create an authorization for a specific app and fingerprint."
+    },
+    "reset": {
+      "url": "/applications/:client_id/tokens/:access_token",
+      "method": "POST",
+      "params": {
+        "client_id": {
+          "type": "string",
+          "description": "The 20 character OAuth app client key for which to create the token."
+        },
+        "access_token": {
+          "type": "string",
+          "required": true,
+          "description": "OAuth token"
+        }
+      },
+      "description": "Reset an authorization"
+    },
+    "revoke": {
+      "url": "/applications/:client_id/tokens/:access_token",
+      "method": "DELETE",
+      "params": {
+        "client_id": {
+          "type": "string",
+          "description": "The 20 character OAuth app client key for which to create the token."
+        },
+        "access_token": {
+          "type": "string",
+          "required": true,
+          "description": "OAuth token"
+        }
+      },
+      "description": "Revoke an authorization for an application"
+    },
+    "revokeGrant": {
+      "url": "/applications/:client_id/grants/:access_token",
+      "method": "DELETE",
+      "params": {
+        "client_id": {
+          "type": "string",
+          "description": "The 20 character OAuth app client key for which to create the token."
+        },
+        "access_token": {
+          "type": "string",
+          "required": true,
+          "description": "OAuth token"
+        }
+      },
+      "description": "Revoke a grant for an application"
+    },
+    "update": {
+      "url": "/authorizations/:id",
+      "method": "PATCH",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "scopes": {
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in."
+        },
+        "add_scopes": {
+          "type": "string[]",
+          "description": "A list of scopes to add to this authorization."
+        },
+        "remove_scopes": {
+          "type": "string[]",
+          "description": "A list of scopes to remove from this authorization."
+        },
+        "note": {
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for."
+        },
+        "note_url": {
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for."
+        },
+        "fingerprint": {
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client ID and user."
+        }
+      },
+      "description": "Update an existing authorization."
+    }
+  },
+  "enterprise": {
+    "createOrg": {
+      "url": "/admin/organizations",
+      "method": "POST",
+      "params": {
+        "login": {
+          "type": "string",
+          "required": true,
+          "description": "The organization's username."
+        },
+        "admin": {
+          "type": "string",
+          "required": true,
+          "description": "The login of the user who will manage this organization."
+        },
+        "profile_name": {
+          "type": "string",
+          "description": "The organization's display name."
+        }
+      },
+      "description": "Create an organization"
+    },
+    "createPreReceiveEnvironment": {
+      "url": "/admin/pre_receive_environments",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.eye-scream-preview"
+      },
+      "params": {
+        "name": {
+          "type": "string",
+          "required": true,
+          "description": "The new pre-receive environment's name."
+        },
+        "image_url": {
+          "type": "string",
+          "required": true,
+          "description": "URL from which to download a tarball of this environment."
+        }
+      },
+      "description": "Create a pre-receive environment. (In preview period. See README.)"
+    },
+    "createPreReceiveHook": {
+      "url": "/admin/pre-receive-hooks",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.eye-scream-preview"
+      },
+      "params": {
+        "name": {
+          "type": "string",
+          "required": true,
+          "description": "The name of the hook."
+        },
+        "script": {
+          "type": "string",
+          "required": true,
+          "description": "The script that the hook runs."
+        },
+        "script_repository": {
+          "type": "json",
+          "required": true,
+          "description": "The GitHub repository where the script is kept."
+        },
+        "environment": {
+          "type": "json",
+          "required": true,
+          "description": "The pre-receive environment where the script is executed."
+        },
+        "enforcement": {
+          "type": "string",
+          "default": "disabled",
+          "description": "The state of enforcement for this hook. default: disabled"
+        },
+        "allow_downstream_configuration": {
+          "type": "boolean",
+          "default": "false",
+          "description": "Whether enforcement can be overridden at the org or repo level. default: false"
+        }
+      },
+      "description": "Create a pre-receive hook. (In preview period. See README.)"
+    },
+    "deletePreReceiveEnvironment": {
+      "url": "/admin/pre_receive_environments/:id",
+      "method": "DELETE",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a pre-receive environment. (In preview period. See README.)"
+    },
+    "deletePreReceiveHook": {
+      "url": "/admin/pre_receive_hooks/:id",
+      "method": "DELETE",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a pre-receive hook. (In preview period. See README.)"
+    },
+    "editPreReceiveEnvironment": {
+      "url": "/admin/pre_receive_environments/:id",
+      "method": "PATCH",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "name": {
+          "type": "string",
+          "required": true,
+          "description": "This pre-receive environment's new name."
+        },
+        "image_url": {
+          "type": "string",
+          "required": true,
+          "description": "URL from which to download a tarball of this environment."
+        }
+      },
+      "description": "Create a pre-receive environment. (In preview period. See README.)"
+    },
+    "editPreReceiveHook": {
+      "url": "/admin/pre_receive_hooks/:id",
+      "method": "PATCH",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "hook": {
+          "type": "json",
+          "required": true,
+          "mapTo": "input",
+          "description": "JSON object that contains pre-receive hook info."
+        }
+      },
+      "description": "Edit a pre-receive hook. (In preview period. See README.)"
+    },
+    "getLicense": {
+      "url": "/enterprise/settings/license",
+      "method": "GET",
+      "params": {},
+      "description": "Get license information"
+    },
+    "getPreReceiveEnvironment": {
+      "url": "/admin/pre-receive-environments/:id",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.eye-scream-preview"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a single pre-receive environment. (In preview period. See README.)"
+    },
+    "getPreReceiveEnvironmentDownloadStatus": {
+      "url": "/admin/pre-receive-environments/:id/downloads/latest",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.eye-scream-preview"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a pre-receive environment's download status. (In preview period. See README.)"
+    },
+    "getPreReceiveEnvironments": {
+      "url": "/admin/pre_receive_environments",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.eye-scream-preview"
+      },
+      "params": {},
+      "description": "List pre-receive environments. (In preview period. See README.)"
+    },
+    "getPreReceiveHook": {
+      "url": "/admin/pre-receive-hooks/:id",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.eye-scream-preview"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a single pre-receive hook. (In preview period. See README.)"
+    },
+    "getPreReceiveHooks": {
+      "url": "/admin/pre-receive-hooks",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.eye-scream-preview"
+      },
+      "params": {},
+      "description": "List pre-receive hooks. (In preview period. See README.)"
+    },
+    "queueIndexingJob": {
+      "url": "/staff/indexing_jobs",
+      "method": "POST",
+      "params": {
+        "target": {
+          "type": "string",
+          "required": true,
+          "description": "A string representing the item to index."
+        }
+      },
+      "description": "Queue an indexing job"
+    },
+    "stats": {
+      "url": "/enterprise/stats/:type",
+      "method": "GET",
+      "params": {
+        "type": {
+          "type": "string",
+          "required": true,
+          "enum": [
+            "issues",
+            "hooks",
+            "milestones",
+            "orgs",
+            "comments",
+            "pages",
+            "users",
+            "gists",
+            "pulls",
+            "repos",
+            "all"
+          ],
+          "description": "Possible values: issues, hooks, milestones, orgs, comments, pages, users, gists, pulls, repos, all."
+        }
+      },
+      "description": "Get statistics."
+    },
+    "syncLdapForTeam": {
+      "url": "/admin/ldap/teams/:team_id/sync",
+      "method": "POST",
+      "params": {
+        "team_id": {
+          "type": "number",
+          "required": true
+        }
+      },
+      "description": "Sync LDAP mapping for a team."
+    },
+    "syncLdapForUser": {
+      "url": "/admin/ldap/users/:username/sync",
+      "method": "POST",
+      "params": {
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Sync LDAP mapping for a user."
+    },
+    "triggerPreReceiveEnvironmentDownload": {
+      "url": "/admin/pre_receive_environments/:id/downloads",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.eye-scream-preview"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Trigger a pre-receive environment download. (In preview period. See README.)"
+    },
+    "updateLdapForTeam": {
+      "url": "/admin/ldap/teams/:team_id/mapping",
+      "method": "PATCH",
+      "params": {
+        "team_id": {
+          "type": "number",
+          "required": true
+        },
+        "ldap_dn": {
+          "type": "string",
+          "required": true,
+          "description": "LDAP DN for user"
+        }
+      },
+      "description": "Update LDAP mapping for a team."
+    },
+    "updateLdapForUser": {
+      "url": "/admin/ldap/users/:username/mapping",
+      "method": "PATCH",
+      "params": {
+        "username": {
+          "type": "string",
+          "required": true
+        },
+        "ldap_dn": {
+          "type": "string",
+          "required": true,
+          "description": "LDAP DN for user"
+        }
+      },
+      "description": "Update LDAP mapping for a user."
+    }
+  },
+  "gists": {
+    "checkStar": {
+      "url": "/gists/:id/star",
+      "method": "GET",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Check if a gist is starred"
     },
     "create": {
       "url": "/gists",
@@ -960,6 +1510,49 @@
         }
       },
       "description": "Create a gist"
+    },
+    "createComment": {
+      "url": "/gists/:gist_id/comments",
+      "method": "POST",
+      "params": {
+        "gist_id": {
+          "type": "string",
+          "required": true,
+          "description": "Id (SHA1 hash) of the gist."
+        },
+        "body": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Create a comment"
+    },
+    "delete": {
+      "url": "/gists/:id",
+      "method": "DELETE",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a gist"
+    },
+    "deleteComment": {
+      "url": "/gists/:gist_id/comments/:id",
+      "method": "DELETE",
+      "params": {
+        "gist_id": {
+          "type": "string",
+          "required": true,
+          "description": "Id (SHA1 hash) of the gist."
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a comment"
     },
     "edit": {
       "url": "/gists/:id",
@@ -988,27 +1581,25 @@
       },
       "description": "Edit a gist"
     },
-    "star": {
-      "url": "/gists/:id/star",
-      "method": "PUT",
+    "editComment": {
+      "url": "/gists/:gist_id/comments/:id",
+      "method": "PATCH",
       "params": {
+        "gist_id": {
+          "type": "string",
+          "required": true,
+          "description": "Id (SHA1 hash) of the gist."
+        },
         "id": {
+          "type": "string",
+          "required": true
+        },
+        "body": {
           "type": "string",
           "required": true
         }
       },
-      "description": "Star a gist"
-    },
-    "unstar": {
-      "url": "/gists/:id/star",
-      "method": "DELETE",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Unstar a gist"
+      "description": "Edit a comment"
     },
     "fork": {
       "url": "/gists/:id/forks",
@@ -1021,16 +1612,75 @@
       },
       "description": "Fork a gist"
     },
-    "delete": {
+    "get": {
       "url": "/gists/:id",
-      "method": "DELETE",
+      "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
       },
-      "description": "Delete a gist"
+      "description": "Get a single gist"
+    },
+    "getAll": {
+      "url": "/gists",
+      "method": "GET",
+      "params": {
+        "since": {
+          "type": "date",
+          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List the authenticated user's gists or if called anonymously, this will return all public gists"
+    },
+    "getComment": {
+      "url": "/gists/:gist_id/comments/:id",
+      "method": "GET",
+      "params": {
+        "gist_id": {
+          "type": "string",
+          "required": true,
+          "description": "Id (SHA1 hash) of the gist."
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a single comment"
+    },
+    "getComments": {
+      "url": "/gists/:gist_id/comments",
+      "method": "GET",
+      "params": {
+        "gist_id": {
+          "type": "string",
+          "required": true,
+          "description": "Id (SHA1 hash) of the gist."
+        }
+      },
+      "description": "List comments on a gist"
+    },
+    "getCommits": {
+      "url": "/gists/:id/commits",
+      "method": "GET",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "List gist commits"
     },
     "getForUser": {
       "url": "/users/:username/gists",
@@ -1056,85 +1706,6 @@
       },
       "description": "List a user's gists"
     },
-    "getAll": {
-      "url": "/gists",
-      "method": "GET",
-      "params": {
-        "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List the authenticated user's gists or if called anonymously, this will return all public gists"
-    },
-    "getPublic": {
-      "url": "/gists/public",
-      "method": "GET",
-      "params": {
-        "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
-        }
-      },
-      "description": "List all public gists"
-    },
-    "getStarred": {
-      "url": "/gists/starred",
-      "method": "GET",
-      "params": {
-        "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
-        }
-      },
-      "description": "List the authenticated user's starred gists"
-    },
-    "getRevision": {
-      "url": "/gists/:id/:sha",
-      "method": "GET",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "sha": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a specific revision of a gist"
-    },
-    "getCommits": {
-      "url": "/gists/:id/commits",
-      "method": "GET",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "List gist commits"
-    },
-    "checkStar": {
-      "url": "/gists/:id/star",
-      "method": "GET",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Check if a gist is starred"
-    },
     "getForks": {
       "url": "/gists/:id/forks",
       "method": "GET",
@@ -1155,116 +1726,67 @@
       },
       "description": "List gist forks"
     },
-    "getComments": {
-      "url": "/gists/:gist_id/comments",
+    "getPublic": {
+      "url": "/gists/public",
       "method": "GET",
       "params": {
-        "gist_id": {
-          "type": "string",
-          "required": true,
-          "description": "Id (SHA1 hash) of the gist."
+        "since": {
+          "type": "date",
+          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
         }
       },
-      "description": "List comments on a gist"
+      "description": "List all public gists"
     },
-    "getComment": {
-      "url": "/gists/:gist_id/comments/:id",
+    "getRevision": {
+      "url": "/gists/:id/:sha",
       "method": "GET",
       "params": {
-        "gist_id": {
-          "type": "string",
-          "required": true,
-          "description": "Id (SHA1 hash) of the gist."
-        },
         "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a single comment"
-    },
-    "createComment": {
-      "url": "/gists/:gist_id/comments",
-      "method": "POST",
-      "params": {
-        "gist_id": {
-          "type": "string",
-          "required": true,
-          "description": "Id (SHA1 hash) of the gist."
-        },
-        "body": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Create a comment"
-    },
-    "editComment": {
-      "url": "/gists/:gist_id/comments/:id",
-      "method": "PATCH",
-      "params": {
-        "gist_id": {
-          "type": "string",
-          "required": true,
-          "description": "Id (SHA1 hash) of the gist."
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "body": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Edit a comment"
-    },
-    "deleteComment": {
-      "url": "/gists/:gist_id/comments/:id",
-      "method": "DELETE",
-      "params": {
-        "gist_id": {
-          "type": "string",
-          "required": true,
-          "description": "Id (SHA1 hash) of the gist."
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete a comment"
-    }
-  },
-  "gitdata": {
-    "getBlob": {
-      "url": "/repos/:owner/:repo/git/blobs/:sha",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
         "sha": {
           "type": "string",
           "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
         }
       },
-      "description": "Get a Blob"
+      "description": "Get a specific revision of a gist"
     },
+    "getStarred": {
+      "url": "/gists/starred",
+      "method": "GET",
+      "params": {
+        "since": {
+          "type": "date",
+          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+        }
+      },
+      "description": "List the authenticated user's starred gists"
+    },
+    "star": {
+      "url": "/gists/:id/star",
+      "method": "PUT",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Star a gist"
+    },
+    "unstar": {
+      "url": "/gists/:id/star",
+      "method": "DELETE",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Unstar a gist"
+    }
+  },
+  "gitdata": {
     "createBlob": {
       "url": "/repos/:owner/:repo/git/blobs",
       "method": "POST",
@@ -1288,25 +1810,6 @@
         }
       },
       "description": "Create a Blob"
-    },
-    "getCommit": {
-      "url": "/repos/:owner/:repo/git/commits/:sha",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "sha": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a Commit"
     },
     "createCommit": {
       "url": "/repos/:owner/:repo/git/commits",
@@ -1343,6 +1846,162 @@
         }
       },
       "description": "Create a Commit"
+    },
+    "createReference": {
+      "url": "/repos/:owner/:repo/git/refs",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "ref": {
+          "type": "string",
+          "required": true,
+          "description": "The name of the fully qualified reference (ie: refs/heads/master). If it doesn't start with 'refs' and have at least two slashes, it will be rejected. NOTE: After creating the reference, on calling (get|update|delete)Reference, drop the leading 'refs/' when providing the 'ref' param."
+        },
+        "sha": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Create a Reference"
+    },
+    "createTag": {
+      "url": "/repos/:owner/:repo/git/tags",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "tag": {
+          "type": "string",
+          "required": true,
+          "description": "String of the tag"
+        },
+        "message": {
+          "type": "string",
+          "required": true,
+          "description": "String of the tag message"
+        },
+        "object": {
+          "type": "string",
+          "required": true,
+          "description": "String of the SHA of the git object this is tagging"
+        },
+        "type": {
+          "type": "string",
+          "required": true,
+          "description": "String of the type of the object we’re tagging. Normally this is a commit but it can also be a tree or a blob."
+        },
+        "tagger": {
+          "type": "json",
+          "required": true,
+          "description": "JSON object that contains the following keys: `name` - String of the name of the author of the tag, `email` - String of the email of the author of the tag, `date` - Timestamp of when this object was tagged"
+        }
+      },
+      "description": "Create a Tag Object"
+    },
+    "createTree": {
+      "url": "/repos/:owner/:repo/git/trees",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "tree": {
+          "type": "json",
+          "required": true,
+          "description": "Array of Hash objects (of path, mode, type and sha) specifying a tree structure"
+        },
+        "base_tree": {
+          "type": "string",
+          "description": "String of the SHA1 of the tree you want to update with new data"
+        }
+      },
+      "description": "Create a Tree"
+    },
+    "deleteReference": {
+      "url": "/repos/:owner/:repo/git/refs/:ref",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "ref": {
+          "type": "string",
+          "required": true,
+          "allow-empty": true,
+          "description": "String of the name of the fully qualified reference (ie: heads/master). If it doesn’t have at least one slash, it will be rejected."
+        }
+      },
+      "description": "Delete a Reference"
+    },
+    "getBlob": {
+      "url": "/repos/:owner/:repo/git/blobs/:sha",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "sha": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Get a Blob"
+    },
+    "getCommit": {
+      "url": "/repos/:owner/:repo/git/commits/:sha",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "sha": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a Commit"
     },
     "getCommitSignatureVerification": {
       "url": "/repos/:owner/:repo/git/commits/:sha",
@@ -1408,6 +2067,44 @@
       },
       "description": "Get all References"
     },
+    "getTag": {
+      "url": "/repos/:owner/:repo/git/tags/:sha",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "sha": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a Tag"
+    },
+    "getTagSignatureVerification": {
+      "url": "/repos/:owner/:repo/git/tags/:sha",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "sha": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a Tag Signature Verification. (In preview period. See README.)"
+    },
     "getTags": {
       "url": "/repos/:owner/:repo/git/refs/tags",
       "method": "GET",
@@ -1432,9 +2129,9 @@
       },
       "description": "Get all tag References"
     },
-    "createReference": {
-      "url": "/repos/:owner/:repo/git/refs",
-      "method": "POST",
+    "getTree": {
+      "url": "/repos/:owner/:repo/git/trees/:sha",
+      "method": "GET",
       "params": {
         "owner": {
           "type": "string",
@@ -1444,17 +2141,15 @@
           "type": "string",
           "required": true
         },
-        "ref": {
-          "type": "string",
-          "required": true,
-          "description": "The name of the fully qualified reference (ie: refs/heads/master). If it doesn't start with 'refs' and have at least two slashes, it will be rejected. NOTE: After creating the reference, on calling (get|update|delete)Reference, drop the leading 'refs/' when providing the 'ref' param."
-        },
         "sha": {
           "type": "string",
           "required": true
+        },
+        "recursive": {
+          "type": "boolean"
         }
       },
-      "description": "Create a Reference"
+      "description": "Get a Tree"
     },
     "updateReference": {
       "url": "/repos/:owner/:repo/git/refs/:ref",
@@ -1485,173 +2180,27 @@
         }
       },
       "description": "Update a Reference"
-    },
-    "deleteReference": {
-      "url": "/repos/:owner/:repo/git/refs/:ref",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "ref": {
-          "type": "string",
-          "required": true,
-          "allow-empty": true,
-          "description": "String of the name of the fully qualified reference (ie: heads/master). If it doesn’t have at least one slash, it will be rejected."
-        }
-      },
-      "description": "Delete a Reference"
-    },
-    "getTag": {
-      "url": "/repos/:owner/:repo/git/tags/:sha",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "sha": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a Tag"
-    },
-    "createTag": {
-      "url": "/repos/:owner/:repo/git/tags",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "tag": {
-          "type": "string",
-          "required": true,
-          "description": "String of the tag"
-        },
-        "message": {
-          "type": "string",
-          "required": true,
-          "description": "String of the tag message"
-        },
-        "object": {
-          "type": "string",
-          "required": true,
-          "description": "String of the SHA of the git object this is tagging"
-        },
-        "type": {
-          "type": "string",
-          "required": true,
-          "description": "String of the type of the object we’re tagging. Normally this is a commit but it can also be a tree or a blob."
-        },
-        "tagger": {
-          "type": "json",
-          "required": true,
-          "description": "JSON object that contains the following keys: `name` - String of the name of the author of the tag, `email` - String of the email of the author of the tag, `date` - Timestamp of when this object was tagged"
-        }
-      },
-      "description": "Create a Tag Object"
-    },
-    "getTagSignatureVerification": {
-      "url": "/repos/:owner/:repo/git/tags/:sha",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "sha": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a Tag Signature Verification. (In preview period. See README.)"
-    },
-    "getTree": {
-      "url": "/repos/:owner/:repo/git/trees/:sha",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "sha": {
-          "type": "string",
-          "required": true
-        },
-        "recursive": {
-          "type": "boolean"
-        }
-      },
-      "description": "Get a Tree"
-    },
-    "createTree": {
-      "url": "/repos/:owner/:repo/git/trees",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "tree": {
-          "type": "json",
-          "required": true,
-          "description": "Array of Hash objects (of path, mode, type and sha) specifying a tree structure"
-        },
-        "base_tree": {
-          "type": "string",
-          "description": "String of the SHA1 of the tree you want to update with new data"
-        }
-      },
-      "description": "Create a Tree"
     }
   },
   "integrations": {
-    "getInstallations": {
-      "url": "/app/installations",
-      "method": "GET",
+    "addRepoToInstallation": {
+      "url": "/installations/:installation_id/repositories/:repository_id",
+      "method": "PUT",
       "deprecated": "`integrations` has been renamed to `apps`",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
       "params": {
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+        "installation_id": {
+          "type": "string",
+          "required": true
         },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+        "repository_id": {
+          "type": "string",
+          "required": true
         }
       },
-      "description": "List the app's installations. (In preview period. See README.)"
+      "description": "Add a single repository to an installation. (In preview period. See README.)"
     },
     "createInstallationToken": {
       "url": "/installations/:installation_id/access_tokens",
@@ -1687,70 +2236,10 @@
       },
       "description": "List repositories that are accessible to the authenticated installation. (In preview period. See README.)"
     },
-    "addRepoToInstallation": {
-      "url": "/installations/:installation_id/repositories/:repository_id",
-      "method": "PUT",
-      "deprecated": "`integrations` has been renamed to `apps`",
-      "headers": {
-        "accept": "application/vnd.github.machine-man-preview"
-      },
-      "params": {
-        "installation_id": {
-          "type": "string",
-          "required": true
-        },
-        "repository_id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Add a single repository to an installation. (In preview period. See README.)"
-    },
-    "removeRepoFromInstallation": {
-      "url": "/installations/:installation_id/repositories/:repository_id",
-      "method": "DELETE",
-      "deprecated": "`integrations` has been renamed to `apps`",
-      "headers": {
-        "accept": "application/vnd.github.machine-man-preview"
-      },
-      "params": {
-        "installation_id": {
-          "type": "string",
-          "required": true
-        },
-        "repository_id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Remove a single repository from an installation. (In preview period. See README.)"
-    }
-  },
-  "apps": {
-    "get": {
-      "url": "/app",
-      "method": "GET",
-      "params": {},
-      "description": "Get the authenticated GitHub App. (In preview period. See README.)"
-    },
-    "getForSlug": {
-      "url": "/apps/:app_slug",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.machine-man-preview"
-      },
-      "params": {
-        "app_slug": {
-          "type": "string",
-          "required": true,
-          "description": "The URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., https://github.com/settings/apps/:app_slug)."
-        }
-      },
-      "description": "Get a single GitHub App. (In preview period. See README.)"
-    },
     "getInstallations": {
       "url": "/app/installations",
       "method": "GET",
+      "deprecated": "`integrations` has been renamed to `apps`",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
@@ -1767,73 +2256,10 @@
       },
       "description": "List the app's installations. (In preview period. See README.)"
     },
-    "getInstallation": {
-      "url": "/app/installations/:installation_id",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.machine-man-preview"
-      },
-      "params": {
-        "installation_id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a single installation. (In preview period. See README.)"
-    },
-    "createInstallationToken": {
-      "url": "/installations/:installation_id/access_tokens",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.machine-man-preview"
-      },
-      "params": {
-        "installation_id": {
-          "type": "string",
-          "required": true
-        },
-        "user_id": {
-          "type": "string",
-          "description": "The id of the user for whom the app is acting on behalf of."
-        }
-      },
-      "description": "Create a new installation token. (In preview period. See README.)"
-    },
-    "getInstallationRepositories": {
-      "url": "/installation/repositories",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.machine-man-preview"
-      },
-      "params": {
-        "user_id": {
-          "type": "string",
-          "description": "The integer ID of a user, to filter results to repositories that are visible to both the installation and the given user."
-        }
-      },
-      "description": "List repositories that are accessible to the authenticated installation. (In preview period. See README.)"
-    },
-    "addRepoToInstallation": {
-      "url": "/installations/:installation_id/repositories/:repository_id",
-      "method": "PUT",
-      "headers": {
-        "accept": "application/vnd.github.machine-man-preview"
-      },
-      "params": {
-        "installation_id": {
-          "type": "string",
-          "required": true
-        },
-        "repository_id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Add a single repository to an installation. (In preview period. See README.)"
-    },
     "removeRepoFromInstallation": {
       "url": "/installations/:installation_id/repositories/:repository_id",
       "method": "DELETE",
+      "deprecated": "`integrations` has been renamed to `apps`",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
@@ -1848,127 +2274,12 @@
         }
       },
       "description": "Remove a single repository from an installation. (In preview period. See README.)"
-    },
-    "getMarketplaceListingPlans": {
-      "url": "/marketplace_listing/plans",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.valkyrie-preview+json"
-      },
-      "params": {
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List all plans for your Marketplace listing. (In preview period. See README.)"
-    },
-    "getMarketplaceListingStubbedPlans": {
-      "url": "/marketplace_listing/stubbed/plans",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.valkyrie-preview+json"
-      },
-      "params": {
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List all stubbed plans for your Marketplace listing. (In preview period. See README.)"
-    },
-    "getMarketplaceListingPlanAccounts": {
-      "url": "/marketplace_listing/plans/:id/accounts",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.valkyrie-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List all GitHub accounts (user or organization) on a specific plan. (In preview period. See README.)"
-    },
-    "getMarketplaceListingStubbedPlanAccounts": {
-      "url": "/marketplace_listing/stubbed/plans/:id/accounts",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.valkyrie-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List all GitHub accounts (user or organization) on a specific stubbed plan. (In preview period. See README.)"
-    },
-    "checkMarketplaceListingAccount": {
-      "url": "/marketplace_listing/accounts/:id",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.valkyrie-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Check if a GitHub account is associated with any Marketplace listing. (In preview period. See README.)"
-    },
-    "checkMarketplaceListingStubbedAccount": {
-      "url": "/marketplace_listing/stubbed/accounts/:id",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.valkyrie-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Check if a stubbed GitHub account is associated with any Marketplace listing. (In preview period. See README.)"
     }
   },
   "issues": {
-    "get": {
-      "url": "/repos/:owner/:repo/issues/:number",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
+    "addAssigneesToIssue": {
+      "url": "/repos/:owner/:repo/issues/:number/assignees",
+      "method": "POST",
       "params": {
         "owner": {
           "type": "string",
@@ -1981,9 +2292,58 @@
         "number": {
           "type": "number",
           "required": true
+        },
+        "assignees": {
+          "type": "string[]",
+          "required": true,
+          "description": "Logins for the users that should be added to the issue."
         }
       },
-      "description": "Get a single issue"
+      "description": "Add assignees to an issue."
+    },
+    "addLabels": {
+      "url": "/repos/:owner/:repo/issues/:number/labels",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "labels": {
+          "type": "string[]",
+          "required": true,
+          "mapTo": "input"
+        }
+      },
+      "description": "Add labels to an issue"
+    },
+    "checkAssignee": {
+      "url": "/repos/:owner/:repo/assignees/:assignee",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "assignee": {
+          "type": "string",
+          "required": true,
+          "description": "Login for the user that this issue should be assigned to."
+        }
+      },
+      "description": "Check assignee"
     },
     "create": {
       "url": "/repos/:owner/:repo/issues",
@@ -2025,6 +2385,151 @@
         }
       },
       "description": "Create an issue"
+    },
+    "createComment": {
+      "url": "/repos/:owner/:repo/issues/:number/comments",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "body": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Create a comment"
+    },
+    "createLabel": {
+      "url": "/repos/:owner/:repo/labels",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "name": {
+          "type": "string",
+          "required": true
+        },
+        "color": {
+          "type": "string",
+          "required": true,
+          "description": "6 character hex code, without a leading #."
+        }
+      },
+      "description": "Create a label"
+    },
+    "createMilestone": {
+      "url": "/repos/:owner/:repo/milestones",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "title": {
+          "type": "string",
+          "required": true
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "closed",
+            "all"
+          ],
+          "default": "open"
+        },
+        "description": {
+          "type": "string"
+        },
+        "due_on": {
+          "type": "date",
+          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+        }
+      },
+      "description": "Create a milestone"
+    },
+    "deleteComment": {
+      "url": "/repos/:owner/:repo/issues/comments/:id",
+      "method": "DELETE",
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a comment"
+    },
+    "deleteLabel": {
+      "url": "/repos/:owner/:repo/labels/:name",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "name": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a label"
+    },
+    "deleteMilestone": {
+      "url": "/repos/:owner/:repo/milestones/:number",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        }
+      },
+      "description": "Delete a milestone"
     },
     "edit": {
       "url": "/repos/:owner/:repo/issues/:number",
@@ -2080,9 +2585,12 @@
       },
       "description": "Edit an issue"
     },
-    "lock": {
-      "url": "/repos/:owner/:repo/issues/:number/lock",
-      "method": "PUT",
+    "editComment": {
+      "url": "/repos/:owner/:repo/issues/comments/:id",
+      "method": "PATCH",
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
       "params": {
         "owner": {
           "type": "string",
@@ -2092,16 +2600,23 @@
           "type": "string",
           "required": true
         },
-        "number": {
-          "type": "number",
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "body": {
+          "type": "string",
           "required": true
         }
       },
-      "description": "Users with push access can lock an issue's conversation."
+      "description": "Edit a comment"
     },
-    "unlock": {
-      "url": "/repos/:owner/:repo/issues/:number/lock",
-      "method": "DELETE",
+    "get": {
+      "url": "/repos/:owner/:repo/issues/:number",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
       "params": {
         "owner": {
           "type": "string",
@@ -2116,7 +2631,7 @@
           "required": true
         }
       },
-      "description": "Users with push access can unlock an issue's conversation."
+      "description": "Get a single issue"
     },
     "getAll": {
       "url": "/issues",
@@ -2184,43 +2699,98 @@
       },
       "description": "List all issues across all the authenticated user's visible repositories including owned repositories, member repositories, and organization repositories"
     },
-    "getForUser": {
-      "url": "/user/issues",
+    "getAssignees": {
+      "url": "/repos/:owner/:repo/assignees",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "List assignees"
+    },
+    "getComment": {
+      "url": "/repos/:owner/:repo/issues/comments/:id",
       "method": "GET",
       "headers": {
         "accept": "application/vnd.github.squirrel-girl-preview"
       },
       "params": {
-        "filter": {
+        "owner": {
           "type": "string",
-          "enum": [
-            "all",
-            "assigned",
-            "created",
-            "mentioned",
-            "subscribed"
-          ]
+          "required": true
         },
-        "state": {
+        "repo": {
           "type": "string",
-          "enum": [
-            "open",
-            "closed",
-            "all"
-          ],
-          "default": "open",
-          "description": "open, closed, or all"
+          "required": true
         },
-        "labels": {
+        "id": {
           "type": "string",
-          "description": "String list of comma separated Label names. Example: bug,ui,@high"
+          "required": true
+        }
+      },
+      "description": "Get a single comment"
+    },
+    "getComments": {
+      "url": "/repos/:owner/:repo/issues/:number/comments",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "since": {
+          "type": "date",
+          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List comments on an issue"
+    },
+    "getCommentsForRepo": {
+      "url": "/repos/:owner/:repo/issues/comments",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         },
         "sort": {
           "type": "string",
           "enum": [
             "created",
-            "updated",
-            "comments"
+            "updated"
           ],
           "default": "created"
         },
@@ -2246,7 +2816,109 @@
           "description": "A custom page size up to 100. Default is 30."
         }
       },
-      "description": "List all issues across owned and member repositories for the authenticated user"
+      "description": "List comments in a repository"
+    },
+    "getEvent": {
+      "url": "/repos/:owner/:repo/issues/events/:id",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a single event"
+    },
+    "getEvents": {
+      "url": "/repos/:owner/:repo/issues/:issue_number/events",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "issue_number": {
+          "type": "number",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List events for an issue"
+    },
+    "getEventsForRepo": {
+      "url": "/repos/:owner/:repo/issues/events",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List events for a repository"
+    },
+    "getEventsTimeline": {
+      "url": "/repos/:owner/:repo/issues/:issue_number/timeline",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.mockingbird-preview"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "issue_number": {
+          "type": "number",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List events for an issue. (In preview period. See README.)"
     },
     "getForOrg": {
       "url": "/orgs/:org/issues",
@@ -2394,143 +3066,43 @@
       },
       "description": "List issues for a repository"
     },
-    "getAssignees": {
-      "url": "/repos/:owner/:repo/assignees",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "List assignees"
-    },
-    "checkAssignee": {
-      "url": "/repos/:owner/:repo/assignees/:assignee",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "assignee": {
-          "type": "string",
-          "required": true,
-          "description": "Login for the user that this issue should be assigned to."
-        }
-      },
-      "description": "Check assignee"
-    },
-    "addAssigneesToIssue": {
-      "url": "/repos/:owner/:repo/issues/:number/assignees",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "assignees": {
-          "type": "string[]",
-          "required": true,
-          "description": "Logins for the users that should be added to the issue."
-        }
-      },
-      "description": "Add assignees to an issue."
-    },
-    "removeAssigneesFromIssue": {
-      "url": "/repos/:owner/:repo/issues/:number/assignees",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "body": {
-          "type": "json",
-          "required": true
-        }
-      },
-      "description": "Remove assignees from an issue."
-    },
-    "getComments": {
-      "url": "/repos/:owner/:repo/issues/:number/comments",
+    "getForUser": {
+      "url": "/user/issues",
       "method": "GET",
       "headers": {
         "accept": "application/vnd.github.squirrel-girl-preview"
       },
       "params": {
-        "owner": {
+        "filter": {
           "type": "string",
-          "required": true
+          "enum": [
+            "all",
+            "assigned",
+            "created",
+            "mentioned",
+            "subscribed"
+          ]
         },
-        "repo": {
+        "state": {
           "type": "string",
-          "required": true
+          "enum": [
+            "open",
+            "closed",
+            "all"
+          ],
+          "default": "open",
+          "description": "open, closed, or all"
         },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List comments on an issue"
-    },
-    "getCommentsForRepo": {
-      "url": "/repos/:owner/:repo/issues/comments",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
-        "owner": {
+        "labels": {
           "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
+          "description": "String list of comma separated Label names. Example: bug,ui,@high"
         },
         "sort": {
           "type": "string",
           "enum": [
             "created",
-            "updated"
+            "updated",
+            "comments"
           ],
           "default": "created"
         },
@@ -2556,36 +3128,11 @@
           "description": "A custom page size up to 100. Default is 30."
         }
       },
-      "description": "List comments in a repository"
+      "description": "List all issues across owned and member repositories for the authenticated user"
     },
-    "getComment": {
-      "url": "/repos/:owner/:repo/issues/comments/:id",
+    "getIssueLabels": {
+      "url": "/repos/:owner/:repo/issues/:number/labels",
       "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a single comment"
-    },
-    "createComment": {
-      "url": "/repos/:owner/:repo/issues/:number/comments",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
       "params": {
         "owner": {
           "type": "string",
@@ -2598,64 +3145,12 @@
         "number": {
           "type": "number",
           "required": true
-        },
-        "body": {
-          "type": "string",
-          "required": true
         }
       },
-      "description": "Create a comment"
+      "description": "List labels on an issue"
     },
-    "editComment": {
-      "url": "/repos/:owner/:repo/issues/comments/:id",
-      "method": "PATCH",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "body": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Edit a comment"
-    },
-    "deleteComment": {
-      "url": "/repos/:owner/:repo/issues/comments/:id",
-      "method": "DELETE",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete a comment"
-    },
-    "getEvents": {
-      "url": "/repos/:owner/:repo/issues/:issue_number/events",
+    "getLabel": {
+      "url": "/repos/:owner/:repo/labels/:name",
       "method": "GET",
       "params": {
         "owner": {
@@ -2666,64 +3161,12 @@
           "type": "string",
           "required": true
         },
-        "issue_number": {
-          "type": "number",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List events for an issue"
-    },
-    "getEventsForRepo": {
-      "url": "/repos/:owner/:repo/issues/events",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List events for a repository"
-    },
-    "getEvent": {
-      "url": "/repos/:owner/:repo/issues/events/:id",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
+        "name": {
           "type": "string",
           "required": true
         }
       },
-      "description": "Get a single event"
+      "description": "Get a single label"
     },
     "getLabels": {
       "url": "/repos/:owner/:repo/labels",
@@ -2749,100 +3192,8 @@
       },
       "description": "List all labels for this repository"
     },
-    "getLabel": {
-      "url": "/repos/:owner/:repo/labels/:name",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "name": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a single label"
-    },
-    "createLabel": {
-      "url": "/repos/:owner/:repo/labels",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "name": {
-          "type": "string",
-          "required": true
-        },
-        "color": {
-          "type": "string",
-          "required": true,
-          "description": "6 character hex code, without a leading #."
-        }
-      },
-      "description": "Create a label"
-    },
-    "updateLabel": {
-      "url": "/repos/:owner/:repo/labels/:oldname",
-      "method": "PATCH",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "oldname": {
-          "type": "string",
-          "required": true,
-          "description": "The old name of the label."
-        },
-        "name": {
-          "type": "string",
-          "required": true,
-          "description": "The new name of the label."
-        },
-        "color": {
-          "type": "string",
-          "required": true,
-          "description": "6 character hex code, without a leading #."
-        }
-      },
-      "description": "Update a label"
-    },
-    "deleteLabel": {
-      "url": "/repos/:owner/:repo/labels/:name",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "name": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete a label"
-    },
-    "getIssueLabels": {
-      "url": "/repos/:owner/:repo/issues/:number/labels",
+    "getMilestone": {
+      "url": "/repos/:owner/:repo/milestones/:number",
       "method": "GET",
       "params": {
         "owner": {
@@ -2858,98 +3209,7 @@
           "required": true
         }
       },
-      "description": "List labels on an issue"
-    },
-    "addLabels": {
-      "url": "/repos/:owner/:repo/issues/:number/labels",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "labels": {
-          "type": "string[]",
-          "required": true,
-          "mapTo": "input"
-        }
-      },
-      "description": "Add labels to an issue"
-    },
-    "removeLabel": {
-      "url": "/repos/:owner/:repo/issues/:number/labels/:name",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "name": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Remove a label from an issue"
-    },
-    "replaceAllLabels": {
-      "url": "/repos/:owner/:repo/issues/:number/labels",
-      "method": "PUT",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "labels": {
-          "type": "string[]",
-          "required": true,
-          "mapTo": "input",
-          "description": "Sending an empty array ([]) will remove all Labels from the Issue."
-        }
-      },
-      "description": "Replace all labels for an issue"
-    },
-    "removeAllLabels": {
-      "url": "/repos/:owner/:repo/issues/:number/labels",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        }
-      },
-      "description": "Remove all labels from an issue"
+      "description": "Get a single milestone"
     },
     "getMilestoneLabels": {
       "url": "/repos/:owner/:repo/milestones/:number/labels",
@@ -3020,9 +3280,9 @@
       },
       "description": "List milestones for a repository"
     },
-    "getMilestone": {
-      "url": "/repos/:owner/:repo/milestones/:number",
-      "method": "GET",
+    "lock": {
+      "url": "/repos/:owner/:repo/issues/:number/lock",
+      "method": "PUT",
       "params": {
         "owner": {
           "type": "string",
@@ -3037,11 +3297,11 @@
           "required": true
         }
       },
-      "description": "Get a single milestone"
+      "description": "Users with push access can lock an issue's conversation."
     },
-    "createMilestone": {
-      "url": "/repos/:owner/:repo/milestones",
-      "method": "POST",
+    "removeAllLabels": {
+      "url": "/repos/:owner/:repo/issues/:number/labels",
+      "method": "DELETE",
       "params": {
         "owner": {
           "type": "string",
@@ -3051,28 +3311,132 @@
           "type": "string",
           "required": true
         },
-        "title": {
+        "number": {
+          "type": "number",
+          "required": true
+        }
+      },
+      "description": "Remove all labels from an issue"
+    },
+    "removeAssigneesFromIssue": {
+      "url": "/repos/:owner/:repo/issues/:number/assignees",
+      "method": "DELETE",
+      "params": {
+        "owner": {
           "type": "string",
           "required": true
         },
-        "state": {
+        "repo": {
           "type": "string",
-          "enum": [
-            "open",
-            "closed",
-            "all"
-          ],
-          "default": "open"
+          "required": true
         },
-        "description": {
-          "type": "string"
+        "number": {
+          "type": "number",
+          "required": true
         },
-        "due_on": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+        "body": {
+          "type": "json",
+          "required": true
         }
       },
-      "description": "Create a milestone"
+      "description": "Remove assignees from an issue."
+    },
+    "removeLabel": {
+      "url": "/repos/:owner/:repo/issues/:number/labels/:name",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "name": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Remove a label from an issue"
+    },
+    "replaceAllLabels": {
+      "url": "/repos/:owner/:repo/issues/:number/labels",
+      "method": "PUT",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "labels": {
+          "type": "string[]",
+          "required": true,
+          "mapTo": "input",
+          "description": "Sending an empty array ([]) will remove all Labels from the Issue."
+        }
+      },
+      "description": "Replace all labels for an issue"
+    },
+    "unlock": {
+      "url": "/repos/:owner/:repo/issues/:number/lock",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        }
+      },
+      "description": "Users with push access can unlock an issue's conversation."
+    },
+    "updateLabel": {
+      "url": "/repos/:owner/:repo/labels/:oldname",
+      "method": "PATCH",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "oldname": {
+          "type": "string",
+          "required": true,
+          "description": "The old name of the label."
+        },
+        "name": {
+          "type": "string",
+          "required": true,
+          "description": "The new name of the label."
+        },
+        "color": {
+          "type": "string",
+          "required": true,
+          "description": "6 character hex code, without a leading #."
+        }
+      },
+      "description": "Update a label"
     },
     "updateMilestone": {
       "url": "/repos/:owner/:repo/milestones/:number",
@@ -3112,62 +3476,30 @@
         }
       },
       "description": "Update a milestone"
-    },
-    "deleteMilestone": {
-      "url": "/repos/:owner/:repo/milestones/:number",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        }
-      },
-      "description": "Delete a milestone"
-    },
-    "getEventsTimeline": {
-      "url": "/repos/:owner/:repo/issues/:issue_number/timeline",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.mockingbird-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "issue_number": {
-          "type": "number",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List events for an issue. (In preview period. See README.)"
     }
   },
   "migrations": {
-    "startMigration": {
-      "url": "/orgs/:org/migrations",
-      "method": "POST",
+    "cancelImport": {
+      "url": "/repos/:owner/:repo/import",
+      "method": "DELETE",
+      "headers": {
+        "accept": "application/vnd.github.barred-rock-preview"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Cancel an import. (In preview period. See README.)"
+    },
+    "deleteMigrationArchive": {
+      "url": "/orgs/:org/migrations/:id/archive",
+      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.wyandotte-preview+json"
       },
@@ -3176,23 +3508,106 @@
           "type": "string",
           "required": true
         },
-        "repositories": {
-          "type": "string[]",
-          "required": true,
-          "description": "A list of arrays indicating which repositories should be migrated."
-        },
-        "lock_repositories": {
-          "type": "boolean",
-          "default": "false",
-          "description": "Indicates whether repositories should be locked (to prevent manipulation) while migrating data. Default: false."
-        },
-        "exclude_attachments": {
-          "type": "boolean",
-          "default": "false",
-          "description": "Indicates whether attachments should be excluded from the migration (to reduce migration archive file size). Default: false."
+        "id": {
+          "type": "string",
+          "required": true
         }
       },
-      "description": "Start a migration. (In preview period. See README.)"
+      "description": "Delete a migration archive. (In preview period. See README.)"
+    },
+    "getImportCommitAuthors": {
+      "url": "/repos/:owner/:repo/import/authors",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.barred-rock-preview"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "since": {
+          "type": "string",
+          "description": "Only authors found after this id are returned. Provide the highest author ID you've seen so far. New authors may be added to the list at any point while the importer is performing the raw step."
+        }
+      },
+      "description": "Get import commit authors. (In preview period. See README.)"
+    },
+    "getImportProgress": {
+      "url": "/repos/:owner/:repo/import",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.barred-rock-preview"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get import progress. (In preview period. See README.)"
+    },
+    "getLargeImportFiles": {
+      "url": "/:owner/:name/import/large_files",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.barred-rock-preview"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "name": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "List files larger than 100MB found during the import. (In preview period. See README.)"
+    },
+    "getMigrationArchiveLink": {
+      "url": "/orgs/:org/migrations/:id/archive",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.wyandotte-preview+json"
+      },
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get the URL to a migration archive. (In preview period. See README.)"
+    },
+    "getMigrationStatus": {
+      "url": "/orgs/:org/migrations/:id",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.wyandotte-preview+json"
+      },
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get the status of a migration. (In preview period. See README.)"
     },
     "getMigrations": {
       "url": "/orgs/:org/migrations",
@@ -3216,193 +3631,6 @@
         }
       },
       "description": "Get a list of migrations. (In preview period. See README.)"
-    },
-    "getMigrationStatus": {
-      "url": "/orgs/:org/migrations/:id",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.wyandotte-preview+json"
-      },
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get the status of a migration. (In preview period. See README.)"
-    },
-    "getMigrationArchiveLink": {
-      "url": "/orgs/:org/migrations/:id/archive",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.wyandotte-preview+json"
-      },
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get the URL to a migration archive. (In preview period. See README.)"
-    },
-    "deleteMigrationArchive": {
-      "url": "/orgs/:org/migrations/:id/archive",
-      "method": "DELETE",
-      "headers": {
-        "accept": "application/vnd.github.wyandotte-preview+json"
-      },
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete a migration archive. (In preview period. See README.)"
-    },
-    "unlockRepoLockedForMigration": {
-      "url": "/orgs/:org/migrations/:id/repos/:repo_name/lock",
-      "method": "DELETE",
-      "headers": {
-        "accept": "application/vnd.github.wyandotte-preview+json"
-      },
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "repo_name": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Unlock a repository that was locked for migration. (In preview period. See README.)"
-    },
-    "startImport": {
-      "url": "/repos/:owner/:repo/import",
-      "method": "PUT",
-      "headers": {
-        "accept": "application/vnd.github.barred-rock-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "vcs_url": {
-          "type": "string",
-          "required": true,
-          "description": "The URL of the originating repository."
-        },
-        "vcs": {
-          "type": "string",
-          "enum": [
-            "subversion",
-            "git",
-            "mercurial",
-            "tfvc"
-          ],
-          "description": "The originating VCS type. Please be aware that without this parameter, the import job will take additional time to detect the VCS type before beginning the import. This detection step will be reflected in the response."
-        },
-        "vcs_username": {
-          "type": "string",
-          "description": "If authentication is required, the username to provide to vcs_url."
-        },
-        "vcs_password": {
-          "type": "string",
-          "description": "If authentication is required, the password to provide to vcs_url."
-        },
-        "tfvc_project": {
-          "type": "string",
-          "description": "For a tfvc import, the name of the project that is being imported."
-        }
-      },
-      "description": "Start an import. (In preview period. See README.)"
-    },
-    "getImportProgress": {
-      "url": "/repos/:owner/:repo/import",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.barred-rock-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get import progress. (In preview period. See README.)"
-    },
-    "updateImport": {
-      "url": "/repos/:owner/:repo/import",
-      "method": "PATCH",
-      "headers": {
-        "accept": "application/vnd.github.barred-rock-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "vcs_username": {
-          "type": "string",
-          "description": "The username to provide to the originating repository."
-        },
-        "vcs_password": {
-          "type": "string",
-          "description": "The password to provide to the originating repository."
-        }
-      },
-      "description": "Update existing import. (In preview period. See README.)"
-    },
-    "getImportCommitAuthors": {
-      "url": "/repos/:owner/:repo/import/authors",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.barred-rock-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "since": {
-          "type": "string",
-          "description": "Only authors found after this id are returned. Provide the highest author ID you've seen so far. New authors may be added to the list at any point while the importer is performing the raw step."
-        }
-      },
-      "description": "Get import commit authors. (In preview period. See README.)"
     },
     "mapImportCommitAuthor": {
       "url": "/repos/:owner/:repo/import/authors/:author_id",
@@ -3458,27 +3686,9 @@
       },
       "description": "Set import LFS preference. (In preview period. See README.)"
     },
-    "getLargeImportFiles": {
-      "url": "/:owner/:name/import/large_files",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.barred-rock-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "name": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "List files larger than 100MB found during the import. (In preview period. See README.)"
-    },
-    "cancelImport": {
+    "startImport": {
       "url": "/repos/:owner/:repo/import",
-      "method": "DELETE",
+      "method": "PUT",
       "headers": {
         "accept": "application/vnd.github.barred-rock-preview"
       },
@@ -3490,21 +3700,116 @@
         "repo": {
           "type": "string",
           "required": true
+        },
+        "vcs_url": {
+          "type": "string",
+          "required": true,
+          "description": "The URL of the originating repository."
+        },
+        "vcs": {
+          "type": "string",
+          "enum": [
+            "subversion",
+            "git",
+            "mercurial",
+            "tfvc"
+          ],
+          "description": "The originating VCS type. Please be aware that without this parameter, the import job will take additional time to detect the VCS type before beginning the import. This detection step will be reflected in the response."
+        },
+        "vcs_username": {
+          "type": "string",
+          "description": "If authentication is required, the username to provide to vcs_url."
+        },
+        "vcs_password": {
+          "type": "string",
+          "description": "If authentication is required, the password to provide to vcs_url."
+        },
+        "tfvc_project": {
+          "type": "string",
+          "description": "For a tfvc import, the name of the project that is being imported."
         }
       },
-      "description": "Cancel an import. (In preview period. See README.)"
+      "description": "Start an import. (In preview period. See README.)"
+    },
+    "startMigration": {
+      "url": "/orgs/:org/migrations",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.wyandotte-preview+json"
+      },
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "repositories": {
+          "type": "string[]",
+          "required": true,
+          "description": "A list of arrays indicating which repositories should be migrated."
+        },
+        "lock_repositories": {
+          "type": "boolean",
+          "default": "false",
+          "description": "Indicates whether repositories should be locked (to prevent manipulation) while migrating data. Default: false."
+        },
+        "exclude_attachments": {
+          "type": "boolean",
+          "default": "false",
+          "description": "Indicates whether attachments should be excluded from the migration (to reduce migration archive file size). Default: false."
+        }
+      },
+      "description": "Start a migration. (In preview period. See README.)"
+    },
+    "unlockRepoLockedForMigration": {
+      "url": "/orgs/:org/migrations/:id/repos/:repo_name/lock",
+      "method": "DELETE",
+      "headers": {
+        "accept": "application/vnd.github.wyandotte-preview+json"
+      },
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "repo_name": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Unlock a repository that was locked for migration. (In preview period. See README.)"
+    },
+    "updateImport": {
+      "url": "/repos/:owner/:repo/import",
+      "method": "PATCH",
+      "headers": {
+        "accept": "application/vnd.github.barred-rock-preview"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "vcs_username": {
+          "type": "string",
+          "description": "The username to provide to the originating repository."
+        },
+        "vcs_password": {
+          "type": "string",
+          "description": "The password to provide to the originating repository."
+        }
+      },
+      "description": "Update existing import. (In preview period. See README.)"
     }
   },
   "misc": {
-    "getCodesOfConduct": {
-      "url": "/codes_of_conduct",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.scarlet-witch-preview+json"
-      },
-      "params": {},
-      "description": "List all codes of conduct. (In preview period. See README.)"
-    },
     "getCodeOfConduct": {
       "url": "/codes_of_conduct/:key",
       "method": "GET",
@@ -3519,6 +3824,75 @@
         }
       },
       "description": "Get an code of conduct. (In preview period. See README.)"
+    },
+    "getCodesOfConduct": {
+      "url": "/codes_of_conduct",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.scarlet-witch-preview+json"
+      },
+      "params": {},
+      "description": "List all codes of conduct. (In preview period. See README.)"
+    },
+    "getEmojis": {
+      "url": "/emojis",
+      "method": "GET",
+      "params": {},
+      "description": "Lists all the emojis available to use on GitHub."
+    },
+    "getGitignoreTemplate": {
+      "url": "/gitignore/templates/:name",
+      "method": "GET",
+      "params": {
+        "name": {
+          "type": "string",
+          "required": true,
+          "description": "The name of the .gitignore template to get e.g. 'C'"
+        }
+      },
+      "description": "Get a single gitignore template"
+    },
+    "getGitignoreTemplates": {
+      "url": "/gitignore/templates",
+      "method": "GET",
+      "params": {},
+      "description": "Lists available gitignore templates"
+    },
+    "getLicense": {
+      "url": "/licenses/:license",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.drax-preview+json"
+      },
+      "params": {
+        "license": {
+          "type": "string",
+          "required": true,
+          "description": "Ex: /licenses/mit"
+        }
+      },
+      "description": "Get an individual license. (In preview period. See README.)"
+    },
+    "getLicenses": {
+      "url": "/licenses",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.drax-preview+json"
+      },
+      "params": {},
+      "description": "List all licenses. (In preview period. See README.)"
+    },
+    "getMeta": {
+      "url": "/meta",
+      "method": "GET",
+      "params": {},
+      "description": "This endpoint provides information about GitHub.com, the service. Or, if you access this endpoint on your organization's GitHub Enterprise installation, this endpoint provides information about that installation."
+    },
+    "getRateLimit": {
+      "url": "/rate_limit",
+      "method": "GET",
+      "params": {},
+      "description": "Get your current rate limit status"
     },
     "getRepoCodeOfConduct": {
       "url": "/repos/:owner/:repo/community/code_of_conduct",
@@ -3537,54 +3911,6 @@
         }
       },
       "description": "Get the contents of a repository's code of conduct. (In preview period. See README.)"
-    },
-    "getEmojis": {
-      "url": "/emojis",
-      "method": "GET",
-      "params": {},
-      "description": "Lists all the emojis available to use on GitHub."
-    },
-    "getGitignoreTemplates": {
-      "url": "/gitignore/templates",
-      "method": "GET",
-      "params": {},
-      "description": "Lists available gitignore templates"
-    },
-    "getGitignoreTemplate": {
-      "url": "/gitignore/templates/:name",
-      "method": "GET",
-      "params": {
-        "name": {
-          "type": "string",
-          "required": true,
-          "description": "The name of the .gitignore template to get e.g. 'C'"
-        }
-      },
-      "description": "Get a single gitignore template"
-    },
-    "getLicenses": {
-      "url": "/licenses",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.drax-preview+json"
-      },
-      "params": {},
-      "description": "List all licenses. (In preview period. See README.)"
-    },
-    "getLicense": {
-      "url": "/licenses/:license",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.drax-preview+json"
-      },
-      "params": {
-        "license": {
-          "type": "string",
-          "required": true,
-          "description": "Ex: /licenses/mit"
-        }
-      },
-      "description": "Get an individual license. (In preview period. See README.)"
     },
     "getRepoLicense": {
       "url": "/repos/:owner/:repo/license",
@@ -3644,21 +3970,398 @@
         }
       },
       "description": "Render a Markdown document in raw mode"
-    },
-    "getMeta": {
-      "url": "/meta",
-      "method": "GET",
-      "params": {},
-      "description": "This endpoint provides information about GitHub.com, the service. Or, if you access this endpoint on your organization's GitHub Enterprise installation, this endpoint provides information about that installation."
-    },
-    "getRateLimit": {
-      "url": "/rate_limit",
-      "method": "GET",
-      "params": {},
-      "description": "Get your current rate limit status"
     }
   },
   "orgs": {
+    "addOrgMembership": {
+      "url": "/orgs/:org/memberships/:username",
+      "method": "PUT",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        },
+        "role": {
+          "type": "string",
+          "required": true,
+          "enum": [
+            "admin",
+            "member"
+          ],
+          "default": "member",
+          "description": "The role to give the user in the organization."
+        }
+      },
+      "description": "Add or update organization membership"
+    },
+    "addTeamMembership": {
+      "url": "/teams/:id/memberships/:username",
+      "method": "PUT",
+      "headers": {
+        "accept": "application/vnd.github.hellcat-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "member",
+            "maintainer"
+          ],
+          "default": "member",
+          "description": "The role that this user should have in the team."
+        }
+      },
+      "description": "Add team membership"
+    },
+    "addTeamRepo": {
+      "url": "/teams/:id/repos/:org/:repo",
+      "method": "PUT",
+      "headers": {
+        "accept": "application/vnd.github.hellcat-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "permission": {
+          "type": "string",
+          "enum": [
+            "pull",
+            "push",
+            "admin"
+          ],
+          "description": "`pull` - team members can pull, but not push or administer this repository, `push` - team members can pull and push, but not administer this repository, `admin` - team members can pull, push and administer this repository."
+        }
+      },
+      "description": "Add team repository"
+    },
+    "blockUser": {
+      "url": "/orgs/:org/blocks/:username",
+      "method": "PUT",
+      "headers": {
+        "accept": "application/vnd.github.giant-sentry-fist-preview+json"
+      },
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Block a user. (In preview period. See README.)"
+    },
+    "checkBlockedUser": {
+      "url": "/orgs/:org/blocks/:username",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.giant-sentry-fist-preview+json"
+      },
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Check whether you've blocked a user. (In preview period. See README.)"
+    },
+    "checkMembership": {
+      "url": "/orgs/:org/members/:username",
+      "method": "GET",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Check membership"
+    },
+    "checkPublicMembership": {
+      "url": "/orgs/:org/public_members/:username",
+      "method": "GET",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Check public membership"
+    },
+    "checkTeamRepo": {
+      "url": "/teams/:id/repos/:owner/:repo",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.hellcat-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Check if a team manages a repository"
+    },
+    "concealMembership": {
+      "url": "/orgs/:org/public_members/:username",
+      "method": "DELETE",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Conceal a user's membership"
+    },
+    "convertMemberToOutsideCollaborator": {
+      "url": "/orgs/:org/outside_collaborators/:username",
+      "method": "PUT",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Convert member to outside collaborator."
+    },
+    "createHook": {
+      "url": "/orgs/:org/hooks",
+      "method": "POST",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "name": {
+          "type": "string",
+          "required": true,
+          "description": "Must be passed as \"web\"."
+        },
+        "config": {
+          "type": "json",
+          "required": true,
+          "description": "Key/value pairs to provide settings for this webhook"
+        },
+        "events": {
+          "type": "string[]",
+          "default": "[\"push\"]",
+          "description": "Determines what events the hook is triggered for. Default: [\"push\"]."
+        },
+        "active": {
+          "type": "boolean",
+          "description": "Determines whether the hook is actually triggered on pushes."
+        }
+      },
+      "description": "Create a hook"
+    },
+    "createTeam": {
+      "url": "/orgs/:org/teams",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.hellcat-preview+json"
+      },
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "name": {
+          "type": "string",
+          "required": true
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the team."
+        },
+        "maintainers": {
+          "type": "string[]",
+          "description": "The logins of organization members to add as maintainers of the team."
+        },
+        "repo_names": {
+          "type": "string[]",
+          "description": "The full name (e.g., \"organization-name/repository-name\") of repositories to add the team to."
+        },
+        "privacy": {
+          "type": "string",
+          "enum": [
+            "secret",
+            "closed"
+          ],
+          "default": "secret",
+          "description": "The level of privacy this team should have."
+        },
+        "parent_team_id": {
+          "type": "number",
+          "description": "The ID of a team to set as the parent team."
+        }
+      },
+      "description": "Create team"
+    },
+    "deleteHook": {
+      "url": "/orgs/:org/hooks/:id",
+      "method": "DELETE",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a hook"
+    },
+    "deleteTeam": {
+      "url": "/teams/:id",
+      "method": "DELETE",
+      "headers": {
+        "accept": "application/vnd.github.hellcat-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete team"
+    },
+    "deleteTeamRepo": {
+      "url": "/teams/:id/repos/:owner/:repo",
+      "method": "DELETE",
+      "headers": {
+        "accept": "application/vnd.github.hellcat-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Remove team repository"
+    },
+    "editHook": {
+      "url": "/orgs/:org/hooks/:id",
+      "method": "PATCH",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "config": {
+          "type": "json",
+          "required": true,
+          "description": "Key/value pairs to provide settings for this webhook"
+        },
+        "events": {
+          "type": "string[]",
+          "default": "[\"push\"]",
+          "description": "Determines what events the hook is triggered for. Default: [\"push\"]."
+        },
+        "active": {
+          "type": "boolean",
+          "description": "Determines whether the hook is actually triggered on pushes."
+        }
+      },
+      "description": "Edit a hook"
+    },
+    "editTeam": {
+      "url": "/teams/:id",
+      "method": "PATCH",
+      "headers": {
+        "accept": "application/vnd.github.hellcat-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "name": {
+          "type": "string",
+          "required": true
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the team."
+        },
+        "privacy": {
+          "type": "string",
+          "enum": [
+            "secret",
+            "closed"
+          ],
+          "default": "secret",
+          "description": "The level of privacy this team should have."
+        },
+        "parent_team_id": {
+          "type": "number",
+          "description": "The ID of a team to set as the parent team."
+        }
+      },
+      "description": "Edit team"
+    },
     "get": {
       "url": "/orgs/:org",
       "method": "GET",
@@ -3678,6 +4381,474 @@
         }
       },
       "description": "Get an organization"
+    },
+    "getAll": {
+      "url": "/organizations",
+      "method": "GET",
+      "params": {
+        "since": {
+          "type": "string",
+          "description": "The integer ID of the last Organization that you've seen."
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List all organizations"
+    },
+    "getBlockedUsers": {
+      "url": "/orgs/:org/blocks",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.giant-sentry-fist-preview+json"
+      },
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List blocked users. (In preview period. See README.)"
+    },
+    "getChildTeams": {
+      "url": "/teams/:id/teams",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.hellcat-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List child teams"
+    },
+    "getForUser": {
+      "url": "/users/:username/orgs",
+      "method": "GET",
+      "params": {
+        "username": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List public organization memberships for the specified user."
+    },
+    "getHook": {
+      "url": "/orgs/:org/hooks/:id",
+      "method": "GET",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get single hook"
+    },
+    "getHooks": {
+      "url": "/orgs/:org/hooks",
+      "method": "GET",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List hooks"
+    },
+    "getMembers": {
+      "url": "/orgs/:org/members",
+      "method": "GET",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "filter": {
+          "type": "string",
+          "enum": [
+            "all",
+            "2fa_disabled"
+          ],
+          "default": "all",
+          "description": "Filter members returned in the list."
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "all",
+            "admin",
+            "member"
+          ],
+          "default": "all",
+          "description": "Filter members returned by their role."
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Members list"
+    },
+    "getOrgMembership": {
+      "url": "/orgs/:org/memberships/:username",
+      "method": "GET",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get organization membership"
+    },
+    "getOutsideCollaborators": {
+      "url": "/orgs/:org/outside_collaborators",
+      "method": "GET",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "filter": {
+          "type": "string",
+          "enum": [
+            "all",
+            "2fa_disabled"
+          ],
+          "default": "all",
+          "description": "Filter the list of outside collaborators."
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List all users who are outside collaborators of an organization."
+    },
+    "getPendingOrgInvites": {
+      "url": "/orgs/:org/invitations",
+      "method": "GET",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "List pending organization invites."
+    },
+    "getPendingTeamInvites": {
+      "url": "/teams/:id/invitations",
+      "method": "GET",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List pending team invitations."
+    },
+    "getPublicMembers": {
+      "url": "/orgs/:org/public_members",
+      "method": "GET",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Public members list"
+    },
+    "getTeam": {
+      "url": "/teams/:id",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.hellcat-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get team"
+    },
+    "getTeamMembers": {
+      "url": "/teams/:id/members",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.hellcat-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "member",
+            "maintainer",
+            "all"
+          ],
+          "default": "all",
+          "description": "Filters members returned by their role in the team."
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List team members"
+    },
+    "getTeamMembership": {
+      "url": "/teams/:id/memberships/:username",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.hellcat-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get team membership"
+    },
+    "getTeamRepos": {
+      "url": "/teams/:id/repos",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.hellcat-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Get team repos"
+    },
+    "getTeams": {
+      "url": "/orgs/:org/teams",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.hellcat-preview+json"
+      },
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List teams"
+    },
+    "pingHook": {
+      "url": "/orgs/:org/hooks/:id/pings",
+      "method": "POST",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Ping a hook"
+    },
+    "publicizeMembership": {
+      "url": "/orgs/:org/public_members/:username",
+      "method": "PUT",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Publicize a user's membership"
+    },
+    "removeMember": {
+      "url": "/orgs/:org/members/:username",
+      "method": "DELETE",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Remove a member"
+    },
+    "removeOrgMembership": {
+      "url": "/orgs/:org/memberships/:username",
+      "method": "DELETE",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Remove organization membership"
+    },
+    "removeOutsideCollaborator": {
+      "url": "/orgs/:org/outside_collaborators/:username",
+      "method": "DELETE",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Remove outside collaborator."
+    },
+    "removeTeamMembership": {
+      "url": "/teams/:id/memberships/:username",
+      "method": "DELETE",
+      "headers": {
+        "accept": "application/vnd.github.hellcat-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Remove team membership"
+    },
+    "unblockUser": {
+      "url": "/orgs/:org/blocks/:username",
+      "method": "DELETE",
+      "headers": {
+        "accept": "application/vnd.github.giant-sentry-fist-preview+json"
+      },
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Unblock a user. (In preview period. See README.)"
     },
     "update": {
       "url": "/orgs/:org",
@@ -3729,869 +4900,77 @@
         }
       },
       "description": "Edit an organization"
-    },
-    "getAll": {
-      "url": "/organizations",
-      "method": "GET",
-      "params": {
-        "since": {
-          "type": "string",
-          "description": "The integer ID of the last Organization that you've seen."
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List all organizations"
-    },
-    "getForUser": {
-      "url": "/users/:username/orgs",
-      "method": "GET",
-      "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List public organization memberships for the specified user."
-    },
-    "getMembers": {
-      "url": "/orgs/:org/members",
-      "method": "GET",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "filter": {
-          "type": "string",
-          "enum": [
-            "all",
-            "2fa_disabled"
-          ],
-          "default": "all",
-          "description": "Filter members returned in the list."
-        },
-        "role": {
-          "type": "string",
-          "enum": [
-            "all",
-            "admin",
-            "member"
-          ],
-          "default": "all",
-          "description": "Filter members returned by their role."
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Members list"
-    },
-    "checkMembership": {
-      "url": "/orgs/:org/members/:username",
-      "method": "GET",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Check membership"
-    },
-    "removeMember": {
-      "url": "/orgs/:org/members/:username",
-      "method": "DELETE",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Remove a member"
-    },
-    "getPublicMembers": {
-      "url": "/orgs/:org/public_members",
-      "method": "GET",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Public members list"
-    },
-    "checkPublicMembership": {
-      "url": "/orgs/:org/public_members/:username",
-      "method": "GET",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Check public membership"
-    },
-    "publicizeMembership": {
-      "url": "/orgs/:org/public_members/:username",
-      "method": "PUT",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Publicize a user's membership"
-    },
-    "concealMembership": {
-      "url": "/orgs/:org/public_members/:username",
-      "method": "DELETE",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Conceal a user's membership"
-    },
-    "getOrgMembership": {
-      "url": "/orgs/:org/memberships/:username",
-      "method": "GET",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get organization membership"
-    },
-    "addOrgMembership": {
-      "url": "/orgs/:org/memberships/:username",
-      "method": "PUT",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        },
-        "role": {
-          "type": "string",
-          "required": true,
-          "enum": [
-            "admin",
-            "member"
-          ],
-          "default": "member",
-          "description": "The role to give the user in the organization."
-        }
-      },
-      "description": "Add or update organization membership"
-    },
-    "removeOrgMembership": {
-      "url": "/orgs/:org/memberships/:username",
-      "method": "DELETE",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Remove organization membership"
-    },
-    "getPendingOrgInvites": {
-      "url": "/orgs/:org/invitations",
-      "method": "GET",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "List pending organization invites."
-    },
-    "getOutsideCollaborators": {
-      "url": "/orgs/:org/outside_collaborators",
-      "method": "GET",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "filter": {
-          "type": "string",
-          "enum": [
-            "all",
-            "2fa_disabled"
-          ],
-          "default": "all",
-          "description": "Filter the list of outside collaborators."
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List all users who are outside collaborators of an organization."
-    },
-    "removeOutsideCollaborator": {
-      "url": "/orgs/:org/outside_collaborators/:username",
-      "method": "DELETE",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Remove outside collaborator."
-    },
-    "convertMemberToOutsideCollaborator": {
-      "url": "/orgs/:org/outside_collaborators/:username",
-      "method": "PUT",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Convert member to outside collaborator."
-    },
-    "getTeams": {
-      "url": "/orgs/:org/teams",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.hellcat-preview+json"
-      },
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List teams"
-    },
-    "getTeam": {
-      "url": "/teams/:id",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.hellcat-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get team"
-    },
-    "createTeam": {
-      "url": "/orgs/:org/teams",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.hellcat-preview+json"
-      },
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "name": {
-          "type": "string",
-          "required": true
-        },
-        "description": {
-          "type": "string",
-          "description": "The description of the team."
-        },
-        "maintainers": {
-          "type": "string[]",
-          "description": "The logins of organization members to add as maintainers of the team."
-        },
-        "repo_names": {
-          "type": "string[]",
-          "description": "The full name (e.g., \"organization-name/repository-name\") of repositories to add the team to."
-        },
-        "privacy": {
-          "type": "string",
-          "enum": [
-            "secret",
-            "closed"
-          ],
-          "default": "secret",
-          "description": "The level of privacy this team should have."
-        },
-        "parent_team_id": {
-          "type": "number",
-          "description": "The ID of a team to set as the parent team."
-        }
-      },
-      "description": "Create team"
-    },
-    "editTeam": {
-      "url": "/teams/:id",
-      "method": "PATCH",
-      "headers": {
-        "accept": "application/vnd.github.hellcat-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "name": {
-          "type": "string",
-          "required": true
-        },
-        "description": {
-          "type": "string",
-          "description": "The description of the team."
-        },
-        "privacy": {
-          "type": "string",
-          "enum": [
-            "secret",
-            "closed"
-          ],
-          "default": "secret",
-          "description": "The level of privacy this team should have."
-        },
-        "parent_team_id": {
-          "type": "number",
-          "description": "The ID of a team to set as the parent team."
-        }
-      },
-      "description": "Edit team"
-    },
-    "deleteTeam": {
-      "url": "/teams/:id",
-      "method": "DELETE",
-      "headers": {
-        "accept": "application/vnd.github.hellcat-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete team"
-    },
-    "getTeamMembers": {
-      "url": "/teams/:id/members",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.hellcat-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "role": {
-          "type": "string",
-          "enum": [
-            "member",
-            "maintainer",
-            "all"
-          ],
-          "default": "all",
-          "description": "Filters members returned by their role in the team."
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List team members"
-    },
-    "getChildTeams": {
-      "url": "/teams/:id/teams",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.hellcat-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List child teams"
-    },
-    "getTeamMembership": {
-      "url": "/teams/:id/memberships/:username",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.hellcat-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get team membership"
-    },
-    "addTeamMembership": {
-      "url": "/teams/:id/memberships/:username",
-      "method": "PUT",
-      "headers": {
-        "accept": "application/vnd.github.hellcat-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        },
-        "role": {
-          "type": "string",
-          "enum": [
-            "member",
-            "maintainer"
-          ],
-          "default": "member",
-          "description": "The role that this user should have in the team."
-        }
-      },
-      "description": "Add team membership"
-    },
-    "removeTeamMembership": {
-      "url": "/teams/:id/memberships/:username",
-      "method": "DELETE",
-      "headers": {
-        "accept": "application/vnd.github.hellcat-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Remove team membership"
-    },
-    "getTeamRepos": {
-      "url": "/teams/:id/repos",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.hellcat-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get team repos"
-    },
-    "getPendingTeamInvites": {
-      "url": "/teams/:id/invitations",
-      "method": "GET",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List pending team invitations."
-    },
-    "checkTeamRepo": {
-      "url": "/teams/:id/repos/:owner/:repo",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.hellcat-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Check if a team manages a repository"
-    },
-    "addTeamRepo": {
-      "url": "/teams/:id/repos/:org/:repo",
-      "method": "PUT",
-      "headers": {
-        "accept": "application/vnd.github.hellcat-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "permission": {
-          "type": "string",
-          "enum": [
-            "pull",
-            "push",
-            "admin"
-          ],
-          "description": "`pull` - team members can pull, but not push or administer this repository, `push` - team members can pull and push, but not administer this repository, `admin` - team members can pull, push and administer this repository."
-        }
-      },
-      "description": "Add team repository"
-    },
-    "deleteTeamRepo": {
-      "url": "/teams/:id/repos/:owner/:repo",
-      "method": "DELETE",
-      "headers": {
-        "accept": "application/vnd.github.hellcat-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Remove team repository"
-    },
-    "getHooks": {
-      "url": "/orgs/:org/hooks",
-      "method": "GET",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List hooks"
-    },
-    "getHook": {
-      "url": "/orgs/:org/hooks/:id",
-      "method": "GET",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get single hook"
-    },
-    "createHook": {
-      "url": "/orgs/:org/hooks",
-      "method": "POST",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "name": {
-          "type": "string",
-          "required": true,
-          "description": "Must be passed as \"web\"."
-        },
-        "config": {
-          "type": "json",
-          "required": true,
-          "description": "Key/value pairs to provide settings for this webhook"
-        },
-        "events": {
-          "type": "string[]",
-          "default": "[\"push\"]",
-          "description": "Determines what events the hook is triggered for. Default: [\"push\"]."
-        },
-        "active": {
-          "type": "boolean",
-          "description": "Determines whether the hook is actually triggered on pushes."
-        }
-      },
-      "description": "Create a hook"
-    },
-    "editHook": {
-      "url": "/orgs/:org/hooks/:id",
-      "method": "PATCH",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "config": {
-          "type": "json",
-          "required": true,
-          "description": "Key/value pairs to provide settings for this webhook"
-        },
-        "events": {
-          "type": "string[]",
-          "default": "[\"push\"]",
-          "description": "Determines what events the hook is triggered for. Default: [\"push\"]."
-        },
-        "active": {
-          "type": "boolean",
-          "description": "Determines whether the hook is actually triggered on pushes."
-        }
-      },
-      "description": "Edit a hook"
-    },
-    "pingHook": {
-      "url": "/orgs/:org/hooks/:id/pings",
-      "method": "POST",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Ping a hook"
-    },
-    "deleteHook": {
-      "url": "/orgs/:org/hooks/:id",
-      "method": "DELETE",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete a hook"
-    },
-    "getBlockedUsers": {
-      "url": "/orgs/:org/blocks",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.giant-sentry-fist-preview+json"
-      },
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List blocked users. (In preview period. See README.)"
-    },
-    "checkBlockedUser": {
-      "url": "/orgs/:org/blocks/:username",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.giant-sentry-fist-preview+json"
-      },
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Check whether you've blocked a user. (In preview period. See README.)"
-    },
-    "blockUser": {
-      "url": "/orgs/:org/blocks/:username",
-      "method": "PUT",
-      "headers": {
-        "accept": "application/vnd.github.giant-sentry-fist-preview+json"
-      },
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Block a user. (In preview period. See README.)"
-    },
-    "unblockUser": {
-      "url": "/orgs/:org/blocks/:username",
-      "method": "DELETE",
-      "headers": {
-        "accept": "application/vnd.github.giant-sentry-fist-preview+json"
-      },
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Unblock a user. (In preview period. See README.)"
     }
   },
   "projects": {
-    "getRepoProjects": {
+    "createOrgProject": {
+      "url": "/orgs/:org/projects",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.inertia-preview+json"
+      },
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "name": {
+          "type": "string",
+          "required": true
+        },
+        "body": {
+          "type": "string"
+        }
+      },
+      "description": "Create an organization project. (In preview period. See README.)"
+    },
+    "createProjectCard": {
+      "url": "/projects/columns/:column_id/cards",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.inertia-preview+json"
+      },
+      "params": {
+        "column_id": {
+          "type": "string",
+          "required": true
+        },
+        "note": {
+          "type": "string",
+          "description": "The note of the card."
+        },
+        "content_id": {
+          "type": "string",
+          "description": "The id of the Issue or Pull Request to associate with this card."
+        },
+        "content_type": {
+          "type": "string",
+          "description": "The type of content to associate with this card. Can be either 'Issue' or 'PullRequest'."
+        }
+      },
+      "description": "Create a project card. (In preview period. See README.)"
+    },
+    "createProjectColumn": {
+      "url": "/projects/:project_id/columns",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.inertia-preview+json"
+      },
+      "params": {
+        "project_id": {
+          "type": "string",
+          "required": true
+        },
+        "name": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Create a project column. (In preview period. See README.)"
+    },
+    "createRepoProject": {
       "url": "/repos/:owner/:repo/projects",
-      "method": "GET",
+      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
@@ -4604,17 +4983,57 @@
           "type": "string",
           "required": true
         },
-        "state": {
+        "name": {
           "type": "string",
-          "enum": [
-            "open",
-            "closed",
-            "all"
-          ],
-          "default": "open"
+          "required": true
+        },
+        "body": {
+          "type": "string"
         }
       },
-      "description": "List repository projects. (In preview period. See README.)"
+      "description": "Create a repository project. (In preview period. See README.)"
+    },
+    "deleteProject": {
+      "url": "/projects/:id",
+      "method": "DELETE",
+      "headers": {
+        "accept": "application/vnd.github.inertia-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a project. (In preview period. See README.)"
+    },
+    "deleteProjectCard": {
+      "url": "/projects/columns/cards/:id",
+      "method": "DELETE",
+      "headers": {
+        "accept": "application/vnd.github.inertia-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a project card. (In preview period. See README.)"
+    },
+    "deleteProjectColumn": {
+      "url": "/projects/columns/:id",
+      "method": "DELETE",
+      "headers": {
+        "accept": "application/vnd.github.inertia-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a project column. (In preview period. See README.)"
     },
     "getOrgProjects": {
       "url": "/orgs/:org/projects",
@@ -4653,9 +5072,65 @@
       },
       "description": "Get a project. (In preview period. See README.)"
     },
-    "createRepoProject": {
+    "getProjectCard": {
+      "url": "/projects/columns/cards/:id",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.inertia-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get project card. (In preview period. See README.)"
+    },
+    "getProjectCards": {
+      "url": "/projects/columns/:column_id/cards",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.inertia-preview+json"
+      },
+      "params": {
+        "column_id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "List project cards. (In preview period. See README.)"
+    },
+    "getProjectColumn": {
+      "url": "/projects/columns/:id",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.inertia-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a project column. (In preview period. See README.)"
+    },
+    "getProjectColumns": {
+      "url": "/projects/:project_id/columns",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.inertia-preview+json"
+      },
+      "params": {
+        "project_id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "List project columns. (In preview period. See README.)"
+    },
+    "getRepoProjects": {
       "url": "/repos/:owner/:repo/projects",
-      "method": "POST",
+      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
@@ -4668,36 +5143,61 @@
           "type": "string",
           "required": true
         },
-        "name": {
+        "state": {
           "type": "string",
-          "required": true
-        },
-        "body": {
-          "type": "string"
+          "enum": [
+            "open",
+            "closed",
+            "all"
+          ],
+          "default": "open"
         }
       },
-      "description": "Create a repository project. (In preview period. See README.)"
+      "description": "List repository projects. (In preview period. See README.)"
     },
-    "createOrgProject": {
-      "url": "/orgs/:org/projects",
+    "moveProjectCard": {
+      "url": "/projects/columns/cards/:id/moves",
       "method": "POST",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
       "params": {
-        "org": {
+        "id": {
           "type": "string",
           "required": true
         },
-        "name": {
+        "position": {
           "type": "string",
-          "required": true
+          "required": true,
+          "validation": "^(top|bottom|after:\\d+)$",
+          "description": "Can be one of top, bottom, or after:<card-id>, where <card-id> is the id value of a card in the same project."
         },
-        "body": {
-          "type": "string"
+        "column_id": {
+          "type": "string",
+          "description": "The id value of a column in the same project."
         }
       },
-      "description": "Create an organization project. (In preview period. See README.)"
+      "description": "Move a project card. (In preview period. See README.)"
+    },
+    "moveProjectColumn": {
+      "url": "/projects/columns/:id/moves",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.inertia-preview+json"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "position": {
+          "type": "string",
+          "required": true,
+          "validation": "^(first|last|after:\\d+)$",
+          "description": "Can be one of first, last, or after:<column-id>, where <column-id> is the id value of a column in the same project."
+        }
+      },
+      "description": "Move a project column. (In preview period. See README.)"
     },
     "updateProject": {
       "url": "/projects/:id",
@@ -4729,74 +5229,6 @@
       },
       "description": "Update a project. (In preview period. See README.)"
     },
-    "deleteProject": {
-      "url": "/projects/:id",
-      "method": "DELETE",
-      "headers": {
-        "accept": "application/vnd.github.inertia-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete a project. (In preview period. See README.)"
-    },
-    "getProjectCards": {
-      "url": "/projects/columns/:column_id/cards",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.inertia-preview+json"
-      },
-      "params": {
-        "column_id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "List project cards. (In preview period. See README.)"
-    },
-    "getProjectCard": {
-      "url": "/projects/columns/cards/:id",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.inertia-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get project card. (In preview period. See README.)"
-    },
-    "createProjectCard": {
-      "url": "/projects/columns/:column_id/cards",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.inertia-preview+json"
-      },
-      "params": {
-        "column_id": {
-          "type": "string",
-          "required": true
-        },
-        "note": {
-          "type": "string",
-          "description": "The note of the card."
-        },
-        "content_id": {
-          "type": "string",
-          "description": "The id of the Issue or Pull Request to associate with this card."
-        },
-        "content_type": {
-          "type": "string",
-          "description": "The type of content to associate with this card. Can be either 'Issue' or 'PullRequest'."
-        }
-      },
-      "description": "Create a project card. (In preview period. See README.)"
-    },
     "updateProjectCard": {
       "url": "/projects/columns/cards/:id",
       "method": "PATCH",
@@ -4815,90 +5247,6 @@
       },
       "description": "Update a project card. (In preview period. See README.)"
     },
-    "deleteProjectCard": {
-      "url": "/projects/columns/cards/:id",
-      "method": "DELETE",
-      "headers": {
-        "accept": "application/vnd.github.inertia-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete a project card. (In preview period. See README.)"
-    },
-    "moveProjectCard": {
-      "url": "/projects/columns/cards/:id/moves",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.inertia-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "position": {
-          "type": "string",
-          "required": true,
-          "validation": "^(top|bottom|after:\\d+)$",
-          "description": "Can be one of top, bottom, or after:<card-id>, where <card-id> is the id value of a card in the same project."
-        },
-        "column_id": {
-          "type": "string",
-          "description": "The id value of a column in the same project."
-        }
-      },
-      "description": "Move a project card. (In preview period. See README.)"
-    },
-    "getProjectColumns": {
-      "url": "/projects/:project_id/columns",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.inertia-preview+json"
-      },
-      "params": {
-        "project_id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "List project columns. (In preview period. See README.)"
-    },
-    "getProjectColumn": {
-      "url": "/projects/columns/:id",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.inertia-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a project column. (In preview period. See README.)"
-    },
-    "createProjectColumn": {
-      "url": "/projects/:project_id/columns",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.inertia-preview+json"
-      },
-      "params": {
-        "project_id": {
-          "type": "string",
-          "required": true
-        },
-        "name": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Create a project column. (In preview period. See README.)"
-    },
     "updateProjectColumn": {
       "url": "/projects/columns/:id",
       "method": "PATCH",
@@ -4916,46 +5264,15 @@
         }
       },
       "description": "Update a project column. (In preview period. See README.)"
-    },
-    "deleteProjectColumn": {
-      "url": "/projects/columns/:id",
-      "method": "DELETE",
-      "headers": {
-        "accept": "application/vnd.github.inertia-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete a project column. (In preview period. See README.)"
-    },
-    "moveProjectColumn": {
-      "url": "/projects/columns/:id/moves",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.inertia-preview+json"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "position": {
-          "type": "string",
-          "required": true,
-          "validation": "^(first|last|after:\\d+)$",
-          "description": "Can be one of first, last, or after:<column-id>, where <column-id> is the id value of a column in the same project."
-        }
-      },
-      "description": "Move a project column. (In preview period. See README.)"
     }
   },
   "pullRequests": {
-    "get": {
-      "url": "/repos/:owner/:repo/pulls/:number",
+    "checkMerged": {
+      "url": "/repos/:owner/:repo/pulls/:number/merge",
       "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.polaris-preview"
+      },
       "params": {
         "owner": {
           "type": "string",
@@ -4968,9 +5285,18 @@
         "number": {
           "type": "number",
           "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
         }
       },
-      "description": "Get a single pull request"
+      "description": "Get if a pull request has been merged"
     },
     "create": {
       "url": "/repos/:owner/:repo/pulls",
@@ -5010,9 +5336,12 @@
       },
       "description": "Create a pull request"
     },
-    "update": {
-      "url": "/repos/:owner/:repo/pulls/:number",
-      "method": "PATCH",
+    "createComment": {
+      "url": "/repos/:owner/:repo/pulls/:number/comments",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
       "params": {
         "owner": {
           "type": "string",
@@ -5025,40 +5354,31 @@
         "number": {
           "type": "number",
           "required": true
-        },
-        "title": {
-          "type": "string",
-          "description": "The title of the pull request."
         },
         "body": {
           "type": "string",
-          "description": "The contents of the pull request."
+          "required": true
         },
-        "state": {
+        "commit_id": {
           "type": "string",
-          "enum": [
-            "open",
-            "closed"
-          ],
-          "description": "open or closed"
+          "required": true
         },
-        "base": {
+        "path": {
           "type": "string",
-          "description": "The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo."
+          "required": true
         },
-        "maintainer_can_modify": {
-          "type": "boolean",
-          "default": "true",
-          "description": "Indicates whether maintainers can modify the pull request."
+        "position": {
+          "type": "number",
+          "required": true
         }
       },
-      "description": "Update a pull request"
+      "description": "Create a comment"
     },
-    "merge": {
-      "url": "/repos/:owner/:repo/pulls/:number/merge",
-      "method": "PUT",
+    "createCommentReply": {
+      "url": "/repos/:owner/:repo/pulls/:number/comments",
+      "method": "POST",
       "headers": {
-        "accept": "application/vnd.github.polaris-preview"
+        "accept": "application/vnd.github.squirrel-girl-preview"
       },
       "params": {
         "owner": {
@@ -5073,30 +5393,275 @@
           "type": "number",
           "required": true
         },
-        "commit_title": {
+        "body": {
           "type": "string",
-          "description": "Title for the automatic commit message. (In preview period. See README.)"
+          "required": true
         },
-        "commit_message": {
-          "type": "string",
-          "description": "Extra detail to append to automatic commit message."
-        },
-        "sha": {
-          "type": "string",
-          "description": "SHA that pull request head must match to allow merge"
-        },
-        "merge_method": {
-          "type": "string",
-          "enum": [
-            "merge",
-            "squash",
-            "rebase"
-          ],
-          "default": "merge",
-          "description": "Merge method to use. Possible values are `merge`, `squash`, or `rebase`. (In preview period. See README.)"
+        "in_reply_to": {
+          "type": "number",
+          "required": true,
+          "description": "The comment id to reply to."
         }
       },
-      "description": "Merge a pull request (Merge Button)"
+      "description": "Reply to existing pull request comment"
+    },
+    "createFromIssue": {
+      "url": "/repos/:owner/:repo/pulls",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "issue": {
+          "type": "number",
+          "required": true,
+          "description": "The issue number in this repository to turn into a Pull Request."
+        },
+        "head": {
+          "type": "string",
+          "required": true,
+          "description": "The branch (or git ref) where your changes are implemented."
+        },
+        "base": {
+          "type": "string",
+          "required": true,
+          "description": "The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo."
+        }
+      },
+      "description": "Create a pull request from an existing issue"
+    },
+    "createReview": {
+      "url": "/repos/:owner/:repo/pulls/:number/reviews",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "commit_id": {
+          "type": "string",
+          "description": "Sha of the commit to comment on."
+        },
+        "body": {
+          "type": "string",
+          "description": "The body text of the pull request review."
+        },
+        "event": {
+          "type": "string",
+          "enum": [
+            "APPROVE",
+            "REQUEST_CHANGES",
+            "COMMENT",
+            "PENDING"
+          ],
+          "default": "PENDING",
+          "description": "The event to perform on the review upon submission, can be one of APPROVE, REQUEST_CHANGES, or COMMENT. If left blank, the review will be in the PENDING state."
+        },
+        "comments": {
+          "type": "string[]",
+          "description": "An array of draft review comment objects. Draft review comments must include a `path`, `position`, and `body`."
+        }
+      },
+      "description": "Create a pull request review."
+    },
+    "createReviewRequest": {
+      "url": "/repos/:owner/:repo/pulls/:number/requested_reviewers",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.thor-preview+json"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "reviewers": {
+          "type": "string[]",
+          "description": "An array of user logins that will be requested."
+        },
+        "team_reviewers": {
+          "type": "string[]",
+          "description": "An array of team slugs that will be requested."
+        }
+      },
+      "description": "Create a review request. (In preview period. See README.)"
+    },
+    "deleteComment": {
+      "url": "/repos/:owner/:repo/pulls/comments/:id",
+      "method": "DELETE",
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a comment"
+    },
+    "deletePendingReview": {
+      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a pending pull request review."
+    },
+    "deleteReviewRequest": {
+      "url": "/repos/:owner/:repo/pulls/:number/requested_reviewers",
+      "method": "DELETE",
+      "headers": {
+        "accept": "application/vnd.github.thor-preview+json"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "reviewers": {
+          "type": "string[]",
+          "description": "An array of user logins that will be requested."
+        },
+        "team_reviewers": {
+          "type": "string[]",
+          "description": "An array of team slugs that will be requested."
+        }
+      },
+      "description": "Delete a review request. (In preview period. See README.)"
+    },
+    "dismissReview": {
+      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id/dismissals",
+      "method": "PUT",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "message": {
+          "type": "string",
+          "description": "The message for the pull request review dismissal."
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Dismiss a pull request review."
+    },
+    "editComment": {
+      "url": "/repos/:owner/:repo/pulls/comments/:id",
+      "method": "PATCH",
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "body": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Edit a comment"
+    },
+    "get": {
+      "url": "/repos/:owner/:repo/pulls/:number",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        }
+      },
+      "description": "Get a single pull request"
     },
     "getAll": {
       "url": "/repos/:owner/:repo/pulls",
@@ -5158,97 +5723,11 @@
       },
       "description": "List pull requests"
     },
-    "createFromIssue": {
-      "url": "/repos/:owner/:repo/pulls",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "issue": {
-          "type": "number",
-          "required": true,
-          "description": "The issue number in this repository to turn into a Pull Request."
-        },
-        "head": {
-          "type": "string",
-          "required": true,
-          "description": "The branch (or git ref) where your changes are implemented."
-        },
-        "base": {
-          "type": "string",
-          "required": true,
-          "description": "The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo."
-        }
-      },
-      "description": "Create a pull request from an existing issue"
-    },
-    "getCommits": {
-      "url": "/repos/:owner/:repo/pulls/:number/commits",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List commits on a pull request"
-    },
-    "getFiles": {
-      "url": "/repos/:owner/:repo/pulls/:number/files",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List pull requests files"
-    },
-    "checkMerged": {
-      "url": "/repos/:owner/:repo/pulls/:number/merge",
+    "getComment": {
+      "url": "/repos/:owner/:repo/pulls/comments/:id",
       "method": "GET",
       "headers": {
-        "accept": "application/vnd.github.polaris-preview"
+        "accept": "application/vnd.github.squirrel-girl-preview"
       },
       "params": {
         "owner": {
@@ -5257,66 +5736,6 @@
         },
         "repo": {
           "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get if a pull request has been merged"
-    },
-    "getReviews": {
-      "url": "/repos/:owner/:repo/pulls/:number/reviews",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List reviews on a pull request."
-    },
-    "getReview": {
-      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
           "required": true
         },
         "id": {
@@ -5324,178 +5743,7 @@
           "required": true
         }
       },
-      "description": "Get a single pull request review."
-    },
-    "deletePendingReview": {
-      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete a pending pull request review."
-    },
-    "getReviewComments": {
-      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id/comments",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get comments for a pull request review."
-    },
-    "createReview": {
-      "url": "/repos/:owner/:repo/pulls/:number/reviews",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "commit_id": {
-          "type": "string",
-          "description": "Sha of the commit to comment on."
-        },
-        "body": {
-          "type": "string",
-          "description": "The body text of the pull request review."
-        },
-        "event": {
-          "type": "string",
-          "enum": [
-            "APPROVE",
-            "REQUEST_CHANGES",
-            "COMMENT",
-            "PENDING"
-          ],
-          "default": "PENDING",
-          "description": "The event to perform on the review upon submission, can be one of APPROVE, REQUEST_CHANGES, or COMMENT. If left blank, the review will be in the PENDING state."
-        },
-        "comments": {
-          "type": "string[]",
-          "description": "An array of draft review comment objects. Draft review comments must include a `path`, `position`, and `body`."
-        }
-      },
-      "description": "Create a pull request review."
-    },
-    "submitReview": {
-      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id/events",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "body": {
-          "type": "string",
-          "description": "The body text of the pull request review."
-        },
-        "event": {
-          "type": "string",
-          "enum": [
-            "APPROVE",
-            "REQUEST_CHANGES",
-            "COMMENT",
-            "PENDING"
-          ],
-          "default": "PENDING",
-          "description": "The event to perform on the review upon submission, can be one of APPROVE, REQUEST_CHANGES, or COMMENT. If left blank, the review will be in the PENDING state."
-        }
-      },
-      "description": "Submit a pull request review."
-    },
-    "dismissReview": {
-      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id/dismissals",
-      "method": "PUT",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "message": {
-          "type": "string",
-          "description": "The message for the pull request review dismissal."
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Dismiss a pull request review."
+      "description": "Get a single comment"
     },
     "getComments": {
       "url": "/repos/:owner/:repo/pulls/:number/comments",
@@ -5576,34 +5824,9 @@
       },
       "description": "List comments in a repository"
     },
-    "getComment": {
-      "url": "/repos/:owner/:repo/pulls/comments/:id",
+    "getCommits": {
+      "url": "/repos/:owner/:repo/pulls/:number/commits",
       "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a single comment"
-    },
-    "createComment": {
-      "url": "/repos/:owner/:repo/pulls/:number/comments",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
       "params": {
         "owner": {
           "type": "string",
@@ -5617,31 +5840,21 @@
           "type": "number",
           "required": true
         },
-        "body": {
-          "type": "string",
-          "required": true
-        },
-        "commit_id": {
-          "type": "string",
-          "required": true
-        },
-        "path": {
-          "type": "string",
-          "required": true
-        },
-        "position": {
+        "page": {
           "type": "number",
-          "required": true
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
         }
       },
-      "description": "Create a comment"
+      "description": "List commits on a pull request"
     },
-    "createCommentReply": {
-      "url": "/repos/:owner/:repo/pulls/:number/comments",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
+    "getFiles": {
+      "url": "/repos/:owner/:repo/pulls/:number/files",
+      "method": "GET",
       "params": {
         "owner": {
           "type": "string",
@@ -5655,24 +5868,21 @@
           "type": "number",
           "required": true
         },
-        "body": {
-          "type": "string",
-          "required": true
-        },
-        "in_reply_to": {
+        "page": {
           "type": "number",
-          "required": true,
-          "description": "The comment id to reply to."
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
         }
       },
-      "description": "Reply to existing pull request comment"
+      "description": "List pull requests files"
     },
-    "editComment": {
-      "url": "/repos/:owner/:repo/pulls/comments/:id",
-      "method": "PATCH",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
+    "getReview": {
+      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id",
+      "method": "GET",
       "params": {
         "owner": {
           "type": "string",
@@ -5682,23 +5892,20 @@
           "type": "string",
           "required": true
         },
-        "id": {
-          "type": "string",
+        "number": {
+          "type": "number",
           "required": true
         },
-        "body": {
+        "id": {
           "type": "string",
           "required": true
         }
       },
-      "description": "Edit a comment"
+      "description": "Get a single pull request review."
     },
-    "deleteComment": {
-      "url": "/repos/:owner/:repo/pulls/comments/:id",
-      "method": "DELETE",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
+    "getReviewComments": {
+      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id/comments",
+      "method": "GET",
       "params": {
         "owner": {
           "type": "string",
@@ -5708,12 +5915,25 @@
           "type": "string",
           "required": true
         },
+        "number": {
+          "type": "number",
+          "required": true
+        },
         "id": {
           "type": "string",
           "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
         }
       },
-      "description": "Delete a comment"
+      "description": "Get comments for a pull request review."
     },
     "getReviewRequests": {
       "url": "/repos/:owner/:repo/pulls/:number/requested_reviewers",
@@ -5746,12 +5966,9 @@
       },
       "description": "List review requests. (In preview period. See README.)"
     },
-    "createReviewRequest": {
-      "url": "/repos/:owner/:repo/pulls/:number/requested_reviewers",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.thor-preview+json"
-      },
+    "getReviews": {
+      "url": "/repos/:owner/:repo/pulls/:number/reviews",
+      "method": "GET",
       "params": {
         "owner": {
           "type": "string",
@@ -5765,22 +5982,23 @@
           "type": "number",
           "required": true
         },
-        "reviewers": {
-          "type": "string[]",
-          "description": "An array of user logins that will be requested."
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
         },
-        "team_reviewers": {
-          "type": "string[]",
-          "description": "An array of team slugs that will be requested."
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
         }
       },
-      "description": "Create a review request. (In preview period. See README.)"
+      "description": "List reviews on a pull request."
     },
-    "deleteReviewRequest": {
-      "url": "/repos/:owner/:repo/pulls/:number/requested_reviewers",
-      "method": "DELETE",
+    "merge": {
+      "url": "/repos/:owner/:repo/pulls/:number/merge",
+      "method": "PUT",
       "headers": {
-        "accept": "application/vnd.github.thor-preview+json"
+        "accept": "application/vnd.github.polaris-preview"
       },
       "params": {
         "owner": {
@@ -5795,19 +6013,255 @@
           "type": "number",
           "required": true
         },
-        "reviewers": {
-          "type": "string[]",
-          "description": "An array of user logins that will be requested."
+        "commit_title": {
+          "type": "string",
+          "description": "Title for the automatic commit message. (In preview period. See README.)"
         },
-        "team_reviewers": {
-          "type": "string[]",
-          "description": "An array of team slugs that will be requested."
+        "commit_message": {
+          "type": "string",
+          "description": "Extra detail to append to automatic commit message."
+        },
+        "sha": {
+          "type": "string",
+          "description": "SHA that pull request head must match to allow merge"
+        },
+        "merge_method": {
+          "type": "string",
+          "enum": [
+            "merge",
+            "squash",
+            "rebase"
+          ],
+          "default": "merge",
+          "description": "Merge method to use. Possible values are `merge`, `squash`, or `rebase`. (In preview period. See README.)"
         }
       },
-      "description": "Delete a review request. (In preview period. See README.)"
+      "description": "Merge a pull request (Merge Button)"
+    },
+    "submitReview": {
+      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id/events",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "body": {
+          "type": "string",
+          "description": "The body text of the pull request review."
+        },
+        "event": {
+          "type": "string",
+          "enum": [
+            "APPROVE",
+            "REQUEST_CHANGES",
+            "COMMENT",
+            "PENDING"
+          ],
+          "default": "PENDING",
+          "description": "The event to perform on the review upon submission, can be one of APPROVE, REQUEST_CHANGES, or COMMENT. If left blank, the review will be in the PENDING state."
+        }
+      },
+      "description": "Submit a pull request review."
+    },
+    "update": {
+      "url": "/repos/:owner/:repo/pulls/:number",
+      "method": "PATCH",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "title": {
+          "type": "string",
+          "description": "The title of the pull request."
+        },
+        "body": {
+          "type": "string",
+          "description": "The contents of the pull request."
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "closed"
+          ],
+          "description": "open or closed"
+        },
+        "base": {
+          "type": "string",
+          "description": "The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo."
+        },
+        "maintainer_can_modify": {
+          "type": "boolean",
+          "default": "true",
+          "description": "Indicates whether maintainers can modify the pull request."
+        }
+      },
+      "description": "Update a pull request"
     }
   },
   "reactions": {
+    "createForCommitComment": {
+      "url": "/repos/:owner/:repo/comments/:id/reactions",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "content": {
+          "type": "string",
+          "required": true,
+          "enum": [
+            "+1",
+            "-1",
+            "laugh",
+            "confused",
+            "heart",
+            "hooray"
+          ],
+          "description": "The reaction type."
+        }
+      },
+      "description": "Create reaction for a commit comment. (In preview period. See README.)"
+    },
+    "createForIssue": {
+      "url": "/repos/:owner/:repo/issues/:number/reactions",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "content": {
+          "type": "string",
+          "required": true,
+          "enum": [
+            "+1",
+            "-1",
+            "laugh",
+            "confused",
+            "heart",
+            "hooray"
+          ],
+          "description": "The reaction type."
+        }
+      },
+      "description": "Create reaction for an issue. (In preview period. See README.)"
+    },
+    "createForIssueComment": {
+      "url": "/repos/:owner/:repo/issues/comments/:id/reactions",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "content": {
+          "type": "string",
+          "required": true,
+          "enum": [
+            "+1",
+            "-1",
+            "laugh",
+            "confused",
+            "heart",
+            "hooray"
+          ],
+          "description": "The reaction type."
+        }
+      },
+      "description": "Create reaction for an issue comment. (In preview period. See README.)"
+    },
+    "createForPullRequestReviewComment": {
+      "url": "/repos/:owner/:repo/pulls/comments/:id/reactions",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "content": {
+          "type": "string",
+          "required": true,
+          "enum": [
+            "+1",
+            "-1",
+            "laugh",
+            "confused",
+            "heart",
+            "hooray"
+          ],
+          "description": "The reaction type."
+        }
+      },
+      "description": "Create reaction for a pull request review comment. (In preview period. See README.)"
+    },
     "delete": {
       "url": "/reactions/:id",
       "method": "DELETE",
@@ -5856,41 +6310,6 @@
       },
       "description": "List reactions for a commit comment. (In preview period. See README.)"
     },
-    "createForCommitComment": {
-      "url": "/repos/:owner/:repo/comments/:id/reactions",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "content": {
-          "type": "string",
-          "required": true,
-          "enum": [
-            "+1",
-            "-1",
-            "laugh",
-            "confused",
-            "heart",
-            "hooray"
-          ],
-          "description": "The reaction type."
-        }
-      },
-      "description": "Create reaction for a commit comment. (In preview period. See README.)"
-    },
     "getForIssue": {
       "url": "/repos/:owner/:repo/issues/:number/reactions",
       "method": "GET",
@@ -5924,41 +6343,6 @@
         }
       },
       "description": "List reactions for an issue. (In preview period. See README.)"
-    },
-    "createForIssue": {
-      "url": "/repos/:owner/:repo/issues/:number/reactions",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "content": {
-          "type": "string",
-          "required": true,
-          "enum": [
-            "+1",
-            "-1",
-            "laugh",
-            "confused",
-            "heart",
-            "hooray"
-          ],
-          "description": "The reaction type."
-        }
-      },
-      "description": "Create reaction for an issue. (In preview period. See README.)"
     },
     "getForIssueComment": {
       "url": "/repos/:owner/:repo/issues/comments/:id/reactions",
@@ -5994,41 +6378,6 @@
       },
       "description": "List reactions for an issue comment. (In preview period. See README.)"
     },
-    "createForIssueComment": {
-      "url": "/repos/:owner/:repo/issues/comments/:id/reactions",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "content": {
-          "type": "string",
-          "required": true,
-          "enum": [
-            "+1",
-            "-1",
-            "laugh",
-            "confused",
-            "heart",
-            "hooray"
-          ],
-          "description": "The reaction type."
-        }
-      },
-      "description": "Create reaction for an issue comment. (In preview period. See README.)"
-    },
     "getForPullRequestReviewComment": {
       "url": "/repos/:owner/:repo/pulls/comments/:id/reactions",
       "method": "GET",
@@ -6062,13 +6411,12 @@
         }
       },
       "description": "List reactions for a pull request review comment. (In preview period. See README.)"
-    },
-    "createForPullRequestReviewComment": {
-      "url": "/repos/:owner/:repo/pulls/comments/:id/reactions",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
+    }
+  },
+  "repos": {
+    "addCollaborator": {
+      "url": "/repos/:owner/:repo/collaborators/:username",
+      "method": "PUT",
       "params": {
         "owner": {
           "type": "string",
@@ -6078,28 +6426,197 @@
           "type": "string",
           "required": true
         },
-        "id": {
+        "username": {
           "type": "string",
           "required": true
         },
-        "content": {
+        "permission": {
           "type": "string",
-          "required": true,
           "enum": [
-            "+1",
-            "-1",
-            "laugh",
-            "confused",
-            "heart",
-            "hooray"
+            "pull",
+            "push",
+            "admin"
           ],
-          "description": "The reaction type."
+          "default": "push",
+          "description": "`pull` - can pull, but not push to or administer this repository, `push` - can pull and push, but not administer this repository, `admin` - can pull, push and administer this repository."
         }
       },
-      "description": "Create reaction for a pull request review comment. (In preview period. See README.)"
-    }
-  },
-  "repos": {
+      "description": "Add user as a collaborator"
+    },
+    "addDeployKey": {
+      "url": "/repos/:owner/:repo/keys",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "title": {
+          "type": "string",
+          "required": true
+        },
+        "key": {
+          "type": "string",
+          "required": true
+        },
+        "read_only": {
+          "type": "boolean",
+          "description": "If true, the key will only be able to read repository contents. Otherwise, the key will be able to read and write."
+        }
+      },
+      "description": "Add a new deploy key."
+    },
+    "addProtectedBranchAdminEnforcement": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Add admin enforcement of protected branch."
+    },
+    "addProtectedBranchRequiredStatusChecksContexts": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        },
+        "contexts": {
+          "type": "string[]",
+          "required": true,
+          "mapTo": "input",
+          "description": "An array of protected branch required status checks contexts (e.g. continuous-integration/jenkins)."
+        }
+      },
+      "description": "Add required status checks contexts of protected branch."
+    },
+    "addProtectedBranchTeamRestrictions": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        },
+        "teams": {
+          "type": "string[]",
+          "required": true,
+          "mapTo": "input",
+          "description": "An array of team slugs (e.g. justice-league)."
+        }
+      },
+      "description": "Add team restrictions of protected branch."
+    },
+    "addProtectedBranchUserRestrictions": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        },
+        "users": {
+          "type": "string[]",
+          "required": true,
+          "mapTo": "input",
+          "description": "An array of team slugs (e.g. justice-league)."
+        }
+      },
+      "description": "Add user restrictions of protected branch."
+    },
+    "checkCollaborator": {
+      "url": "/repos/:owner/:repo/collaborators/:username",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Check if user is a collaborator."
+    },
+    "compareCommits": {
+      "url": "/repos/:owner/:repo/compare/:base...:head",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "base": {
+          "type": "string",
+          "required": true,
+          "description": "The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo."
+        },
+        "head": {
+          "type": "string",
+          "required": true,
+          "description": "The branch (or git ref) where your changes are implemented."
+        }
+      },
+      "description": "Compare two commits."
+    },
     "create": {
       "url": "/user/repos",
       "method": "POST",
@@ -6169,12 +6686,9 @@
       },
       "description": "Create a new repository for the authenticated user."
     },
-    "get": {
-      "url": "/repos/:owner/:repo",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.drax-preview+json"
-      },
+    "createCommitComment": {
+      "url": "/repos/:owner/:repo/commits/:sha/comments",
+      "method": "POST",
       "params": {
         "owner": {
           "type": "string",
@@ -6183,15 +6697,31 @@
         "repo": {
           "type": "string",
           "required": true
+        },
+        "sha": {
+          "type": "string",
+          "required": true
+        },
+        "body": {
+          "type": "string",
+          "required": true
+        },
+        "path": {
+          "type": "string",
+          "description": "Relative path of the file to comment on."
+        },
+        "position": {
+          "type": "number",
+          "description": "Line index in the diff to comment on."
         }
       },
-      "description": "Get a repo for a user."
+      "description": "Create a commit comment."
     },
-    "edit": {
-      "url": "/repos/:owner/:repo",
-      "method": "PATCH",
+    "createDeployment": {
+      "url": "/repos/:owner/:repo/deployments",
+      "method": "POST",
       "headers": {
-        "accept": "application/vnd.github.drax-preview+json"
+        "accept": "application/vnd.github.ant-man-preview+json"
       },
       "params": {
         "owner": {
@@ -6202,63 +6732,57 @@
           "type": "string",
           "required": true
         },
-        "name": {
+        "ref": {
           "type": "string",
-          "required": true
+          "required": true,
+          "description": "The ref to deploy. This can be a branch, tag, or sha."
+        },
+        "task": {
+          "type": "string",
+          "default": "deploy",
+          "description": "The named task to execute. e.g. deploy or deploy:migrations. Default: deploy"
+        },
+        "auto_merge": {
+          "type": "boolean",
+          "default": "true",
+          "description": "Optional parameter to merge the default branch into the requested ref if it is behind the default branch. Default: true"
+        },
+        "required_contexts": {
+          "type": "string[]",
+          "description": "Optional array of status contexts verified against commit status checks. If this parameter is omitted from the parameters then all unique contexts will be verified before a deployment is created. To bypass checking entirely pass an empty array. Defaults to all unique contexts."
+        },
+        "payload": {
+          "type": "string",
+          "default": "\"\"",
+          "description": "Optional JSON payload with extra information about the deployment. Default: \"\""
+        },
+        "environment": {
+          "type": "string",
+          "default": "none",
+          "description": "The name of the environment that was deployed to. e.g. staging or production. Default: none."
         },
         "description": {
-          "type": "string"
-        },
-        "homepage": {
-          "type": "string"
-        },
-        "private": {
-          "type": "boolean",
-          "default": "false",
-          "description": "True to create a private repository, false to create a public one. Creating private repositories requires a paid GitHub account. Default is false."
-        },
-        "has_issues": {
-          "type": "boolean",
-          "default": "true",
-          "description": "True to enable issues for this repository, false to disable them. Default is true."
-        },
-        "has_projects": {
-          "type": "boolean",
-          "default": "true",
-          "description": "True to enable projects for this repository, false to disable them. Default is true."
-        },
-        "has_wiki": {
-          "type": "boolean",
-          "default": "true",
-          "description": "True to enable the wiki for this repository, false to disable it. Default is true."
-        },
-        "default_branch": {
           "type": "string",
-          "description": "Updates the default branch for this repository."
+          "default": "\"\"",
+          "description": "Optional short description. Default: \"\""
         },
-        "allow_squash_merge": {
+        "transient_environment": {
           "type": "boolean",
-          "default": "true",
-          "description": "Either true to allow squash-merging pull requests, or false to prevent squash-merging. Default: true. (In preview period. See README.)"
+          "default": false,
+          "description": "Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future. Default: false. (In preview period. See README.)"
         },
-        "allow_merge_commit": {
+        "production_environment": {
           "type": "boolean",
-          "default": "true",
-          "description": "Either true to allow merging pull requests with a merge commit, or false to prevent merging pull requests with merge commits. Default: true. (In preview period. See README.)"
-        },
-        "allow_rebase_merge": {
-          "type": "boolean",
-          "default": "true",
-          "description": "Either true to allow rebase-merging pull requests, or false to prevent rebase-merging. Default: true. (In preview period. See README.)"
+          "description": "Specifies if the given environment is a one that end-users directly interact with. Default: true when environment is `production` and false otherwise. (In preview period. See README.)"
         }
       },
-      "description": "Update a repo."
+      "description": "Create a deployment. (In preview period. See README.)"
     },
-    "delete": {
-      "url": "/repos/:owner/:repo",
-      "method": "DELETE",
+    "createDeploymentStatus": {
+      "url": "/repos/:owner/:repo/deployments/:id/statuses",
+      "method": "POST",
       "headers": {
-        "accept": "application/vnd.github.drax-preview+json"
+        "accept": "application/vnd.github.ant-man-preview+json"
       },
       "params": {
         "owner": {
@@ -6268,13 +6792,46 @@
         "repo": {
           "type": "string",
           "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "state": {
+          "type": "string",
+          "description": "The state of the status. Can be one of pending, success, error, or failure."
+        },
+        "target_url": {
+          "type": "string",
+          "default": "\"\"",
+          "description": "The target URL to associate with this status. This URL should contain output to keep the user updated while the task is running or serve as historical information for what happened in the deployment. Default: \"\""
+        },
+        "log_url": {
+          "type": "string",
+          "default": "\"\"",
+          "description": "Functionally equivalent to target_url. Default: \"\". (In preview period. See README.)"
+        },
+        "description": {
+          "type": "string",
+          "default": "\"\"",
+          "description": "A short description of the status. Default: \"\""
+        },
+        "environment_url": {
+          "type": "string",
+          "default": "\"\"",
+          "description": "URL for accessing the deployment environment. Default: \"\". (In preview period. See README.)"
+        },
+        "auto_inactive": {
+          "type": "boolean",
+          "default": true,
+          "description": "When true the new `inactive` status is added to all other non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment. Default: true. (In preview period. See README.)"
         }
       },
-      "description": "Delete a repository."
+      "description": "Create a deployment status. (In preview period. See README.)"
     },
-    "fork": {
-      "url": "/repos/:owner/:repo/forks",
-      "method": "POST",
+    "createFile": {
+      "url": "/repos/:owner/:repo/contents/:path",
+      "method": "PUT",
       "params": {
         "owner": {
           "type": "string",
@@ -6284,205 +6841,33 @@
           "type": "string",
           "required": true
         },
-        "organization": {
-          "type": "string",
-          "description": "Optional parameter to specify the organization name if forking into an organization."
-        }
-      },
-      "description": "Create a fork."
-    },
-    "merge": {
-      "url": "/repos/:owner/:repo/merges",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "base": {
+        "path": {
           "type": "string",
           "required": true,
-          "description": "The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo."
+          "description": "The content path."
         },
-        "head": {
+        "message": {
           "type": "string",
           "required": true,
-          "description": "The branch (or git ref) where your changes are implemented."
+          "description": "The commit message."
         },
-        "commit_message": {
+        "content": {
           "type": "string",
-          "description": "Commit message to use for the merge commit. If omitted, a default message will be used."
+          "required": true,
+          "description": "The new file content, Base64 encoded."
+        },
+        "branch": {
+          "type": "string",
+          "description": "The branch name. If not provided, uses the repository’s default branch (usually master)."
+        },
+        "committer": {
+          "type": "json"
+        },
+        "author": {
+          "type": "json"
         }
       },
-      "description": "Perform a merge."
-    },
-    "getAll": {
-      "url": "/user/repos",
-      "method": "GET",
-      "params": {
-        "visibility": {
-          "type": "string",
-          "enum": [
-            "all",
-            "public",
-            "private"
-          ],
-          "default": "all",
-          "description": "Can be one of `all`, `public`, or `private`. Default: `all`."
-        },
-        "affiliation": {
-          "type": "string",
-          "default": "owner,collaborator,organization_member",
-          "description": "Comma-separated list of values. Can include: `owner`, `collaborator`, `organization_member`."
-        },
-        "type": {
-          "type": "string",
-          "enum": [
-            "all",
-            "owner",
-            "public",
-            "private",
-            "member"
-          ],
-          "default": "all",
-          "description": "Possible values: `all`, `owner`, `public`, `private`, `member`. Default: `all`."
-        },
-        "sort": {
-          "type": "string",
-          "enum": [
-            "created",
-            "updated",
-            "pushed",
-            "full_name"
-          ],
-          "default": "full_name",
-          "description": "Possible values: `created`, `updated`, `pushed`, `full_name`. Default: `full_name`."
-        },
-        "direction": {
-          "type": "string",
-          "enum": [
-            "asc",
-            "desc"
-          ],
-          "default": "desc"
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List your repositories"
-    },
-    "getForUser": {
-      "url": "/users/:username/repos",
-      "method": "GET",
-      "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        },
-        "type": {
-          "type": "string",
-          "enum": [
-            "all",
-            "owner",
-            "member"
-          ],
-          "default": "owner",
-          "description": "Possible values: `all`, `owner`, `member`. Default: `owner`."
-        },
-        "sort": {
-          "type": "string",
-          "enum": [
-            "created",
-            "updated",
-            "pushed",
-            "full_name"
-          ],
-          "default": "full_name",
-          "description": "Possible values: `created`, `updated`, `pushed`, `full_name`. Default: `full_name`."
-        },
-        "direction": {
-          "type": "string",
-          "enum": [
-            "asc",
-            "desc"
-          ],
-          "default": "desc"
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List public repositories for the specified user."
-    },
-    "getForOrg": {
-      "url": "/orgs/:org/repos",
-      "method": "GET",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "type": {
-          "type": "string",
-          "enum": [
-            "all",
-            "public",
-            "private",
-            "forks",
-            "sources",
-            "member"
-          ],
-          "default": "all",
-          "description": "Possible values: `all`, `public`, `private`, `forks`, `sources`, `member`. Default: `all`."
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List repositories for the specified org."
-    },
-    "getPublic": {
-      "url": "/repositories",
-      "method": "GET",
-      "params": {
-        "since": {
-          "type": "string",
-          "description": "The integer ID of the last Repository that you've seen."
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List all public repositories"
+      "description": "Create a new file in the given repository."
     },
     "createForOrg": {
       "url": "/orgs/:org/repos",
@@ -6557,23 +6942,317 @@
       },
       "description": "Create a new repository for an organization."
     },
-    "getById": {
-      "url": "/repositories/:id",
-      "method": "GET",
+    "createHook": {
+      "url": "/repos/:owner/:repo/hooks",
+      "method": "POST",
       "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "name": {
+          "type": "string",
+          "required": true
+        },
+        "config": {
+          "type": "json",
+          "required": true,
+          "description": "A Hash containing key/value pairs to provide settings for this hook. These settings vary between the services and are defined in the github-services repo. Booleans are stored internally as `1` for true, and `0` for false. Any JSON true/false values will be converted automatically."
+        },
+        "events": {
+          "type": "string[]",
+          "default": "[\"push\"]",
+          "description": "Determines what events the hook is triggered for. Default: `['push']`."
+        },
+        "active": {
+          "type": "boolean",
+          "description": "Determines whether the hook is actually triggered on pushes."
+        }
+      },
+      "description": "Create a hook."
+    },
+    "createRelease": {
+      "url": "/repos/:owner/:repo/releases",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "tag_name": {
+          "type": "string",
+          "required": true,
+          "description": "String of the tag"
+        },
+        "target_commitish": {
+          "type": "string",
+          "description": "Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch (usually master)."
+        },
+        "name": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "draft": {
+          "type": "boolean",
+          "default": "false",
+          "description": "true to create a draft (unpublished) release, false to create a published one. Default: false"
+        },
+        "prerelease": {
+          "type": "boolean",
+          "default": "false",
+          "description": "true to identify the release as a prerelease. false to identify the release as a full release. Default: false"
+        }
+      },
+      "description": "Create a release."
+    },
+    "createStatus": {
+      "url": "/repos/:owner/:repo/statuses/:sha",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "sha": {
+          "type": "string",
+          "required": true
+        },
+        "state": {
+          "type": "string",
+          "required": true,
+          "enum": [
+            "pending",
+            "success",
+            "error",
+            "failure"
+          ],
+          "description": "State of the status - can be one of pending, success, error, or failure."
+        },
+        "target_url": {
+          "type": "string",
+          "description": "Target url to associate with this status. This URL will be linked from the GitHub UI to allow users to easily see the ‘source’ of the Status."
+        },
+        "description": {
+          "type": "string",
+          "description": "Short description of the status."
+        },
+        "context": {
+          "type": "string",
+          "description": "A string label to differentiate this status from the status of other systems."
+        }
+      },
+      "description": "Create a status."
+    },
+    "delete": {
+      "url": "/repos/:owner/:repo",
+      "method": "DELETE",
+      "headers": {
+        "accept": "application/vnd.github.drax-preview+json"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a repository."
+    },
+    "deleteAsset": {
+      "url": "/repos/:owner/:repo/releases/assets/:id",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
         "id": {
           "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a release asset."
+    },
+    "deleteCommitComment": {
+      "url": "/repos/:owner/:repo/comments/:id",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a commit comment."
+    },
+    "deleteDeployKey": {
+      "url": "/repos/:owner/:repo/keys/:id",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Remove a deploy key."
+    },
+    "deleteDownload": {
+      "url": "/repos/:owner/:repo/downloads/:id",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a download."
+    },
+    "deleteFile": {
+      "url": "/repos/:owner/:repo/contents/:path",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "path": {
+          "type": "string",
           "required": true,
-          "description": "Numerical ID of the repository."
+          "description": "The content path."
+        },
+        "message": {
+          "type": "string",
+          "required": true,
+          "description": "The commit message."
+        },
+        "sha": {
+          "type": "string",
+          "required": true,
+          "description": "The blob SHA of the file being removed."
+        },
+        "branch": {
+          "type": "string",
+          "description": "The branch name. If not provided, uses the repository’s default branch (usually master)."
+        },
+        "committer": {
+          "type": "json"
+        },
+        "author": {
+          "type": "json"
         }
       },
-      "description": "Get a single repo by id."
+      "description": "Delete a file."
     },
-    "getTopics": {
-      "url": "/repos/:owner/:repo/topics",
-      "method": "GET",
+    "deleteHook": {
+      "url": "/repos/:owner/:repo/hooks/:id",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Deleate a hook."
+    },
+    "deleteInvite": {
+      "url": "/repos/:owner/:repo/invitations/:invitation_id",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "invitation_id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a repository invitation."
+    },
+    "deleteRelease": {
+      "url": "/repos/:owner/:repo/releases/:id",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a release"
+    },
+    "edit": {
+      "url": "/repos/:owner/:repo",
+      "method": "PATCH",
       "headers": {
-        "accept": "application/vnd.github.mercy-preview+json"
+        "accept": "application/vnd.github.drax-preview+json"
       },
       "params": {
         "owner": {
@@ -6584,24 +7263,61 @@
           "type": "string",
           "required": true
         },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+        "name": {
+          "type": "string",
+          "required": true
         },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+        "description": {
+          "type": "string"
+        },
+        "homepage": {
+          "type": "string"
+        },
+        "private": {
+          "type": "boolean",
+          "default": "false",
+          "description": "True to create a private repository, false to create a public one. Creating private repositories requires a paid GitHub account. Default is false."
+        },
+        "has_issues": {
+          "type": "boolean",
+          "default": "true",
+          "description": "True to enable issues for this repository, false to disable them. Default is true."
+        },
+        "has_projects": {
+          "type": "boolean",
+          "default": "true",
+          "description": "True to enable projects for this repository, false to disable them. Default is true."
+        },
+        "has_wiki": {
+          "type": "boolean",
+          "default": "true",
+          "description": "True to enable the wiki for this repository, false to disable it. Default is true."
+        },
+        "default_branch": {
+          "type": "string",
+          "description": "Updates the default branch for this repository."
+        },
+        "allow_squash_merge": {
+          "type": "boolean",
+          "default": "true",
+          "description": "Either true to allow squash-merging pull requests, or false to prevent squash-merging. Default: true. (In preview period. See README.)"
+        },
+        "allow_merge_commit": {
+          "type": "boolean",
+          "default": "true",
+          "description": "Either true to allow merging pull requests with a merge commit, or false to prevent merging pull requests with merge commits. Default: true. (In preview period. See README.)"
+        },
+        "allow_rebase_merge": {
+          "type": "boolean",
+          "default": "true",
+          "description": "Either true to allow rebase-merging pull requests, or false to prevent rebase-merging. Default: true. (In preview period. See README.)"
         }
       },
-      "description": "List all topics for a repository. (In preview period. See README.)"
+      "description": "Update a repo."
     },
-    "replaceTopics": {
-      "url": "/repos/:owner/:repo/topics",
-      "method": "PUT",
-      "headers": {
-        "accept": "application/vnd.github.mercy-preview+json"
-      },
+    "editAsset": {
+      "url": "/repos/:owner/:repo/releases/assets/:id",
+      "method": "PATCH",
       "params": {
         "owner": {
           "type": "string",
@@ -6611,129 +7327,196 @@
           "type": "string",
           "required": true
         },
-        "names": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "name": {
+          "type": "string",
+          "required": true
+        },
+        "label": {
+          "type": "string",
+          "description": "An alternate short description of the asset. Used in place of the filename."
+        }
+      },
+      "description": "Edit a release asset."
+    },
+    "editHook": {
+      "url": "/repos/:owner/:repo/hooks/:id",
+      "method": "PATCH",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "name": {
+          "type": "string",
+          "required": true
+        },
+        "config": {
+          "type": "json",
+          "required": true,
+          "description": "A Hash containing key/value pairs to provide settings for this hook. Modifying this will replace the entire config object. These settings vary between the services and are defined in the github-services repo. Booleans are stored internally as `1` for true, and `0` for false. Any JSON true/false values will be converted automatically."
+        },
+        "events": {
           "type": "string[]",
+          "default": "[\"push\"]",
+          "description": "Determines what events the hook is triggered for. This replaces the entire array of events. Default: `['push']`."
+        },
+        "add_events": {
+          "type": "string[]",
+          "description": "Determines a list of events to be added to the list of events that the Hook triggers for."
+        },
+        "remove_events": {
+          "type": "string[]",
+          "description": "Determines a list of events to be removed from the list of events that the Hook triggers for."
+        },
+        "active": {
+          "type": "boolean",
+          "description": "Determines whether the hook is actually triggered on pushes."
+        }
+      },
+      "description": "Edit a hook."
+    },
+    "editRelease": {
+      "url": "/repos/:owner/:repo/releases/:id",
+      "method": "PATCH",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "tag_name": {
+          "type": "string",
           "required": true,
-          "description": "An array of topics to add to the repository. Pass one or more topics to replace the set of existing topics. Send an empty array ([]) to clear all topics from the repository."
-        }
-      },
-      "description": "Replace all topics for a repository. (In preview period. See README.)"
-    },
-    "getContributors": {
-      "url": "/repos/:owner/:repo/contributors",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
+          "description": "String of the tag"
         },
-        "repo": {
+        "target_commitish": {
           "type": "string",
-          "required": true
+          "description": "Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch (usually master)."
         },
-        "anon": {
+        "name": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "draft": {
           "type": "boolean",
-          "description": "Set to 1 or true to include anonymous contributors in results."
+          "default": "false",
+          "description": "true to create a draft (unpublished) release, false to create a published one. Default: false"
         },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get contributors for the specified repository."
-    },
-    "getLanguages": {
-      "url": "/repos/:owner/:repo/languages",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get languages for the specified repository."
-    },
-    "getTeams": {
-      "url": "/repos/:owner/:repo/teams",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get teams for the specified repository."
-    },
-    "getTags": {
-      "url": "/repos/:owner/:repo/tags",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get tags for the specified repository."
-    },
-    "getBranches": {
-      "url": "/repos/:owner/:repo/branches",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "protected": {
+        "prerelease": {
           "type": "boolean",
-          "description": "Set to true to only return protected branches"
+          "default": "false",
+          "description": "true to identify the release as a prerelease. false to identify the release as a full release. Default: false"
+        }
+      },
+      "description": "Edit a release."
+    },
+    "fork": {
+      "url": "/repos/:owner/:repo/forks",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "organization": {
+          "type": "string",
+          "description": "Optional parameter to specify the organization name if forking into an organization."
+        }
+      },
+      "description": "Create a fork."
+    },
+    "get": {
+      "url": "/repos/:owner/:repo",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.drax-preview+json"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a repo for a user."
+    },
+    "getAll": {
+      "url": "/user/repos",
+      "method": "GET",
+      "params": {
+        "visibility": {
+          "type": "string",
+          "enum": [
+            "all",
+            "public",
+            "private"
+          ],
+          "default": "all",
+          "description": "Can be one of `all`, `public`, or `private`. Default: `all`."
+        },
+        "affiliation": {
+          "type": "string",
+          "default": "owner,collaborator,organization_member",
+          "description": "Comma-separated list of values. Can include: `owner`, `collaborator`, `organization_member`."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "all",
+            "owner",
+            "public",
+            "private",
+            "member"
+          ],
+          "default": "all",
+          "description": "Possible values: `all`, `owner`, `public`, `private`, `member`. Default: `all`."
+        },
+        "sort": {
+          "type": "string",
+          "enum": [
+            "created",
+            "updated",
+            "pushed",
+            "full_name"
+          ],
+          "default": "full_name",
+          "description": "Possible values: `created`, `updated`, `pushed`, `full_name`. Default: `full_name`."
+        },
+        "direction": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "default": "desc"
         },
         "page": {
           "type": "number",
@@ -6745,7 +7528,98 @@
           "description": "A custom page size up to 100. Default is 30."
         }
       },
-      "description": "List branches."
+      "description": "List your repositories"
+    },
+    "getAllCommitComments": {
+      "url": "/repos/:owner/:repo/comments",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List commit comments for a repository."
+    },
+    "getArchiveLink": {
+      "url": "/repos/:owner/:repo/:archive_format/:ref",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "archive_format": {
+          "type": "string",
+          "required": true,
+          "enum": [
+            "tarball",
+            "zipball"
+          ],
+          "default": "tarball",
+          "description": "Either tarball or zipball, Deafult: tarball."
+        },
+        "ref": {
+          "type": "string",
+          "description": "A valid Git reference. Default: the repository’s default branch (usually master)."
+        }
+      },
+      "description": "Get archive link."
+    },
+    "getAsset": {
+      "url": "/repos/:owner/:repo/releases/assets/:id",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a single release asset."
+    },
+    "getAssets": {
+      "url": "/repos/:owner/:repo/releases/:id/assets",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "List assets for a release."
     },
     "getBranch": {
       "url": "/repos/:owner/:repo/branches/:branch",
@@ -6802,6 +7676,1785 @@
         }
       },
       "description": "Get branch protection."
+    },
+    "getBranches": {
+      "url": "/repos/:owner/:repo/branches",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "protected": {
+          "type": "boolean",
+          "description": "Set to true to only return protected branches"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List branches."
+    },
+    "getById": {
+      "url": "/repositories/:id",
+      "method": "GET",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true,
+          "description": "Numerical ID of the repository."
+        }
+      },
+      "description": "Get a single repo by id."
+    },
+    "getClones": {
+      "url": "/repos/:owner/:repo/traffic/clones",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Get the total number of clones and breakdown per day or week for the last 14 days."
+    },
+    "getCollaborators": {
+      "url": "/repos/:owner/:repo/collaborators",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "affiliation": {
+          "type": "string",
+          "enum": [
+            "outside",
+            "all",
+            "direct"
+          ],
+          "default": "all",
+          "description": "Filter collaborators returned by their affiliation."
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List collaborators"
+    },
+    "getCombinedStatusForRef": {
+      "url": "/repos/:owner/:repo/commits/:ref/status",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "ref": {
+          "type": "string",
+          "required": true,
+          "description": "Ref to fetch the status for. It can be a SHA, a branch name, or a tag name."
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Get the combined status for a specific ref."
+    },
+    "getCommit": {
+      "url": "/repos/:owner/:repo/commits/:sha",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.cryptographer-preview"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "sha": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a single commit."
+    },
+    "getCommitComment": {
+      "url": "/repos/:owner/:repo/comments/:id",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a single commit comment."
+    },
+    "getCommitComments": {
+      "url": "/repos/:owner/:repo/commits/:ref/comments",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "ref": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List comments for a single commit."
+    },
+    "getCommits": {
+      "url": "/repos/:owner/:repo/commits",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "sha": {
+          "type": "string",
+          "description": "Sha or branch to start listing commits from."
+        },
+        "path": {
+          "type": "string",
+          "description": "Only commits containing this file path will be returned."
+        },
+        "author": {
+          "type": "string",
+          "description": "GitHub login or email address by which to filter by commit author."
+        },
+        "since": {
+          "type": "date",
+          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+        },
+        "until": {
+          "type": "date",
+          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List commits on a repository."
+    },
+    "getCommunityProfileMetrics": {
+      "url": "/repos/:owner/:name/community/profile",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.black-panther-preview+json"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "name": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Retrieve community profile metrics."
+    },
+    "getContent": {
+      "url": "/repos/:owner/:repo/contents/:path",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "path": {
+          "type": "string",
+          "required": true,
+          "allow-empty": true,
+          "description": "The content path."
+        },
+        "ref": {
+          "type": "string",
+          "description": "The String name of the Commit/Branch/Tag. Defaults to master."
+        }
+      },
+      "description": "Get the contents of a file or directory in a repository."
+    },
+    "getContributors": {
+      "url": "/repos/:owner/:repo/contributors",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "anon": {
+          "type": "boolean",
+          "description": "Set to 1 or true to include anonymous contributors in results."
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Get contributors for the specified repository."
+    },
+    "getDeployKey": {
+      "url": "/repos/:owner/:repo/keys/:id",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a deploy key."
+    },
+    "getDeployKeys": {
+      "url": "/repos/:owner/:repo/keys",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List deploy keys."
+    },
+    "getDeployment": {
+      "url": "/repos/:owner/:repo/deployments/:deployment_id",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "deployment_id": {
+          "type": "string",
+          "required": true,
+          "description": "The deployment id."
+        }
+      },
+      "description": "Get a single Deployment. (In preview period. See README.)"
+    },
+    "getDeploymentStatus": {
+      "url": "/repos/:owner/:repo/deployments/:id/statuses/:status_id",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true,
+          "description": "The Deployment ID to list the statuses from."
+        },
+        "status_id": {
+          "type": "string",
+          "required": true,
+          "description": "The Deployment Status ID."
+        }
+      },
+      "description": "List deployment statuses. (In preview period. See README.)"
+    },
+    "getDeploymentStatuses": {
+      "url": "/repos/:owner/:repo/deployments/:id/statuses",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.ant-man-preview+json"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "List deployment statuses. (In preview period. See README.)"
+    },
+    "getDeployments": {
+      "url": "/repos/:owner/:repo/deployments",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.ant-man-preview+json"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "sha": {
+          "type": "string",
+          "default": "none",
+          "description": "The short or long sha that was recorded at creation time. Default: none."
+        },
+        "ref": {
+          "type": "string",
+          "default": "none",
+          "description": "The name of the ref. This can be a branch, tag, or sha. Default: none."
+        },
+        "task": {
+          "type": "string",
+          "default": "none",
+          "description": "The name of the task for the deployment. e.g. deploy or deploy:migrations. Default: none."
+        },
+        "environment": {
+          "type": "string",
+          "default": "none",
+          "description": "The name of the environment that was deployed to. e.g. staging or production. Default: none."
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List deployments."
+    },
+    "getDownload": {
+      "url": "/repos/:owner/:repo/downloads/:id",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a single download."
+    },
+    "getDownloads": {
+      "url": "/repos/:owner/:repo/downloads",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List downloads for a repository."
+    },
+    "getForOrg": {
+      "url": "/orgs/:org/repos",
+      "method": "GET",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "all",
+            "public",
+            "private",
+            "forks",
+            "sources",
+            "member"
+          ],
+          "default": "all",
+          "description": "Possible values: `all`, `public`, `private`, `forks`, `sources`, `member`. Default: `all`."
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List repositories for the specified org."
+    },
+    "getForUser": {
+      "url": "/users/:username/repos",
+      "method": "GET",
+      "params": {
+        "username": {
+          "type": "string",
+          "required": true
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "all",
+            "owner",
+            "member"
+          ],
+          "default": "owner",
+          "description": "Possible values: `all`, `owner`, `member`. Default: `owner`."
+        },
+        "sort": {
+          "type": "string",
+          "enum": [
+            "created",
+            "updated",
+            "pushed",
+            "full_name"
+          ],
+          "default": "full_name",
+          "description": "Possible values: `created`, `updated`, `pushed`, `full_name`. Default: `full_name`."
+        },
+        "direction": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "default": "desc"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List public repositories for the specified user."
+    },
+    "getForks": {
+      "url": "/repos/:owner/:repo/forks",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "sort": {
+          "type": "string",
+          "enum": [
+            "newest",
+            "oldest",
+            "stargazers"
+          ],
+          "default": "newest",
+          "description": "Possible values: `newest`, `oldest`, `stargazers`, default: `newest`."
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List forks."
+    },
+    "getHook": {
+      "url": "/repos/:owner/:repo/hooks/:id",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get single hook."
+    },
+    "getHooks": {
+      "url": "/repos/:owner/:repo/hooks",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List hooks."
+    },
+    "getInvites": {
+      "url": "/repos/:owner/:repo/invitations",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "List invitations for a repository."
+    },
+    "getLanguages": {
+      "url": "/repos/:owner/:repo/languages",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Get languages for the specified repository."
+    },
+    "getLatestPagesBuild": {
+      "url": "/repos/:owner/:repo/pages/builds/latest",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.mister-fantastic-preview+json"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get latest Pages build. (In preview period. See README.)"
+    },
+    "getLatestRelease": {
+      "url": "/repos/:owner/:repo/releases/latest",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get the latest release."
+    },
+    "getPages": {
+      "url": "/repos/:owner/:repo/pages",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.mister-fantastic-preview+json"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Get information about a Pages site. (In preview period. See README.)"
+    },
+    "getPagesBuild": {
+      "url": "/repos/:owner/:repo/pages/builds/:id",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.mister-fantastic-preview+json"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a specific Pages build. (In preview period. See README.)"
+    },
+    "getPagesBuilds": {
+      "url": "/repos/:owner/:repo/pages/builds",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.mister-fantastic-preview+json"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List Pages builds. (In preview period. See README.)"
+    },
+    "getPaths": {
+      "url": "/repos/:owner/:repo/traffic/popular/paths",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Get the top 10 popular contents over the last 14 days."
+    },
+    "getProtectedBranchAdminEnforcement": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Get admin enforcement of protected branch."
+    },
+    "getProtectedBranchPullRequestReviewEnforcement": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Get pull request review enforcement of protected branch."
+    },
+    "getProtectedBranchRequiredStatusChecks": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Get required status checks of protected branch."
+    },
+    "getProtectedBranchRequiredStatusChecksContexts": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List required status checks contexts of protected branch."
+    },
+    "getProtectedBranchRestrictions": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Get restrictions of protected branch."
+    },
+    "getProtectedBranchTeamRestrictions": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List team restrictions of protected branch."
+    },
+    "getProtectedBranchUserRestrictions": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List user restrictions of protected branch."
+    },
+    "getPublic": {
+      "url": "/repositories",
+      "method": "GET",
+      "params": {
+        "since": {
+          "type": "string",
+          "description": "The integer ID of the last Repository that you've seen."
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List all public repositories"
+    },
+    "getReadme": {
+      "url": "/repos/:owner/:repo/readme",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "ref": {
+          "type": "string",
+          "description": "The name of the commit/branch/tag. Default: the repository’s default branch (usually master)"
+        }
+      },
+      "description": "Get the README for the given repository."
+    },
+    "getReferrers": {
+      "url": "/repos/:owner/:repo/traffic/popular/referrers",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Get the top 10 referrers over the last 14 days."
+    },
+    "getRelease": {
+      "url": "/repos/:owner/:repo/releases/:id",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a single release."
+    },
+    "getReleaseByTag": {
+      "url": "/repos/:owner/:repo/releases/tags/:tag",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "tag": {
+          "type": "string",
+          "required": true,
+          "description": "String of the tag"
+        }
+      },
+      "description": "Get a release by tag name."
+    },
+    "getReleases": {
+      "url": "/repos/:owner/:repo/releases",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List releases for a repository."
+    },
+    "getShaOfCommitRef": {
+      "url": "/repos/:owner/:repo/commits/:ref",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "ref": {
+          "type": "string",
+          "required": true,
+          "allow-empty": true,
+          "description": "String of the name of the fully qualified reference (ie: heads/master). If it doesn’t have at least one slash, it will be rejected."
+        }
+      },
+      "description": "Get the SHA-1 of a commit reference."
+    },
+    "getStatsCodeFrequency": {
+      "url": "/repos/:owner/:repo/stats/code_frequency",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get the number of additions and deletions per week."
+    },
+    "getStatsCommitActivity": {
+      "url": "/repos/:owner/:repo/stats/commit_activity",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get the last year of commit activity data."
+    },
+    "getStatsContributors": {
+      "url": "/repos/:owner/:repo/stats/contributors",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get contributors list with additions, deletions, and commit counts."
+    },
+    "getStatsParticipation": {
+      "url": "/repos/:owner/:repo/stats/participation",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get the weekly commit count for the repository owner and everyone else."
+    },
+    "getStatsPunchCard": {
+      "url": "/repos/:owner/:repo/stats/punch_card",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get the number of commits per hour in each day."
+    },
+    "getStatuses": {
+      "url": "/repos/:owner/:repo/commits/:ref/statuses",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "ref": {
+          "type": "string",
+          "required": true,
+          "description": "Ref to list the statuses from. It can be a SHA, a branch name, or a tag name."
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List statuses for a specfic ref."
+    },
+    "getTags": {
+      "url": "/repos/:owner/:repo/tags",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Get tags for the specified repository."
+    },
+    "getTeams": {
+      "url": "/repos/:owner/:repo/teams",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Get teams for the specified repository."
+    },
+    "getTopics": {
+      "url": "/repos/:owner/:repo/topics",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.mercy-preview+json"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List all topics for a repository. (In preview period. See README.)"
+    },
+    "getViews": {
+      "url": "/repos/:owner/:repo/traffic/views",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Get the total number of views and breakdown per day or week for the last 14 days."
+    },
+    "merge": {
+      "url": "/repos/:owner/:repo/merges",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "base": {
+          "type": "string",
+          "required": true,
+          "description": "The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo."
+        },
+        "head": {
+          "type": "string",
+          "required": true,
+          "description": "The branch (or git ref) where your changes are implemented."
+        },
+        "commit_message": {
+          "type": "string",
+          "description": "Commit message to use for the merge commit. If omitted, a default message will be used."
+        }
+      },
+      "description": "Perform a merge."
+    },
+    "pingHook": {
+      "url": "/repos/:owner/:repo/hooks/:id/pings",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Ping a hook."
+    },
+    "removeBranchProtection": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Remove branch protection."
+    },
+    "removeCollaborator": {
+      "url": "/repos/:owner/:repo/collaborators/:username",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Remove user as a collaborator."
+    },
+    "removeProtectedBranchAdminEnforcement": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Remove admin enforcement of protected branch."
+    },
+    "removeProtectedBranchPullRequestReviewEnforcement": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Remove pull request review enforcement of protected branch."
+    },
+    "removeProtectedBranchRequiredStatusChecks": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Remove required status checks of protected branch."
+    },
+    "removeProtectedBranchRequiredStatusChecksContexts": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        },
+        "contexts": {
+          "type": "string[]",
+          "required": true,
+          "mapTo": "input",
+          "description": "An array of protected branch required status checks contexts (e.g. continuous-integration/jenkins)."
+        }
+      },
+      "description": "Remove required status checks contexts of protected branch."
+    },
+    "removeProtectedBranchRestrictions": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Remove restrictions of protected branch."
+    },
+    "removeProtectedBranchTeamRestrictions": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        },
+        "teams": {
+          "type": "string[]",
+          "required": true,
+          "mapTo": "input",
+          "description": "An array of team slugs (e.g. justice-league)."
+        }
+      },
+      "description": "Remove team restrictions of protected branch."
+    },
+    "removeProtectedBranchUserRestrictions": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
+      "method": "DELETE",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        },
+        "users": {
+          "type": "string[]",
+          "required": true,
+          "mapTo": "input",
+          "description": "An array of team slugs (e.g. justice-league)."
+        }
+      },
+      "description": "Remove user restrictions of protected branch."
+    },
+    "replaceProtectedBranchRequiredStatusChecksContexts": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
+      "method": "PUT",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        },
+        "contexts": {
+          "type": "string[]",
+          "required": true,
+          "mapTo": "input",
+          "description": "An array of protected branch required status checks contexts (e.g. continuous-integration/jenkins)."
+        }
+      },
+      "description": "Replace required status checks contexts of protected branch."
+    },
+    "replaceProtectedBranchTeamRestrictions": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
+      "method": "PUT",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        },
+        "teams": {
+          "type": "string[]",
+          "required": true,
+          "mapTo": "input",
+          "description": "An array of team slugs (e.g. justice-league)."
+        }
+      },
+      "description": "Replace team restrictions of protected branch."
+    },
+    "replaceProtectedBranchUserRestrictions": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
+      "method": "PUT",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "branch": {
+          "type": "string",
+          "required": true
+        },
+        "users": {
+          "type": "string[]",
+          "required": true,
+          "mapTo": "input",
+          "description": "An array of team slugs (e.g. justice-league)."
+        }
+      },
+      "description": "Replace user restrictions of protected branch."
+    },
+    "replaceTopics": {
+      "url": "/repos/:owner/:repo/topics",
+      "method": "PUT",
+      "headers": {
+        "accept": "application/vnd.github.mercy-preview+json"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "names": {
+          "type": "string[]",
+          "required": true,
+          "description": "An array of topics to add to the repository. Pass one or more topics to replace the set of existing topics. Send an empty array ([]) to clear all topics from the repository."
+        }
+      },
+      "description": "Replace all topics for a repository. (In preview period. See README.)"
+    },
+    "requestPageBuild": {
+      "url": "/repos/:owner/:repo/pages/builds",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.mister-fantastic-preview+json"
+      },
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Request a page build. (In preview period. See README.)"
+    },
+    "reviewUserPermissionLevel": {
+      "url": "/repos/:owner/:repo/collaborators/:username/permission",
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Review a user's permission level."
+    },
+    "testHook": {
+      "url": "/repos/:owner/:repo/hooks/:id/tests",
+      "method": "POST",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Test a [push] hook."
     },
     "updateBranchProtection": {
       "url": "/repos/:owner/:repo/branches/:branch/protection",
@@ -6860,831 +9513,6 @@
       },
       "description": "Update branch protection."
     },
-    "removeBranchProtection": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Remove branch protection."
-    },
-    "getProtectedBranchRequiredStatusChecks": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get required status checks of protected branch."
-    },
-    "updateProtectedBranchRequiredStatusChecks": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks",
-      "method": "PATCH",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "strict": {
-          "type": "boolean",
-          "description": "Require branches to be up to date before merging."
-        },
-        "contexts": {
-          "type": "string[]",
-          "description": "The list of status checks to require in order to merge into this branch."
-        }
-      },
-      "description": "Update required status checks of protected branch."
-    },
-    "removeProtectedBranchRequiredStatusChecks": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Remove required status checks of protected branch."
-    },
-    "getProtectedBranchRequiredStatusChecksContexts": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List required status checks contexts of protected branch."
-    },
-    "replaceProtectedBranchRequiredStatusChecksContexts": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
-      "method": "PUT",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "contexts": {
-          "type": "string[]",
-          "required": true,
-          "mapTo": "input",
-          "description": "An array of protected branch required status checks contexts (e.g. continuous-integration/jenkins)."
-        }
-      },
-      "description": "Replace required status checks contexts of protected branch."
-    },
-    "addProtectedBranchRequiredStatusChecksContexts": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "contexts": {
-          "type": "string[]",
-          "required": true,
-          "mapTo": "input",
-          "description": "An array of protected branch required status checks contexts (e.g. continuous-integration/jenkins)."
-        }
-      },
-      "description": "Add required status checks contexts of protected branch."
-    },
-    "removeProtectedBranchRequiredStatusChecksContexts": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "contexts": {
-          "type": "string[]",
-          "required": true,
-          "mapTo": "input",
-          "description": "An array of protected branch required status checks contexts (e.g. continuous-integration/jenkins)."
-        }
-      },
-      "description": "Remove required status checks contexts of protected branch."
-    },
-    "getProtectedBranchPullRequestReviewEnforcement": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get pull request review enforcement of protected branch."
-    },
-    "updateProtectedBranchPullRequestReviewEnforcement": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews",
-      "method": "PATCH",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "dismissal_restrictions": {
-          "type": "json",
-          "allow-null": true,
-          "description": "JSON object that contains the following keys: `users` - The list of user logins with dismissal access, `teams` - The list of team slugs with dismissal access. This object can have the value of `null` for disabled."
-        },
-        "dismiss_stale_reviews": {
-          "type": "boolean",
-          "description": "Dismiss approved reviews automatically when a new commit is pushed."
-        },
-        "require_code_owner_reviews": {
-          "type": "boolean",
-          "description": "Blocks merge until code owners have reviewed."
-        }
-      },
-      "description": "Update pull request review enforcement of protected branch."
-    },
-    "removeProtectedBranchPullRequestReviewEnforcement": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Remove pull request review enforcement of protected branch."
-    },
-    "getProtectedBranchAdminEnforcement": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get admin enforcement of protected branch."
-    },
-    "addProtectedBranchAdminEnforcement": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Add admin enforcement of protected branch."
-    },
-    "removeProtectedBranchAdminEnforcement": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Remove admin enforcement of protected branch."
-    },
-    "getProtectedBranchRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get restrictions of protected branch."
-    },
-    "removeProtectedBranchRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Remove restrictions of protected branch."
-    },
-    "getProtectedBranchTeamRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List team restrictions of protected branch."
-    },
-    "replaceProtectedBranchTeamRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
-      "method": "PUT",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "teams": {
-          "type": "string[]",
-          "required": true,
-          "mapTo": "input",
-          "description": "An array of team slugs (e.g. justice-league)."
-        }
-      },
-      "description": "Replace team restrictions of protected branch."
-    },
-    "addProtectedBranchTeamRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "teams": {
-          "type": "string[]",
-          "required": true,
-          "mapTo": "input",
-          "description": "An array of team slugs (e.g. justice-league)."
-        }
-      },
-      "description": "Add team restrictions of protected branch."
-    },
-    "removeProtectedBranchTeamRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "teams": {
-          "type": "string[]",
-          "required": true,
-          "mapTo": "input",
-          "description": "An array of team slugs (e.g. justice-league)."
-        }
-      },
-      "description": "Remove team restrictions of protected branch."
-    },
-    "getProtectedBranchUserRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List user restrictions of protected branch."
-    },
-    "replaceProtectedBranchUserRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
-      "method": "PUT",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "users": {
-          "type": "string[]",
-          "required": true,
-          "mapTo": "input",
-          "description": "An array of team slugs (e.g. justice-league)."
-        }
-      },
-      "description": "Replace user restrictions of protected branch."
-    },
-    "addProtectedBranchUserRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "users": {
-          "type": "string[]",
-          "required": true,
-          "mapTo": "input",
-          "description": "An array of team slugs (e.g. justice-league)."
-        }
-      },
-      "description": "Add user restrictions of protected branch."
-    },
-    "removeProtectedBranchUserRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
-        "users": {
-          "type": "string[]",
-          "required": true,
-          "mapTo": "input",
-          "description": "An array of team slugs (e.g. justice-league)."
-        }
-      },
-      "description": "Remove user restrictions of protected branch."
-    },
-    "getCollaborators": {
-      "url": "/repos/:owner/:repo/collaborators",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "affiliation": {
-          "type": "string",
-          "enum": [
-            "outside",
-            "all",
-            "direct"
-          ],
-          "default": "all",
-          "description": "Filter collaborators returned by their affiliation."
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List collaborators"
-    },
-    "checkCollaborator": {
-      "url": "/repos/:owner/:repo/collaborators/:username",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Check if user is a collaborator."
-    },
-    "reviewUserPermissionLevel": {
-      "url": "/repos/:owner/:repo/collaborators/:username/permission",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Review a user's permission level."
-    },
-    "addCollaborator": {
-      "url": "/repos/:owner/:repo/collaborators/:username",
-      "method": "PUT",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        },
-        "permission": {
-          "type": "string",
-          "enum": [
-            "pull",
-            "push",
-            "admin"
-          ],
-          "default": "push",
-          "description": "`pull` - can pull, but not push to or administer this repository, `push` - can pull and push, but not administer this repository, `admin` - can pull, push and administer this repository."
-        }
-      },
-      "description": "Add user as a collaborator"
-    },
-    "removeCollaborator": {
-      "url": "/repos/:owner/:repo/collaborators/:username",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Remove user as a collaborator."
-    },
-    "getAllCommitComments": {
-      "url": "/repos/:owner/:repo/comments",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List commit comments for a repository."
-    },
-    "getCommitComments": {
-      "url": "/repos/:owner/:repo/commits/:ref/comments",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "ref": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List comments for a single commit."
-    },
-    "createCommitComment": {
-      "url": "/repos/:owner/:repo/commits/:sha/comments",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "sha": {
-          "type": "string",
-          "required": true
-        },
-        "body": {
-          "type": "string",
-          "required": true
-        },
-        "path": {
-          "type": "string",
-          "description": "Relative path of the file to comment on."
-        },
-        "position": {
-          "type": "number",
-          "description": "Line index in the diff to comment on."
-        }
-      },
-      "description": "Create a commit comment."
-    },
-    "getCommitComment": {
-      "url": "/repos/:owner/:repo/comments/:id",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a single commit comment."
-    },
     "updateCommitComment": {
       "url": "/repos/:owner/:repo/comments/:id",
       "method": "PATCH",
@@ -7707,239 +9535,6 @@
         }
       },
       "description": "Update a commit comment."
-    },
-    "deleteCommitComment": {
-      "url": "/repos/:owner/:repo/comments/:id",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete a commit comment."
-    },
-    "getCommunityProfileMetrics": {
-      "url": "/repos/:owner/:name/community/profile",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.black-panther-preview+json"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "name": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Retrieve community profile metrics."
-    },
-    "getCommits": {
-      "url": "/repos/:owner/:repo/commits",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "sha": {
-          "type": "string",
-          "description": "Sha or branch to start listing commits from."
-        },
-        "path": {
-          "type": "string",
-          "description": "Only commits containing this file path will be returned."
-        },
-        "author": {
-          "type": "string",
-          "description": "GitHub login or email address by which to filter by commit author."
-        },
-        "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
-        },
-        "until": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List commits on a repository."
-    },
-    "getCommit": {
-      "url": "/repos/:owner/:repo/commits/:sha",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.cryptographer-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "sha": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a single commit."
-    },
-    "getShaOfCommitRef": {
-      "url": "/repos/:owner/:repo/commits/:ref",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "ref": {
-          "type": "string",
-          "required": true,
-          "allow-empty": true,
-          "description": "String of the name of the fully qualified reference (ie: heads/master). If it doesn’t have at least one slash, it will be rejected."
-        }
-      },
-      "description": "Get the SHA-1 of a commit reference."
-    },
-    "compareCommits": {
-      "url": "/repos/:owner/:repo/compare/:base...:head",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "base": {
-          "type": "string",
-          "required": true,
-          "description": "The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo."
-        },
-        "head": {
-          "type": "string",
-          "required": true,
-          "description": "The branch (or git ref) where your changes are implemented."
-        }
-      },
-      "description": "Compare two commits."
-    },
-    "getReadme": {
-      "url": "/repos/:owner/:repo/readme",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "ref": {
-          "type": "string",
-          "description": "The name of the commit/branch/tag. Default: the repository’s default branch (usually master)"
-        }
-      },
-      "description": "Get the README for the given repository."
-    },
-    "getContent": {
-      "url": "/repos/:owner/:repo/contents/:path",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "path": {
-          "type": "string",
-          "required": true,
-          "allow-empty": true,
-          "description": "The content path."
-        },
-        "ref": {
-          "type": "string",
-          "description": "The String name of the Commit/Branch/Tag. Defaults to master."
-        }
-      },
-      "description": "Get the contents of a file or directory in a repository."
-    },
-    "createFile": {
-      "url": "/repos/:owner/:repo/contents/:path",
-      "method": "PUT",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "path": {
-          "type": "string",
-          "required": true,
-          "description": "The content path."
-        },
-        "message": {
-          "type": "string",
-          "required": true,
-          "description": "The commit message."
-        },
-        "content": {
-          "type": "string",
-          "required": true,
-          "description": "The new file content, Base64 encoded."
-        },
-        "branch": {
-          "type": "string",
-          "description": "The branch name. If not provided, uses the repository’s default branch (usually master)."
-        },
-        "committer": {
-          "type": "json"
-        },
-        "author": {
-          "type": "json"
-        }
-      },
-      "description": "Create a new file in the given repository."
     },
     "updateFile": {
       "url": "/repos/:owner/:repo/contents/:path",
@@ -7986,520 +9581,6 @@
       },
       "description": "Update a file."
     },
-    "deleteFile": {
-      "url": "/repos/:owner/:repo/contents/:path",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "path": {
-          "type": "string",
-          "required": true,
-          "description": "The content path."
-        },
-        "message": {
-          "type": "string",
-          "required": true,
-          "description": "The commit message."
-        },
-        "sha": {
-          "type": "string",
-          "required": true,
-          "description": "The blob SHA of the file being removed."
-        },
-        "branch": {
-          "type": "string",
-          "description": "The branch name. If not provided, uses the repository’s default branch (usually master)."
-        },
-        "committer": {
-          "type": "json"
-        },
-        "author": {
-          "type": "json"
-        }
-      },
-      "description": "Delete a file."
-    },
-    "getArchiveLink": {
-      "url": "/repos/:owner/:repo/:archive_format/:ref",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "archive_format": {
-          "type": "string",
-          "required": true,
-          "enum": [
-            "tarball",
-            "zipball"
-          ],
-          "default": "tarball",
-          "description": "Either tarball or zipball, Deafult: tarball."
-        },
-        "ref": {
-          "type": "string",
-          "description": "A valid Git reference. Default: the repository’s default branch (usually master)."
-        }
-      },
-      "description": "Get archive link."
-    },
-    "getDeployKeys": {
-      "url": "/repos/:owner/:repo/keys",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List deploy keys."
-    },
-    "getDeployKey": {
-      "url": "/repos/:owner/:repo/keys/:id",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a deploy key."
-    },
-    "addDeployKey": {
-      "url": "/repos/:owner/:repo/keys",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "title": {
-          "type": "string",
-          "required": true
-        },
-        "key": {
-          "type": "string",
-          "required": true
-        },
-        "read_only": {
-          "type": "boolean",
-          "description": "If true, the key will only be able to read repository contents. Otherwise, the key will be able to read and write."
-        }
-      },
-      "description": "Add a new deploy key."
-    },
-    "deleteDeployKey": {
-      "url": "/repos/:owner/:repo/keys/:id",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Remove a deploy key."
-    },
-    "getDeployments": {
-      "url": "/repos/:owner/:repo/deployments",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.ant-man-preview+json"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "sha": {
-          "type": "string",
-          "default": "none",
-          "description": "The short or long sha that was recorded at creation time. Default: none."
-        },
-        "ref": {
-          "type": "string",
-          "default": "none",
-          "description": "The name of the ref. This can be a branch, tag, or sha. Default: none."
-        },
-        "task": {
-          "type": "string",
-          "default": "none",
-          "description": "The name of the task for the deployment. e.g. deploy or deploy:migrations. Default: none."
-        },
-        "environment": {
-          "type": "string",
-          "default": "none",
-          "description": "The name of the environment that was deployed to. e.g. staging or production. Default: none."
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List deployments."
-    },
-    "getDeployment": {
-      "url": "/repos/:owner/:repo/deployments/:deployment_id",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "deployment_id": {
-          "type": "string",
-          "required": true,
-          "description": "The deployment id."
-        }
-      },
-      "description": "Get a single Deployment. (In preview period. See README.)"
-    },
-    "createDeployment": {
-      "url": "/repos/:owner/:repo/deployments",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.ant-man-preview+json"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "ref": {
-          "type": "string",
-          "required": true,
-          "description": "The ref to deploy. This can be a branch, tag, or sha."
-        },
-        "task": {
-          "type": "string",
-          "default": "deploy",
-          "description": "The named task to execute. e.g. deploy or deploy:migrations. Default: deploy"
-        },
-        "auto_merge": {
-          "type": "boolean",
-          "default": "true",
-          "description": "Optional parameter to merge the default branch into the requested ref if it is behind the default branch. Default: true"
-        },
-        "required_contexts": {
-          "type": "string[]",
-          "description": "Optional array of status contexts verified against commit status checks. If this parameter is omitted from the parameters then all unique contexts will be verified before a deployment is created. To bypass checking entirely pass an empty array. Defaults to all unique contexts."
-        },
-        "payload": {
-          "type": "string",
-          "default": "\"\"",
-          "description": "Optional JSON payload with extra information about the deployment. Default: \"\""
-        },
-        "environment": {
-          "type": "string",
-          "default": "none",
-          "description": "The name of the environment that was deployed to. e.g. staging or production. Default: none."
-        },
-        "description": {
-          "type": "string",
-          "default": "\"\"",
-          "description": "Optional short description. Default: \"\""
-        },
-        "transient_environment": {
-          "type": "boolean",
-          "default": false,
-          "description": "Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future. Default: false. (In preview period. See README.)"
-        },
-        "production_environment": {
-          "type": "boolean",
-          "description": "Specifies if the given environment is a one that end-users directly interact with. Default: true when environment is `production` and false otherwise. (In preview period. See README.)"
-        }
-      },
-      "description": "Create a deployment. (In preview period. See README.)"
-    },
-    "getDeploymentStatuses": {
-      "url": "/repos/:owner/:repo/deployments/:id/statuses",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.ant-man-preview+json"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "List deployment statuses. (In preview period. See README.)"
-    },
-    "getDeploymentStatus": {
-      "url": "/repos/:owner/:repo/deployments/:id/statuses/:status_id",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true,
-          "description": "The Deployment ID to list the statuses from."
-        },
-        "status_id": {
-          "type": "string",
-          "required": true,
-          "description": "The Deployment Status ID."
-        }
-      },
-      "description": "List deployment statuses. (In preview period. See README.)"
-    },
-    "createDeploymentStatus": {
-      "url": "/repos/:owner/:repo/deployments/:id/statuses",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.ant-man-preview+json"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "state": {
-          "type": "string",
-          "description": "The state of the status. Can be one of pending, success, error, or failure."
-        },
-        "target_url": {
-          "type": "string",
-          "default": "\"\"",
-          "description": "The target URL to associate with this status. This URL should contain output to keep the user updated while the task is running or serve as historical information for what happened in the deployment. Default: \"\""
-        },
-        "log_url": {
-          "type": "string",
-          "default": "\"\"",
-          "description": "Functionally equivalent to target_url. Default: \"\". (In preview period. See README.)"
-        },
-        "description": {
-          "type": "string",
-          "default": "\"\"",
-          "description": "A short description of the status. Default: \"\""
-        },
-        "environment_url": {
-          "type": "string",
-          "default": "\"\"",
-          "description": "URL for accessing the deployment environment. Default: \"\". (In preview period. See README.)"
-        },
-        "auto_inactive": {
-          "type": "boolean",
-          "default": true,
-          "description": "When true the new `inactive` status is added to all other non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment. Default: true. (In preview period. See README.)"
-        }
-      },
-      "description": "Create a deployment status. (In preview period. See README.)"
-    },
-    "getDownloads": {
-      "url": "/repos/:owner/:repo/downloads",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List downloads for a repository."
-    },
-    "getDownload": {
-      "url": "/repos/:owner/:repo/downloads/:id",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a single download."
-    },
-    "deleteDownload": {
-      "url": "/repos/:owner/:repo/downloads/:id",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete a download."
-    },
-    "getForks": {
-      "url": "/repos/:owner/:repo/forks",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "sort": {
-          "type": "string",
-          "enum": [
-            "newest",
-            "oldest",
-            "stargazers"
-          ],
-          "default": "newest",
-          "description": "Possible values: `newest`, `oldest`, `stargazers`, default: `newest`."
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List forks."
-    },
-    "getInvites": {
-      "url": "/repos/:owner/:repo/invitations",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "List invitations for a repository."
-    },
-    "deleteInvite": {
-      "url": "/repos/:owner/:repo/invitations/:invitation_id",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "invitation_id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete a repository invitation."
-    },
     "updateInvite": {
       "url": "/repos/:owner/:repo/invitations/:invitation_id",
       "method": "PATCH",
@@ -8528,238 +9609,8 @@
       },
       "description": "Update a repository invitation."
     },
-    "getPages": {
-      "url": "/repos/:owner/:repo/pages",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.mister-fantastic-preview+json"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get information about a Pages site. (In preview period. See README.)"
-    },
-    "requestPageBuild": {
-      "url": "/repos/:owner/:repo/pages/builds",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.mister-fantastic-preview+json"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Request a page build. (In preview period. See README.)"
-    },
-    "getPagesBuilds": {
-      "url": "/repos/:owner/:repo/pages/builds",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.mister-fantastic-preview+json"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List Pages builds. (In preview period. See README.)"
-    },
-    "getLatestPagesBuild": {
-      "url": "/repos/:owner/:repo/pages/builds/latest",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.mister-fantastic-preview+json"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get latest Pages build. (In preview period. See README.)"
-    },
-    "getPagesBuild": {
-      "url": "/repos/:owner/:repo/pages/builds/:id",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.mister-fantastic-preview+json"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a specific Pages build. (In preview period. See README.)"
-    },
-    "getReleases": {
-      "url": "/repos/:owner/:repo/releases",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List releases for a repository."
-    },
-    "getRelease": {
-      "url": "/repos/:owner/:repo/releases/:id",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a single release."
-    },
-    "getLatestRelease": {
-      "url": "/repos/:owner/:repo/releases/latest",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get the latest release."
-    },
-    "getReleaseByTag": {
-      "url": "/repos/:owner/:repo/releases/tags/:tag",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "tag": {
-          "type": "string",
-          "required": true,
-          "description": "String of the tag"
-        }
-      },
-      "description": "Get a release by tag name."
-    },
-    "createRelease": {
-      "url": "/repos/:owner/:repo/releases",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "tag_name": {
-          "type": "string",
-          "required": true,
-          "description": "String of the tag"
-        },
-        "target_commitish": {
-          "type": "string",
-          "description": "Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch (usually master)."
-        },
-        "name": {
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        },
-        "draft": {
-          "type": "boolean",
-          "default": "false",
-          "description": "true to create a draft (unpublished) release, false to create a published one. Default: false"
-        },
-        "prerelease": {
-          "type": "boolean",
-          "default": "false",
-          "description": "true to identify the release as a prerelease. false to identify the release as a full release. Default: false"
-        }
-      },
-      "description": "Create a release."
-    },
-    "editRelease": {
-      "url": "/repos/:owner/:repo/releases/:id",
+    "updateProtectedBranchPullRequestReviewEnforcement": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews",
       "method": "PATCH",
       "params": {
         "owner": {
@@ -8770,41 +9621,29 @@
           "type": "string",
           "required": true
         },
-        "id": {
+        "branch": {
           "type": "string",
           "required": true
         },
-        "tag_name": {
-          "type": "string",
-          "required": true,
-          "description": "String of the tag"
+        "dismissal_restrictions": {
+          "type": "json",
+          "allow-null": true,
+          "description": "JSON object that contains the following keys: `users` - The list of user logins with dismissal access, `teams` - The list of team slugs with dismissal access. This object can have the value of `null` for disabled."
         },
-        "target_commitish": {
-          "type": "string",
-          "description": "Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch (usually master)."
-        },
-        "name": {
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        },
-        "draft": {
+        "dismiss_stale_reviews": {
           "type": "boolean",
-          "default": "false",
-          "description": "true to create a draft (unpublished) release, false to create a published one. Default: false"
+          "description": "Dismiss approved reviews automatically when a new commit is pushed."
         },
-        "prerelease": {
+        "require_code_owner_reviews": {
           "type": "boolean",
-          "default": "false",
-          "description": "true to identify the release as a prerelease. false to identify the release as a full release. Default: false"
+          "description": "Blocks merge until code owners have reviewed."
         }
       },
-      "description": "Edit a release."
+      "description": "Update pull request review enforcement of protected branch."
     },
-    "deleteRelease": {
-      "url": "/repos/:owner/:repo/releases/:id",
-      "method": "DELETE",
+    "updateProtectedBranchRequiredStatusChecks": {
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks",
+      "method": "PATCH",
       "params": {
         "owner": {
           "type": "string",
@@ -8814,31 +9653,20 @@
           "type": "string",
           "required": true
         },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete a release"
-    },
-    "getAssets": {
-      "url": "/repos/:owner/:repo/releases/:id/assets",
-      "method": "GET",
-      "params": {
-        "owner": {
+        "branch": {
           "type": "string",
           "required": true
         },
-        "repo": {
-          "type": "string",
-          "required": true
+        "strict": {
+          "type": "boolean",
+          "description": "Require branches to be up to date before merging."
         },
-        "id": {
-          "type": "string",
-          "required": true
+        "contexts": {
+          "type": "string[]",
+          "description": "The list of status checks to require in order to merge into this branch."
         }
       },
-      "description": "List assets for a release."
+      "description": "Update required status checks of protected branch."
     },
     "uploadAsset": {
       "method": "POST",
@@ -8878,565 +9706,9 @@
         }
       },
       "description": "Upload a release asset."
-    },
-    "getAsset": {
-      "url": "/repos/:owner/:repo/releases/assets/:id",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a single release asset."
-    },
-    "editAsset": {
-      "url": "/repos/:owner/:repo/releases/assets/:id",
-      "method": "PATCH",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "name": {
-          "type": "string",
-          "required": true
-        },
-        "label": {
-          "type": "string",
-          "description": "An alternate short description of the asset. Used in place of the filename."
-        }
-      },
-      "description": "Edit a release asset."
-    },
-    "deleteAsset": {
-      "url": "/repos/:owner/:repo/releases/assets/:id",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete a release asset."
-    },
-    "getStatsContributors": {
-      "url": "/repos/:owner/:repo/stats/contributors",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get contributors list with additions, deletions, and commit counts."
-    },
-    "getStatsCommitActivity": {
-      "url": "/repos/:owner/:repo/stats/commit_activity",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get the last year of commit activity data."
-    },
-    "getStatsCodeFrequency": {
-      "url": "/repos/:owner/:repo/stats/code_frequency",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get the number of additions and deletions per week."
-    },
-    "getStatsParticipation": {
-      "url": "/repos/:owner/:repo/stats/participation",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get the weekly commit count for the repository owner and everyone else."
-    },
-    "getStatsPunchCard": {
-      "url": "/repos/:owner/:repo/stats/punch_card",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get the number of commits per hour in each day."
-    },
-    "createStatus": {
-      "url": "/repos/:owner/:repo/statuses/:sha",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "sha": {
-          "type": "string",
-          "required": true
-        },
-        "state": {
-          "type": "string",
-          "required": true,
-          "enum": [
-            "pending",
-            "success",
-            "error",
-            "failure"
-          ],
-          "description": "State of the status - can be one of pending, success, error, or failure."
-        },
-        "target_url": {
-          "type": "string",
-          "description": "Target url to associate with this status. This URL will be linked from the GitHub UI to allow users to easily see the ‘source’ of the Status."
-        },
-        "description": {
-          "type": "string",
-          "description": "Short description of the status."
-        },
-        "context": {
-          "type": "string",
-          "description": "A string label to differentiate this status from the status of other systems."
-        }
-      },
-      "description": "Create a status."
-    },
-    "getStatuses": {
-      "url": "/repos/:owner/:repo/commits/:ref/statuses",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "ref": {
-          "type": "string",
-          "required": true,
-          "description": "Ref to list the statuses from. It can be a SHA, a branch name, or a tag name."
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List statuses for a specfic ref."
-    },
-    "getCombinedStatusForRef": {
-      "url": "/repos/:owner/:repo/commits/:ref/status",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "ref": {
-          "type": "string",
-          "required": true,
-          "description": "Ref to fetch the status for. It can be a SHA, a branch name, or a tag name."
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get the combined status for a specific ref."
-    },
-    "getReferrers": {
-      "url": "/repos/:owner/:repo/traffic/popular/referrers",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get the top 10 referrers over the last 14 days."
-    },
-    "getPaths": {
-      "url": "/repos/:owner/:repo/traffic/popular/paths",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get the top 10 popular contents over the last 14 days."
-    },
-    "getViews": {
-      "url": "/repos/:owner/:repo/traffic/views",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get the total number of views and breakdown per day or week for the last 14 days."
-    },
-    "getClones": {
-      "url": "/repos/:owner/:repo/traffic/clones",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get the total number of clones and breakdown per day or week for the last 14 days."
-    },
-    "getHooks": {
-      "url": "/repos/:owner/:repo/hooks",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List hooks."
-    },
-    "getHook": {
-      "url": "/repos/:owner/:repo/hooks/:id",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get single hook."
-    },
-    "createHook": {
-      "url": "/repos/:owner/:repo/hooks",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "name": {
-          "type": "string",
-          "required": true
-        },
-        "config": {
-          "type": "json",
-          "required": true,
-          "description": "A Hash containing key/value pairs to provide settings for this hook. These settings vary between the services and are defined in the github-services repo. Booleans are stored internally as `1` for true, and `0` for false. Any JSON true/false values will be converted automatically."
-        },
-        "events": {
-          "type": "string[]",
-          "default": "[\"push\"]",
-          "description": "Determines what events the hook is triggered for. Default: `['push']`."
-        },
-        "active": {
-          "type": "boolean",
-          "description": "Determines whether the hook is actually triggered on pushes."
-        }
-      },
-      "description": "Create a hook."
-    },
-    "editHook": {
-      "url": "/repos/:owner/:repo/hooks/:id",
-      "method": "PATCH",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "name": {
-          "type": "string",
-          "required": true
-        },
-        "config": {
-          "type": "json",
-          "required": true,
-          "description": "A Hash containing key/value pairs to provide settings for this hook. Modifying this will replace the entire config object. These settings vary between the services and are defined in the github-services repo. Booleans are stored internally as `1` for true, and `0` for false. Any JSON true/false values will be converted automatically."
-        },
-        "events": {
-          "type": "string[]",
-          "default": "[\"push\"]",
-          "description": "Determines what events the hook is triggered for. This replaces the entire array of events. Default: `['push']`."
-        },
-        "add_events": {
-          "type": "string[]",
-          "description": "Determines a list of events to be added to the list of events that the Hook triggers for."
-        },
-        "remove_events": {
-          "type": "string[]",
-          "description": "Determines a list of events to be removed from the list of events that the Hook triggers for."
-        },
-        "active": {
-          "type": "boolean",
-          "description": "Determines whether the hook is actually triggered on pushes."
-        }
-      },
-      "description": "Edit a hook."
-    },
-    "testHook": {
-      "url": "/repos/:owner/:repo/hooks/:id/tests",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Test a [push] hook."
-    },
-    "pingHook": {
-      "url": "/repos/:owner/:repo/hooks/:id/pings",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Ping a hook."
-    },
-    "deleteHook": {
-      "url": "/repos/:owner/:repo/hooks/:id",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Deleate a hook."
     }
   },
   "search": {
-    "repos": {
-      "url": "/search/repositories",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.mercy-preview+json"
-      },
-      "params": {
-        "q": {
-          "type": "string",
-          "required": true,
-          "description": "Search Term"
-        },
-        "sort": {
-          "type": "string",
-          "enum": [
-            "stars",
-            "forks",
-            "updated"
-          ],
-          "description": "stars, forks, or updated"
-        },
-        "order": {
-          "type": "string",
-          "enum": [
-            "asc",
-            "desc"
-          ],
-          "default": "desc",
-          "description": "asc or desc"
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Search repositories."
-    },
     "code": {
       "url": "/search/code",
       "method": "GET",
@@ -9554,6 +9826,48 @@
       },
       "description": "Search issues."
     },
+    "repos": {
+      "url": "/search/repositories",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.mercy-preview+json"
+      },
+      "params": {
+        "q": {
+          "type": "string",
+          "required": true,
+          "description": "Search Term"
+        },
+        "sort": {
+          "type": "string",
+          "enum": [
+            "stars",
+            "forks",
+            "updated"
+          ],
+          "description": "stars, forks, or updated"
+        },
+        "order": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "default": "desc",
+          "description": "asc or desc"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Search repositories."
+    },
     "users": {
       "url": "/search/users",
       "method": "GET",
@@ -9595,236 +9909,16 @@
     }
   },
   "users": {
-    "get": {
-      "url": "/user",
-      "method": "GET",
-      "params": {},
-      "description": "Get the authenticated user"
-    },
-    "update": {
-      "url": "/user",
+    "acceptRepoInvite": {
+      "url": "/user/repository_invitations/:invitation_id",
       "method": "PATCH",
       "params": {
-        "name": {
-          "type": "string",
-          "description": "The new name of the user"
-        },
-        "email": {
-          "type": "string",
-          "description": "Publicly visible email address."
-        },
-        "blog": {
-          "type": "string",
-          "description": "The new blog URL of the user."
-        },
-        "company": {
-          "type": "string",
-          "description": "The new company of the user."
-        },
-        "location": {
-          "type": "string",
-          "description": "The new location of the user."
-        },
-        "hireable": {
-          "type": "boolean",
-          "description": "The new hiring availability of the user."
-        },
-        "bio": {
-          "type": "string",
-          "description": "The new short biography of the user."
-        }
-      },
-      "description": "Update the authenticated user"
-    },
-    "promote": {
-      "url": "/users/:username/site_admin",
-      "method": "PUT",
-      "params": {
-        "username": {
+        "invitation_id": {
           "type": "string",
           "required": true
         }
       },
-      "description": "Promote an ordinary user to a site administrator"
-    },
-    "demote": {
-      "url": "/users/:username/site_admin",
-      "method": "DELETE",
-      "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Demote a site administrator to an ordinary user"
-    },
-    "suspend": {
-      "url": "/users/:username/suspended",
-      "method": "PUT",
-      "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Suspend a user"
-    },
-    "unsuspend": {
-      "url": "/users/:username/suspended",
-      "method": "DELETE",
-      "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Unsuspend a user"
-    },
-    "getForUser": {
-      "url": "/users/:username",
-      "method": "GET",
-      "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a single user"
-    },
-    "getById": {
-      "url": "/user/:id",
-      "method": "GET",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true,
-          "description": "Numerical ID of the user."
-        }
-      },
-      "description": "Get a single user by GitHub ID. This method uses numerical user ID. Use users.getForUser method if you need to get a user by username."
-    },
-    "getAll": {
-      "url": "/users",
-      "method": "GET",
-      "params": {
-        "since": {
-          "type": "number",
-          "description": "The integer ID of the last User that you’ve seen."
-        }
-      },
-      "description": "Get all users"
-    },
-    "getOrgs": {
-      "url": "/user/orgs",
-      "method": "GET",
-      "params": {
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List organizations for the authenticated user."
-    },
-    "getOrgMemberships": {
-      "url": "/user/memberships/orgs",
-      "method": "GET",
-      "params": {
-        "state": {
-          "type": "string",
-          "enum": [
-            "active",
-            "pending"
-          ],
-          "description": "Indicates the state of the memberships to return. Can be either active or pending. If not specified, both active and pending memberships are returned."
-        }
-      },
-      "description": "List your organization memberships"
-    },
-    "getOrgMembership": {
-      "url": "/user/memberships/orgs/:org",
-      "method": "GET",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get your organization membership"
-    },
-    "editOrgMembership": {
-      "url": "/user/memberships/orgs/:org",
-      "method": "PATCH",
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "state": {
-          "type": "string",
-          "required": true,
-          "enum": [
-            "active"
-          ],
-          "description": "The state that the membership should be in. Only \"active\" will be accepted."
-        }
-      },
-      "description": "Edit your organization membership."
-    },
-    "getTeams": {
-      "url": "/user/teams",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.hellcat-preview+json"
-      },
-      "params": {
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "Get your teams."
-    },
-    "getEmails": {
-      "url": "/user/emails",
-      "method": "GET",
-      "params": {
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List email addresses for a user."
-    },
-    "getPublicEmails": {
-      "url": "/user/public_emails",
-      "method": "GET",
-      "params": {
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List public email addresses for a user."
+      "description": "Accept a repository invitation."
     },
     "addEmails": {
       "url": "/user/emails",
@@ -9839,96 +9933,51 @@
       },
       "description": "Add email address(es)."
     },
-    "deleteEmails": {
-      "url": "/user/emails",
-      "method": "DELETE",
+    "addRepoToInstallation": {
+      "url": "/user/installations/:installation_id/repositories/:repository_id",
+      "method": "PUT",
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview"
+      },
       "params": {
-        "emails": {
-          "type": "string[]",
-          "required": true,
-          "mapTo": "input",
-          "description": "You can post a single email address or an array of addresses."
+        "installation_id": {
+          "type": "string",
+          "required": true
+        },
+        "repository_id": {
+          "type": "string",
+          "required": true
         }
       },
-      "description": "Delete email address(es)."
+      "description": "Add a single repository to an installation. (In preview period. See README.)"
     },
-    "togglePrimaryEmailVisibility": {
-      "url": "/user/email/visibility",
-      "method": "PATCH",
-      "params": {},
-      "description": "Toggle primary email visibility."
-    },
-    "getFollowersForUser": {
-      "url": "/users/:username/followers",
-      "method": "GET",
+    "blockUser": {
+      "url": "/user/blocks/:username",
+      "method": "PUT",
+      "headers": {
+        "accept": "application/vnd.github.giant-sentry-fist-preview+json"
+      },
       "params": {
         "username": {
           "type": "string",
           "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
         }
       },
-      "description": "List a user's followers"
+      "description": "Block a user. (In preview period. See README.)"
     },
-    "getFollowers": {
-      "url": "/user/followers",
+    "checkBlockedUser": {
+      "url": "/user/blocks/:username",
       "method": "GET",
-      "params": {
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
+      "headers": {
+        "accept": "application/vnd.github.giant-sentry-fist-preview+json"
       },
-      "description": "List the authenticated user's followers"
-    },
-    "getFollowingForUser": {
-      "url": "/users/:username/following",
-      "method": "GET",
       "params": {
         "username": {
           "type": "string",
           "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
         }
       },
-      "description": "List who a user is following"
-    },
-    "getFollowing": {
-      "url": "/user/following",
-      "method": "GET",
-      "params": {
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List who the authenticated user is following"
+      "description": "Check whether you've blocked a user. (In preview period. See README.)"
     },
     "checkFollowing": {
       "url": "/user/following/:username",
@@ -9956,74 +10005,20 @@
       },
       "description": "Check if one user follows another"
     },
-    "followUser": {
-      "url": "/user/following/:username",
-      "method": "PUT",
+    "createGpgKey": {
+      "url": "/user/gpg_keys",
+      "method": "POST",
+      "headers": {
+        "accept": "application/vnd.github.cryptographer-preview"
+      },
       "params": {
-        "username": {
+        "armored_public_key": {
           "type": "string",
-          "required": true
+          "required": true,
+          "description": "GPG key contents"
         }
       },
-      "description": "Follow a user"
-    },
-    "unfollowUser": {
-      "url": "/user/following/:username",
-      "method": "DELETE",
-      "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Unfollow a user"
-    },
-    "getKeysForUser": {
-      "url": "/users/:username/keys",
-      "method": "GET",
-      "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List public keys for a user"
-    },
-    "getKeys": {
-      "url": "/user/keys",
-      "method": "GET",
-      "params": {
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List your public keys"
-    },
-    "getKey": {
-      "url": "/user/keys/:id",
-      "method": "GET",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a single public key"
+      "description": "Create a GPG key. (In preview period. See README.)"
     },
     "createKey": {
       "url": "/user/keys",
@@ -10040,6 +10035,44 @@
       },
       "description": "Create a public key"
     },
+    "declineRepoInvite": {
+      "url": "/user/repository_invitations/:invitation_id",
+      "method": "DELETE",
+      "params": {
+        "invitation_id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Decline a repository invitation."
+    },
+    "deleteEmails": {
+      "url": "/user/emails",
+      "method": "DELETE",
+      "params": {
+        "emails": {
+          "type": "string[]",
+          "required": true,
+          "mapTo": "input",
+          "description": "You can post a single email address or an array of addresses."
+        }
+      },
+      "description": "Delete email address(es)."
+    },
+    "deleteGpgKey": {
+      "url": "/user/gpg_keys/:id",
+      "method": "DELETE",
+      "headers": {
+        "accept": "application/vnd.github.cryptographer-preview"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Delete a GPG key. (In preview period. See README.)"
+    },
     "deleteKey": {
       "url": "/user/keys/:id",
       "method": "DELETE",
@@ -10050,6 +10083,217 @@
         }
       },
       "description": "Delete a public key"
+    },
+    "demote": {
+      "url": "/users/:username/site_admin",
+      "method": "DELETE",
+      "params": {
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Demote a site administrator to an ordinary user"
+    },
+    "editOrgMembership": {
+      "url": "/user/memberships/orgs/:org",
+      "method": "PATCH",
+      "params": {
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "state": {
+          "type": "string",
+          "required": true,
+          "enum": [
+            "active"
+          ],
+          "description": "The state that the membership should be in. Only \"active\" will be accepted."
+        }
+      },
+      "description": "Edit your organization membership."
+    },
+    "followUser": {
+      "url": "/user/following/:username",
+      "method": "PUT",
+      "params": {
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Follow a user"
+    },
+    "get": {
+      "url": "/user",
+      "method": "GET",
+      "params": {},
+      "description": "Get the authenticated user"
+    },
+    "getAll": {
+      "url": "/users",
+      "method": "GET",
+      "params": {
+        "since": {
+          "type": "number",
+          "description": "The integer ID of the last User that you’ve seen."
+        }
+      },
+      "description": "Get all users"
+    },
+    "getBlockedUsers": {
+      "url": "/user/blocks",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.giant-sentry-fist-preview+json"
+      },
+      "params": {},
+      "description": "List blocked users. (In preview period. See README.)"
+    },
+    "getById": {
+      "url": "/user/:id",
+      "method": "GET",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true,
+          "description": "Numerical ID of the user."
+        }
+      },
+      "description": "Get a single user by GitHub ID. This method uses numerical user ID. Use users.getForUser method if you need to get a user by username."
+    },
+    "getEmails": {
+      "url": "/user/emails",
+      "method": "GET",
+      "params": {
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List email addresses for a user."
+    },
+    "getFollowers": {
+      "url": "/user/followers",
+      "method": "GET",
+      "params": {
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List the authenticated user's followers"
+    },
+    "getFollowersForUser": {
+      "url": "/users/:username/followers",
+      "method": "GET",
+      "params": {
+        "username": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List a user's followers"
+    },
+    "getFollowing": {
+      "url": "/user/following",
+      "method": "GET",
+      "params": {
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List who the authenticated user is following"
+    },
+    "getFollowingForUser": {
+      "url": "/users/:username/following",
+      "method": "GET",
+      "params": {
+        "username": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List who a user is following"
+    },
+    "getForUser": {
+      "url": "/users/:username",
+      "method": "GET",
+      "params": {
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a single user"
+    },
+    "getGpgKey": {
+      "url": "/user/gpg_keys/:id",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.cryptographer-preview"
+      },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Get a single GPG key. (In preview period. See README.)"
+    },
+    "getGpgKeys": {
+      "url": "/user/gpg_keys",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.cryptographer-preview"
+      },
+      "params": {
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List your GPG keys. (In preview period. See README.)"
     },
     "getGpgKeysForUser": {
       "url": "/users/:username/gpg_keys",
@@ -10074,166 +10318,6 @@
       },
       "description": "Lists the GPG keys for a user. This information is accessible by anyone. (In preview period. See README.)"
     },
-    "getGpgKeys": {
-      "url": "/user/gpg_keys",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.cryptographer-preview"
-      },
-      "params": {
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List your GPG keys. (In preview period. See README.)"
-    },
-    "getGpgKey": {
-      "url": "/user/gpg_keys/:id",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.cryptographer-preview"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a single GPG key. (In preview period. See README.)"
-    },
-    "createGpgKey": {
-      "url": "/user/gpg_keys",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.cryptographer-preview"
-      },
-      "params": {
-        "armored_public_key": {
-          "type": "string",
-          "required": true,
-          "description": "GPG key contents"
-        }
-      },
-      "description": "Create a GPG key. (In preview period. See README.)"
-    },
-    "deleteGpgKey": {
-      "url": "/user/gpg_keys/:id",
-      "method": "DELETE",
-      "headers": {
-        "accept": "application/vnd.github.cryptographer-preview"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete a GPG key. (In preview period. See README.)"
-    },
-    "getBlockedUsers": {
-      "url": "/user/blocks",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.giant-sentry-fist-preview+json"
-      },
-      "params": {},
-      "description": "List blocked users. (In preview period. See README.)"
-    },
-    "checkBlockedUser": {
-      "url": "/user/blocks/:username",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.giant-sentry-fist-preview+json"
-      },
-      "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Check whether you've blocked a user. (In preview period. See README.)"
-    },
-    "blockUser": {
-      "url": "/user/blocks/:username",
-      "method": "PUT",
-      "headers": {
-        "accept": "application/vnd.github.giant-sentry-fist-preview+json"
-      },
-      "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Block a user. (In preview period. See README.)"
-    },
-    "unblockUser": {
-      "url": "/user/blocks/:username",
-      "method": "DELETE",
-      "headers": {
-        "accept": "application/vnd.github.giant-sentry-fist-preview+json"
-      },
-      "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Unblock a user. (In preview period. See README.)"
-    },
-    "getRepoInvites": {
-      "url": "/user/repository_invitations",
-      "method": "GET",
-      "params": {},
-      "description": "List a user's repository invitations."
-    },
-    "acceptRepoInvite": {
-      "url": "/user/repository_invitations/:invitation_id",
-      "method": "PATCH",
-      "params": {
-        "invitation_id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Accept a repository invitation."
-    },
-    "declineRepoInvite": {
-      "url": "/user/repository_invitations/:invitation_id",
-      "method": "DELETE",
-      "params": {
-        "invitation_id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Decline a repository invitation."
-    },
-    "getInstallations": {
-      "url": "/user/installations",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.machine-man-preview"
-      },
-      "params": {
-        "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
-        }
-      },
-      "description": "List installations. (In preview period. See README.)"
-    },
     "getInstallationRepos": {
       "url": "/user/installations/:installation_id/repositories",
       "method": "GET",
@@ -10254,41 +10338,71 @@
       },
       "description": "List repositories accessible to the user for an installation. (In preview period. See README.)"
     },
-    "addRepoToInstallation": {
-      "url": "/user/installations/:installation_id/repositories/:repository_id",
-      "method": "PUT",
+    "getInstallations": {
+      "url": "/user/installations",
+      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
       "params": {
-        "installation_id": {
-          "type": "string",
-          "required": true
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
         },
-        "repository_id": {
-          "type": "string",
-          "required": true
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
         }
       },
-      "description": "Add a single repository to an installation. (In preview period. See README.)"
+      "description": "List installations. (In preview period. See README.)"
     },
-    "removeRepoFromInstallation": {
-      "url": "/user/installations/:installation_id/repositories/:repository_id",
-      "method": "DELETE",
-      "headers": {
-        "accept": "application/vnd.github.machine-man-preview"
-      },
+    "getKey": {
+      "url": "/user/keys/:id",
+      "method": "GET",
       "params": {
-        "installation_id": {
-          "type": "string",
-          "required": true
-        },
-        "repository_id": {
+        "id": {
           "type": "string",
           "required": true
         }
       },
-      "description": "Remove a single repository from an installation. (In preview period. See README.)"
+      "description": "Get a single public key"
+    },
+    "getKeys": {
+      "url": "/user/keys",
+      "method": "GET",
+      "params": {
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List your public keys"
+    },
+    "getKeysForUser": {
+      "url": "/users/:username/keys",
+      "method": "GET",
+      "params": {
+        "username": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List public keys for a user"
     },
     "getMarketplacePurchases": {
       "url": "/user/marketplace_purchases",
@@ -10327,320 +10441,206 @@
         }
       },
       "description": "Get a user's stubbed Marketplace purchases. (In preview period. See README.)"
-    }
-  },
-  "enterprise": {
-    "stats": {
-      "url": "/enterprise/stats/:type",
+    },
+    "getOrgMembership": {
+      "url": "/user/memberships/orgs/:org",
       "method": "GET",
       "params": {
-        "type": {
+        "org": {
           "type": "string",
-          "required": true,
+          "required": true
+        }
+      },
+      "description": "Get your organization membership"
+    },
+    "getOrgMemberships": {
+      "url": "/user/memberships/orgs",
+      "method": "GET",
+      "params": {
+        "state": {
+          "type": "string",
           "enum": [
-            "issues",
-            "hooks",
-            "milestones",
-            "orgs",
-            "comments",
-            "pages",
-            "users",
-            "gists",
-            "pulls",
-            "repos",
-            "all"
+            "active",
+            "pending"
           ],
-          "description": "Possible values: issues, hooks, milestones, orgs, comments, pages, users, gists, pulls, repos, all."
+          "description": "Indicates the state of the memberships to return. Can be either active or pending. If not specified, both active and pending memberships are returned."
         }
       },
-      "description": "Get statistics."
+      "description": "List your organization memberships"
     },
-    "updateLdapForUser": {
-      "url": "/admin/ldap/users/:username/mapping",
-      "method": "PATCH",
+    "getOrgs": {
+      "url": "/user/orgs",
+      "method": "GET",
+      "params": {
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List organizations for the authenticated user."
+    },
+    "getPublicEmails": {
+      "url": "/user/public_emails",
+      "method": "GET",
+      "params": {
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "List public email addresses for a user."
+    },
+    "getRepoInvites": {
+      "url": "/user/repository_invitations",
+      "method": "GET",
+      "params": {},
+      "description": "List a user's repository invitations."
+    },
+    "getTeams": {
+      "url": "/user/teams",
+      "method": "GET",
+      "headers": {
+        "accept": "application/vnd.github.hellcat-preview+json"
+      },
+      "params": {
+        "page": {
+          "type": "number",
+          "description": "Page number of the results to fetch."
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30",
+          "description": "A custom page size up to 100. Default is 30."
+        }
+      },
+      "description": "Get your teams."
+    },
+    "promote": {
+      "url": "/users/:username/site_admin",
+      "method": "PUT",
       "params": {
         "username": {
           "type": "string",
           "required": true
-        },
-        "ldap_dn": {
-          "type": "string",
-          "required": true,
-          "description": "LDAP DN for user"
         }
       },
-      "description": "Update LDAP mapping for a user."
+      "description": "Promote an ordinary user to a site administrator"
     },
-    "syncLdapForUser": {
-      "url": "/admin/ldap/users/:username/sync",
-      "method": "POST",
+    "removeRepoFromInstallation": {
+      "url": "/user/installations/:installation_id/repositories/:repository_id",
+      "method": "DELETE",
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview"
+      },
+      "params": {
+        "installation_id": {
+          "type": "string",
+          "required": true
+        },
+        "repository_id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "description": "Remove a single repository from an installation. (In preview period. See README.)"
+    },
+    "suspend": {
+      "url": "/users/:username/suspended",
+      "method": "PUT",
       "params": {
         "username": {
           "type": "string",
           "required": true
         }
       },
-      "description": "Sync LDAP mapping for a user."
+      "description": "Suspend a user"
     },
-    "updateLdapForTeam": {
-      "url": "/admin/ldap/teams/:team_id/mapping",
+    "togglePrimaryEmailVisibility": {
+      "url": "/user/email/visibility",
       "method": "PATCH",
-      "params": {
-        "team_id": {
-          "type": "number",
-          "required": true
-        },
-        "ldap_dn": {
-          "type": "string",
-          "required": true,
-          "description": "LDAP DN for user"
-        }
-      },
-      "description": "Update LDAP mapping for a team."
-    },
-    "syncLdapForTeam": {
-      "url": "/admin/ldap/teams/:team_id/sync",
-      "method": "POST",
-      "params": {
-        "team_id": {
-          "type": "number",
-          "required": true
-        }
-      },
-      "description": "Sync LDAP mapping for a team."
-    },
-    "getLicense": {
-      "url": "/enterprise/settings/license",
-      "method": "GET",
       "params": {},
-      "description": "Get license information"
+      "description": "Toggle primary email visibility."
     },
-    "getPreReceiveEnvironment": {
-      "url": "/admin/pre-receive-environments/:id",
-      "method": "GET",
+    "unblockUser": {
+      "url": "/user/blocks/:username",
+      "method": "DELETE",
       "headers": {
-        "accept": "application/vnd.github.eye-scream-preview"
+        "accept": "application/vnd.github.giant-sentry-fist-preview+json"
       },
       "params": {
-        "id": {
+        "username": {
           "type": "string",
           "required": true
         }
       },
-      "description": "Get a single pre-receive environment. (In preview period. See README.)"
+      "description": "Unblock a user. (In preview period. See README.)"
     },
-    "getPreReceiveEnvironments": {
-      "url": "/admin/pre_receive_environments",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.eye-scream-preview"
-      },
-      "params": {},
-      "description": "List pre-receive environments. (In preview period. See README.)"
-    },
-    "createPreReceiveEnvironment": {
-      "url": "/admin/pre_receive_environments",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.eye-scream-preview"
-      },
-      "params": {
-        "name": {
-          "type": "string",
-          "required": true,
-          "description": "The new pre-receive environment's name."
-        },
-        "image_url": {
-          "type": "string",
-          "required": true,
-          "description": "URL from which to download a tarball of this environment."
-        }
-      },
-      "description": "Create a pre-receive environment. (In preview period. See README.)"
-    },
-    "editPreReceiveEnvironment": {
-      "url": "/admin/pre_receive_environments/:id",
-      "method": "PATCH",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "name": {
-          "type": "string",
-          "required": true,
-          "description": "This pre-receive environment's new name."
-        },
-        "image_url": {
-          "type": "string",
-          "required": true,
-          "description": "URL from which to download a tarball of this environment."
-        }
-      },
-      "description": "Create a pre-receive environment. (In preview period. See README.)"
-    },
-    "deletePreReceiveEnvironment": {
-      "url": "/admin/pre_receive_environments/:id",
+    "unfollowUser": {
+      "url": "/user/following/:username",
       "method": "DELETE",
       "params": {
-        "id": {
+        "username": {
           "type": "string",
           "required": true
         }
       },
-      "description": "Delete a pre-receive environment. (In preview period. See README.)"
+      "description": "Unfollow a user"
     },
-    "getPreReceiveEnvironmentDownloadStatus": {
-      "url": "/admin/pre-receive-environments/:id/downloads/latest",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.eye-scream-preview"
-      },
+    "unsuspend": {
+      "url": "/users/:username/suspended",
+      "method": "DELETE",
       "params": {
-        "id": {
+        "username": {
           "type": "string",
           "required": true
         }
       },
-      "description": "Get a pre-receive environment's download status. (In preview period. See README.)"
+      "description": "Unsuspend a user"
     },
-    "triggerPreReceiveEnvironmentDownload": {
-      "url": "/admin/pre_receive_environments/:id/downloads",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.eye-scream-preview"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Trigger a pre-receive environment download. (In preview period. See README.)"
-    },
-    "getPreReceiveHook": {
-      "url": "/admin/pre-receive-hooks/:id",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.eye-scream-preview"
-      },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Get a single pre-receive hook. (In preview period. See README.)"
-    },
-    "getPreReceiveHooks": {
-      "url": "/admin/pre-receive-hooks",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.eye-scream-preview"
-      },
-      "params": {},
-      "description": "List pre-receive hooks. (In preview period. See README.)"
-    },
-    "createPreReceiveHook": {
-      "url": "/admin/pre-receive-hooks",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.eye-scream-preview"
-      },
+    "update": {
+      "url": "/user",
+      "method": "PATCH",
       "params": {
         "name": {
           "type": "string",
-          "required": true,
-          "description": "The name of the hook."
+          "description": "The new name of the user"
         },
-        "script": {
+        "email": {
           "type": "string",
-          "required": true,
-          "description": "The script that the hook runs."
+          "description": "Publicly visible email address."
         },
-        "script_repository": {
-          "type": "json",
-          "required": true,
-          "description": "The GitHub repository where the script is kept."
-        },
-        "environment": {
-          "type": "json",
-          "required": true,
-          "description": "The pre-receive environment where the script is executed."
-        },
-        "enforcement": {
+        "blog": {
           "type": "string",
-          "default": "disabled",
-          "description": "The state of enforcement for this hook. default: disabled"
+          "description": "The new blog URL of the user."
         },
-        "allow_downstream_configuration": {
+        "company": {
+          "type": "string",
+          "description": "The new company of the user."
+        },
+        "location": {
+          "type": "string",
+          "description": "The new location of the user."
+        },
+        "hireable": {
           "type": "boolean",
-          "default": "false",
-          "description": "Whether enforcement can be overridden at the org or repo level. default: false"
-        }
-      },
-      "description": "Create a pre-receive hook. (In preview period. See README.)"
-    },
-    "editPreReceiveHook": {
-      "url": "/admin/pre_receive_hooks/:id",
-      "method": "PATCH",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
+          "description": "The new hiring availability of the user."
         },
-        "hook": {
-          "type": "json",
-          "required": true,
-          "mapTo": "input",
-          "description": "JSON object that contains pre-receive hook info."
+        "bio": {
+          "type": "string",
+          "description": "The new short biography of the user."
         }
       },
-      "description": "Edit a pre-receive hook. (In preview period. See README.)"
-    },
-    "deletePreReceiveHook": {
-      "url": "/admin/pre_receive_hooks/:id",
-      "method": "DELETE",
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      },
-      "description": "Delete a pre-receive hook. (In preview period. See README.)"
-    },
-    "queueIndexingJob": {
-      "url": "/staff/indexing_jobs",
-      "method": "POST",
-      "params": {
-        "target": {
-          "type": "string",
-          "required": true,
-          "description": "A string representing the item to index."
-        }
-      },
-      "description": "Queue an indexing job"
-    },
-    "createOrg": {
-      "url": "/admin/organizations",
-      "method": "POST",
-      "params": {
-        "login": {
-          "type": "string",
-          "required": true,
-          "description": "The organization's username."
-        },
-        "admin": {
-          "type": "string",
-          "required": true,
-          "description": "The login of the user who will manage this organization."
-        },
-        "profile_name": {
-          "type": "string",
-          "description": "The organization's display name."
-        }
-      },
-      "description": "Create an organization"
+      "description": "Update the authenticated user"
     }
   }
 }

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -3582,6 +3582,10 @@
           "type": "string"
         },
         "org": {
+          "alias": "owner",
+          "deprecated": "`org` parameter has been renamed to `owner`"
+        },
+        "owner": {
           "required": true,
           "type": "string"
         },
@@ -3598,7 +3602,7 @@
           "type": "string"
         }
       },
-      "url": "/teams/:id/repos/:org/:repo"
+      "url": "/teams/:id/repos/:owner/:repo"
     },
     "blockUser": {
       "headers": {

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -4435,13 +4435,17 @@
       }
     },
     "createProjectColumn": {
-      "url": "/projects/:project_id/columns",
+      "url": "/projects/:id/columns",
       "method": "POST",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
       "params": {
         "project_id": {
+          "alias": "id",
+          "deprecated": "`project_id` parameter has been renamed to `id`"
+        },
+        "id": {
           "type": "string",
           "required": true
         },
@@ -4593,13 +4597,17 @@
       }
     },
     "getProjectColumns": {
-      "url": "/projects/:project_id/columns",
+      "url": "/projects/:id/columns",
       "method": "GET",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
       "params": {
         "project_id": {
+          "alias": "id",
+          "deprecated": "`project_id` parameter has been renamed to `id`"
+        },
+        "id": {
           "type": "string",
           "required": true
         }

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -2510,7 +2510,7 @@
       }
     },
     "getEvents": {
-      "url": "/repos/:owner/:repo/issues/:issue_number/events",
+      "url": "/repos/:owner/:repo/issues/:number/events",
       "method": "GET",
       "params": {
         "owner": {
@@ -2522,6 +2522,10 @@
           "required": true
         },
         "issue_number": {
+          "alias": "number",
+          "deprecated": "`issue_number` parameter has been renamed to `number`"
+        },
+        "number": {
           "type": "number",
           "required": true
         },
@@ -2556,7 +2560,7 @@
       }
     },
     "getEventsTimeline": {
-      "url": "/repos/:owner/:repo/issues/:issue_number/timeline",
+      "url": "/repos/:owner/:repo/issues/:number/timeline",
       "method": "GET",
       "headers": {
         "accept": "application/vnd.github.mockingbird-preview"
@@ -2571,6 +2575,10 @@
           "required": true
         },
         "issue_number": {
+          "alias": "number",
+          "deprecated": "`issue_number` parameter has been renamed to `number`"
+        },
+        "number": {
           "type": "number",
           "required": true
         },

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -569,7 +569,7 @@
   },
   "apps": {
     "addRepoToInstallation": {
-      "url": "/installations/:installation_id/repositories/:repository_id",
+      "url": "/user/installations/:installation_id/repositories/:repository_id",
       "method": "PUT",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
@@ -759,7 +759,7 @@
       }
     },
     "removeRepoFromInstallation": {
-      "url": "/installations/:installation_id/repositories/:repository_id",
+      "url": "/user/installations/:installation_id/repositories/:repository_id",
       "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
@@ -1909,7 +1909,7 @@
   },
   "integrations": {
     "addRepoToInstallation": {
-      "url": "/installations/:installation_id/repositories/:repository_id",
+      "url": "/user/installations/:installation_id/repositories/:repository_id",
       "method": "PUT",
       "deprecated": "`integrations` has been renamed to `apps`",
       "headers": {
@@ -1974,7 +1974,7 @@
       }
     },
     "removeRepoFromInstallation": {
-      "url": "/installations/:installation_id/repositories/:repository_id",
+      "url": "/user/installations/:installation_id/repositories/:repository_id",
       "method": "DELETE",
       "deprecated": "`integrations` has been renamed to `apps`",
       "headers": {

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -1927,6 +1927,12 @@
           "required": true,
           "type": "string"
         },
+        "recursive": {
+          "enum": [
+            1
+          ],
+          "type": "integer"
+        },
         "repo": {
           "required": true,
           "type": "string"

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -8785,19 +8785,23 @@
       "method": "POST",
       "params": {
         "contentLength": {
-          "mapTo": "headers.content-length",
-          "required": true,
-          "type": "integer"
+          "alias": "headers.content-length"
         },
         "contentType": {
-          "mapTo": "headers.content-type",
-          "required": true,
-          "type": "string"
+          "alias": "headers.content-type"
         },
         "file": {
           "mapTo": "input",
           "required": true,
           "type": "string | object"
+        },
+        "headers.content-length": {
+          "required": true,
+          "type": "integer"
+        },
+        "headers.content-type": {
+          "required": true,
+          "type": "string"
         },
         "label": {
           "type": "string"

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -8,8 +8,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Check to see if the current user is subscribed to a thread."
+      }
     },
     "checkStarringRepo": {
       "url": "/user/starred/:owner/:repo",
@@ -24,16 +23,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Check if you are starring a repository"
+      }
     },
     "deleteNotificationThreadSubscription": {
       "url": "/notifications/threads/:id/subscription",
@@ -43,24 +39,20 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a notification thread subscription."
+      }
     },
     "getEvents": {
       "url": "/events",
       "method": "GET",
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List public events"
+      }
     },
     "getEventsForOrg": {
       "url": "/orgs/:org/events",
@@ -71,16 +63,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List public events for an organization"
+      }
     },
     "getEventsForRepo": {
       "url": "/repos/:owner/:repo/events",
@@ -95,16 +84,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List repository events"
+      }
     },
     "getEventsForRepoIssues": {
       "url": "/repos/:owner/:repo/issues/events",
@@ -119,16 +105,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List issue events for a repository"
+      }
     },
     "getEventsForRepoNetwork": {
       "url": "/networks/:owner/:repo/events",
@@ -143,16 +126,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List public events for a network of repositories"
+      }
     },
     "getEventsForUser": {
       "url": "/users/:username/events",
@@ -163,16 +143,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List events performed by a user"
+      }
     },
     "getEventsForUserOrg": {
       "url": "/users/:username/events/orgs/:org",
@@ -187,16 +164,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List events for a user's organization"
+      }
     },
     "getEventsForUserPublic": {
       "url": "/users/:username/events/public",
@@ -207,16 +181,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List public events performed by a user"
+      }
     },
     "getEventsReceived": {
       "url": "/users/:username/received_events",
@@ -227,16 +198,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List events that a user has received"
+      }
     },
     "getEventsReceivedPublic": {
       "url": "/users/:username/received_events/public",
@@ -247,22 +215,18 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List public events that a user has received"
+      }
     },
     "getFeeds": {
       "url": "/feeds",
       "method": "GET",
-      "params": {},
-      "description": "Get all feeds available for the authenticated user."
+      "params": {}
     },
     "getNotificationThread": {
       "url": "/notifications/threads/:id",
@@ -272,8 +236,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "View a single notification thread."
+      }
     },
     "getNotifications": {
       "url": "/notifications",
@@ -281,24 +244,19 @@
       "params": {
         "all": {
           "type": "boolean",
-          "default": "false",
-          "description": "If true, show notifications marked as read. Default: false"
+          "default": "false"
         },
         "participating": {
           "type": "boolean",
-          "default": "false",
-          "description": "If true, only shows notifications in which the user is directly participating or mentioned. Default: false"
+          "default": "false"
         },
         "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+          "type": "date"
         },
         "before": {
-          "type": "string",
-          "description": "Only show notifications updated before the given time. This is a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ."
+          "type": "string"
         }
-      },
-      "description": "Get all notifications for the current user, grouped by repository."
+      }
     },
     "getNotificationsForUser": {
       "url": "/repos/:owner/:repo/notifications",
@@ -314,24 +272,19 @@
         },
         "all": {
           "type": "boolean",
-          "default": "false",
-          "description": "If true, show notifications marked as read. Default: false"
+          "default": "false"
         },
         "participating": {
           "type": "boolean",
-          "default": "false",
-          "description": "If true, only shows notifications in which the user is directly participating or mentioned. Default: false"
+          "default": "false"
         },
         "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+          "type": "date"
         },
         "before": {
-          "type": "string",
-          "description": "Only show notifications updated before the given time. This is a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ."
+          "type": "string"
         }
-      },
-      "description": "Get all notifications for the given user."
+      }
     },
     "getRepoSubscription": {
       "url": "/repos/:owner/:repo/subscription",
@@ -346,16 +299,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get a Repository Subscription."
+      }
     },
     "getStargazersForRepo": {
       "url": "/repos/:owner/:repo/stargazers",
@@ -373,16 +323,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List Stargazers"
+      }
     },
     "getStarredRepos": {
       "url": "/user/starred",
@@ -408,16 +355,13 @@
           "default": "desc"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List repositories being starred by the authenticated user"
+      }
     },
     "getStarredReposForUser": {
       "url": "/users/:username/starred",
@@ -447,32 +391,26 @@
           "default": "desc"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List repositories being starred by a user"
+      }
     },
     "getWatchedRepos": {
       "url": "/user/subscriptions",
       "method": "GET",
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List repositories being watched by the authenticated user."
+      }
     },
     "getWatchedReposForUser": {
       "url": "/users/:username/subscriptions",
@@ -483,16 +421,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List repositories being watched by a user."
+      }
     },
     "getWatchersForRepo": {
       "url": "/repos/:owner/:repo/subscribers",
@@ -507,16 +442,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get watchers for repository."
+      }
     },
     "markNotificationThreadAsRead": {
       "url": "/notifications/threads/:id",
@@ -526,8 +458,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Mark a notification thread as read."
+      }
     },
     "markNotificationsAsRead": {
       "url": "/notifications",
@@ -535,11 +466,9 @@
       "params": {
         "last_read_at": {
           "type": "string",
-          "default": "Time.now",
-          "description": "Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. Default: Time.now"
+          "default": "Time.now"
         }
-      },
-      "description": "Mark notifications as read for authenticated user."
+      }
     },
     "markNotificationsAsReadForRepo": {
       "url": "/repos/:owner/:repo/notifications",
@@ -555,11 +484,9 @@
         },
         "last_read_at": {
           "type": "string",
-          "default": "Time.now",
-          "description": "Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. Default: Time.now"
+          "default": "Time.now"
         }
-      },
-      "description": "Mark notifications in a repo as read."
+      }
     },
     "setNotificationThreadSubscription": {
       "url": "/notifications/threads/:id/subscription",
@@ -570,15 +497,12 @@
           "required": true
         },
         "subscribed": {
-          "type": "boolean",
-          "description": "Determines if notifications should be received from this thread"
+          "type": "boolean"
         },
         "ignored": {
-          "type": "boolean",
-          "description": "Determines if all notifications should be blocked from this thread"
+          "type": "boolean"
         }
-      },
-      "description": "This lets you subscribe or unsubscribe from a conversation. Unsubscribing from a conversation mutes all future notifications (until you comment or get @mentioned once more)."
+      }
     },
     "setRepoSubscription": {
       "url": "/repos/:owner/:repo/subscription",
@@ -593,15 +517,12 @@
           "required": true
         },
         "subscribed": {
-          "type": "boolean",
-          "description": "Determines if notifications should be received from this repository."
+          "type": "boolean"
         },
         "ignored": {
-          "type": "boolean",
-          "description": "Determines if all notifications should be blocked from this repository."
+          "type": "boolean"
         }
-      },
-      "description": "Set a Repository Subscription"
+      }
     },
     "starRepo": {
       "url": "/user/starred/:owner/:repo",
@@ -615,8 +536,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Star a repository"
+      }
     },
     "unstarRepo": {
       "url": "/user/starred/:owner/:repo",
@@ -630,8 +550,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Unstar a repository"
+      }
     },
     "unwatchRepo": {
       "url": "/repos/:owner/:repo/subscription",
@@ -645,8 +564,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Unwatch a repository."
+      }
     }
   },
   "apps": {
@@ -665,8 +583,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Add a single repository to an installation. (In preview period. See README.)"
+      }
     },
     "checkMarketplaceListingAccount": {
       "url": "/marketplace_listing/accounts/:id",
@@ -679,8 +596,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Check if a GitHub account is associated with any Marketplace listing. (In preview period. See README.)"
+      }
     },
     "checkMarketplaceListingStubbedAccount": {
       "url": "/marketplace_listing/stubbed/accounts/:id",
@@ -693,8 +609,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Check if a stubbed GitHub account is associated with any Marketplace listing. (In preview period. See README.)"
+      }
     },
     "createInstallationToken": {
       "url": "/installations/:installation_id/access_tokens",
@@ -708,17 +623,14 @@
           "required": true
         },
         "user_id": {
-          "type": "string",
-          "description": "The id of the user for whom the app is acting on behalf of."
+          "type": "string"
         }
-      },
-      "description": "Create a new installation token. (In preview period. See README.)"
+      }
     },
     "get": {
       "url": "/app",
       "method": "GET",
-      "params": {},
-      "description": "Get the authenticated GitHub App. (In preview period. See README.)"
+      "params": {}
     },
     "getForSlug": {
       "url": "/apps/:app_slug",
@@ -729,11 +641,9 @@
       "params": {
         "app_slug": {
           "type": "string",
-          "required": true,
-          "description": "The URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., https://github.com/settings/apps/:app_slug)."
+          "required": true
         }
-      },
-      "description": "Get a single GitHub App. (In preview period. See README.)"
+      }
     },
     "getInstallation": {
       "url": "/app/installations/:installation_id",
@@ -746,8 +656,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single installation. (In preview period. See README.)"
+      }
     },
     "getInstallationRepositories": {
       "url": "/installation/repositories",
@@ -757,11 +666,9 @@
       },
       "params": {
         "user_id": {
-          "type": "string",
-          "description": "The integer ID of a user, to filter results to repositories that are visible to both the installation and the given user."
+          "type": "string"
         }
-      },
-      "description": "List repositories that are accessible to the authenticated installation. (In preview period. See README.)"
+      }
     },
     "getInstallations": {
       "url": "/app/installations",
@@ -771,16 +678,13 @@
       },
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List the app's installations. (In preview period. See README.)"
+      }
     },
     "getMarketplaceListingPlanAccounts": {
       "url": "/marketplace_listing/plans/:id/accounts",
@@ -794,16 +698,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List all GitHub accounts (user or organization) on a specific plan. (In preview period. See README.)"
+      }
     },
     "getMarketplaceListingPlans": {
       "url": "/marketplace_listing/plans",
@@ -813,16 +714,13 @@
       },
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List all plans for your Marketplace listing. (In preview period. See README.)"
+      }
     },
     "getMarketplaceListingStubbedPlanAccounts": {
       "url": "/marketplace_listing/stubbed/plans/:id/accounts",
@@ -836,16 +734,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List all GitHub accounts (user or organization) on a specific stubbed plan. (In preview period. See README.)"
+      }
     },
     "getMarketplaceListingStubbedPlans": {
       "url": "/marketplace_listing/stubbed/plans",
@@ -855,16 +750,13 @@
       },
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List all stubbed plans for your Marketplace listing. (In preview period. See README.)"
+      }
     },
     "removeRepoFromInstallation": {
       "url": "/installations/:installation_id/repositories/:repository_id",
@@ -881,8 +773,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Remove a single repository from an installation. (In preview period. See README.)"
+      }
     }
   },
   "authorization": {
@@ -891,47 +782,37 @@
       "method": "GET",
       "params": {
         "client_id": {
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token."
+          "type": "string"
         },
         "access_token": {
           "type": "string",
-          "required": true,
-          "description": "OAuth token"
+          "required": true
         }
-      },
-      "description": "Check an authorization"
+      }
     },
     "create": {
       "url": "/authorizations",
       "method": "POST",
       "params": {
         "scopes": {
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in."
+          "type": "string[]"
         },
         "note": {
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for."
+          "type": "string"
         },
         "note_url": {
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for."
+          "type": "string"
         },
         "client_id": {
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token."
+          "type": "string"
         },
         "client_secret": {
-          "type": "string",
-          "description": "The 40 character OAuth app client secret for which to create the token."
+          "type": "string"
         },
         "fingerprint": {
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user."
+          "type": "string"
         }
-      },
-      "description": "Create a new authorization."
+      }
     },
     "delete": {
       "url": "/authorizations/:id",
@@ -941,8 +822,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete an authorization."
+      }
     },
     "deleteGrant": {
       "url": "/applications/grants/:id",
@@ -952,8 +832,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a grant."
+      }
     },
     "get": {
       "url": "/authorizations/:id",
@@ -963,24 +842,20 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single authorization."
+      }
     },
     "getAll": {
       "url": "/authorizations",
       "method": "GET",
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List your authorizations."
+      }
     },
     "getGrant": {
       "url": "/applications/grants/:id",
@@ -991,144 +866,115 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get a single grant."
+      }
     },
     "getGrants": {
       "url": "/applications/grants",
       "method": "GET",
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List your grants."
+      }
     },
     "getOrCreateAuthorizationForApp": {
       "url": "/authorizations/clients/:client_id",
       "method": "PUT",
       "params": {
         "client_id": {
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token."
+          "type": "string"
         },
         "client_secret": {
           "type": "string",
-          "required": true,
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL."
+          "required": true
         },
         "scopes": {
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in."
+          "type": "string[]"
         },
         "note": {
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for."
+          "type": "string"
         },
         "note_url": {
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for."
+          "type": "string"
         },
         "fingerprint": {
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user."
+          "type": "string"
         }
-      },
-      "description": "Get or create an authorization for a specific app."
+      }
     },
     "getOrCreateAuthorizationForAppAndFingerprint": {
       "url": "/authorizations/clients/:client_id/:fingerprint",
       "method": "PUT",
       "params": {
         "client_id": {
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token."
+          "type": "string"
         },
         "fingerprint": {
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user."
+          "type": "string"
         },
         "client_secret": {
           "type": "string",
-          "required": true,
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL."
+          "required": true
         },
         "scopes": {
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in."
+          "type": "string[]"
         },
         "note": {
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for."
+          "type": "string"
         },
         "note_url": {
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for."
+          "type": "string"
         }
-      },
-      "description": "Get or create an authorization for a specific app and fingerprint."
+      }
     },
     "reset": {
       "url": "/applications/:client_id/tokens/:access_token",
       "method": "POST",
       "params": {
         "client_id": {
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token."
+          "type": "string"
         },
         "access_token": {
           "type": "string",
-          "required": true,
-          "description": "OAuth token"
+          "required": true
         }
-      },
-      "description": "Reset an authorization"
+      }
     },
     "revoke": {
       "url": "/applications/:client_id/tokens/:access_token",
       "method": "DELETE",
       "params": {
         "client_id": {
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token."
+          "type": "string"
         },
         "access_token": {
           "type": "string",
-          "required": true,
-          "description": "OAuth token"
+          "required": true
         }
-      },
-      "description": "Revoke an authorization for an application"
+      }
     },
     "revokeGrant": {
       "url": "/applications/:client_id/grants/:access_token",
       "method": "DELETE",
       "params": {
         "client_id": {
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token."
+          "type": "string"
         },
         "access_token": {
           "type": "string",
-          "required": true,
-          "description": "OAuth token"
+          "required": true
         }
-      },
-      "description": "Revoke a grant for an application"
+      }
     },
     "update": {
       "url": "/authorizations/:id",
@@ -1139,31 +985,24 @@
           "required": true
         },
         "scopes": {
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in."
+          "type": "string[]"
         },
         "add_scopes": {
-          "type": "string[]",
-          "description": "A list of scopes to add to this authorization."
+          "type": "string[]"
         },
         "remove_scopes": {
-          "type": "string[]",
-          "description": "A list of scopes to remove from this authorization."
+          "type": "string[]"
         },
         "note": {
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for."
+          "type": "string"
         },
         "note_url": {
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for."
+          "type": "string"
         },
         "fingerprint": {
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user."
+          "type": "string"
         }
-      },
-      "description": "Update an existing authorization."
+      }
     }
   },
   "enterprise": {
@@ -1173,20 +1012,16 @@
       "params": {
         "login": {
           "type": "string",
-          "required": true,
-          "description": "The organization's username."
+          "required": true
         },
         "admin": {
           "type": "string",
-          "required": true,
-          "description": "The login of the user who will manage this organization."
+          "required": true
         },
         "profile_name": {
-          "type": "string",
-          "description": "The organization's display name."
+          "type": "string"
         }
-      },
-      "description": "Create an organization"
+      }
     },
     "createPreReceiveEnvironment": {
       "url": "/admin/pre_receive_environments",
@@ -1197,16 +1032,13 @@
       "params": {
         "name": {
           "type": "string",
-          "required": true,
-          "description": "The new pre-receive environment's name."
+          "required": true
         },
         "image_url": {
           "type": "string",
-          "required": true,
-          "description": "URL from which to download a tarball of this environment."
+          "required": true
         }
-      },
-      "description": "Create a pre-receive environment. (In preview period. See README.)"
+      }
     },
     "createPreReceiveHook": {
       "url": "/admin/pre-receive-hooks",
@@ -1217,36 +1049,29 @@
       "params": {
         "name": {
           "type": "string",
-          "required": true,
-          "description": "The name of the hook."
+          "required": true
         },
         "script": {
           "type": "string",
-          "required": true,
-          "description": "The script that the hook runs."
+          "required": true
         },
         "script_repository": {
           "type": "json",
-          "required": true,
-          "description": "The GitHub repository where the script is kept."
+          "required": true
         },
         "environment": {
           "type": "json",
-          "required": true,
-          "description": "The pre-receive environment where the script is executed."
+          "required": true
         },
         "enforcement": {
           "type": "string",
-          "default": "disabled",
-          "description": "The state of enforcement for this hook. default: disabled"
+          "default": "disabled"
         },
         "allow_downstream_configuration": {
           "type": "boolean",
-          "default": "false",
-          "description": "Whether enforcement can be overridden at the org or repo level. default: false"
+          "default": "false"
         }
-      },
-      "description": "Create a pre-receive hook. (In preview period. See README.)"
+      }
     },
     "deletePreReceiveEnvironment": {
       "url": "/admin/pre_receive_environments/:id",
@@ -1256,8 +1081,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a pre-receive environment. (In preview period. See README.)"
+      }
     },
     "deletePreReceiveHook": {
       "url": "/admin/pre_receive_hooks/:id",
@@ -1267,8 +1091,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a pre-receive hook. (In preview period. See README.)"
+      }
     },
     "editPreReceiveEnvironment": {
       "url": "/admin/pre_receive_environments/:id",
@@ -1280,16 +1103,13 @@
         },
         "name": {
           "type": "string",
-          "required": true,
-          "description": "This pre-receive environment's new name."
+          "required": true
         },
         "image_url": {
           "type": "string",
-          "required": true,
-          "description": "URL from which to download a tarball of this environment."
+          "required": true
         }
-      },
-      "description": "Create a pre-receive environment. (In preview period. See README.)"
+      }
     },
     "editPreReceiveHook": {
       "url": "/admin/pre_receive_hooks/:id",
@@ -1302,17 +1122,14 @@
         "hook": {
           "type": "json",
           "required": true,
-          "mapTo": "input",
-          "description": "JSON object that contains pre-receive hook info."
+          "mapTo": "input"
         }
-      },
-      "description": "Edit a pre-receive hook. (In preview period. See README.)"
+      }
     },
     "getLicense": {
       "url": "/enterprise/settings/license",
       "method": "GET",
-      "params": {},
-      "description": "Get license information"
+      "params": {}
     },
     "getPreReceiveEnvironment": {
       "url": "/admin/pre-receive-environments/:id",
@@ -1325,8 +1142,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single pre-receive environment. (In preview period. See README.)"
+      }
     },
     "getPreReceiveEnvironmentDownloadStatus": {
       "url": "/admin/pre-receive-environments/:id/downloads/latest",
@@ -1339,8 +1155,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a pre-receive environment's download status. (In preview period. See README.)"
+      }
     },
     "getPreReceiveEnvironments": {
       "url": "/admin/pre_receive_environments",
@@ -1348,8 +1163,7 @@
       "headers": {
         "accept": "application/vnd.github.eye-scream-preview"
       },
-      "params": {},
-      "description": "List pre-receive environments. (In preview period. See README.)"
+      "params": {}
     },
     "getPreReceiveHook": {
       "url": "/admin/pre-receive-hooks/:id",
@@ -1362,8 +1176,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single pre-receive hook. (In preview period. See README.)"
+      }
     },
     "getPreReceiveHooks": {
       "url": "/admin/pre-receive-hooks",
@@ -1371,8 +1184,7 @@
       "headers": {
         "accept": "application/vnd.github.eye-scream-preview"
       },
-      "params": {},
-      "description": "List pre-receive hooks. (In preview period. See README.)"
+      "params": {}
     },
     "queueIndexingJob": {
       "url": "/staff/indexing_jobs",
@@ -1380,11 +1192,9 @@
       "params": {
         "target": {
           "type": "string",
-          "required": true,
-          "description": "A string representing the item to index."
+          "required": true
         }
-      },
-      "description": "Queue an indexing job"
+      }
     },
     "stats": {
       "url": "/enterprise/stats/:type",
@@ -1405,11 +1215,9 @@
             "pulls",
             "repos",
             "all"
-          ],
-          "description": "Possible values: issues, hooks, milestones, orgs, comments, pages, users, gists, pulls, repos, all."
+          ]
         }
-      },
-      "description": "Get statistics."
+      }
     },
     "syncLdapForTeam": {
       "url": "/admin/ldap/teams/:team_id/sync",
@@ -1419,8 +1227,7 @@
           "type": "number",
           "required": true
         }
-      },
-      "description": "Sync LDAP mapping for a team."
+      }
     },
     "syncLdapForUser": {
       "url": "/admin/ldap/users/:username/sync",
@@ -1430,8 +1237,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Sync LDAP mapping for a user."
+      }
     },
     "triggerPreReceiveEnvironmentDownload": {
       "url": "/admin/pre_receive_environments/:id/downloads",
@@ -1444,8 +1250,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Trigger a pre-receive environment download. (In preview period. See README.)"
+      }
     },
     "updateLdapForTeam": {
       "url": "/admin/ldap/teams/:team_id/mapping",
@@ -1457,11 +1262,9 @@
         },
         "ldap_dn": {
           "type": "string",
-          "required": true,
-          "description": "LDAP DN for user"
+          "required": true
         }
-      },
-      "description": "Update LDAP mapping for a team."
+      }
     },
     "updateLdapForUser": {
       "url": "/admin/ldap/users/:username/mapping",
@@ -1473,11 +1276,9 @@
         },
         "ldap_dn": {
           "type": "string",
-          "required": true,
-          "description": "LDAP DN for user"
+          "required": true
         }
-      },
-      "description": "Update LDAP mapping for a user."
+      }
     }
   },
   "gists": {
@@ -1489,8 +1290,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Check if a gist is starred"
+      }
     },
     "create": {
       "url": "/gists",
@@ -1498,8 +1298,7 @@
       "params": {
         "files": {
           "type": "json",
-          "required": true,
-          "description": "Files that make up this gist. The key of which should be a required string filename and the value another required hash with parameters: 'content'"
+          "required": true
         },
         "description": {
           "type": "string"
@@ -1508,8 +1307,7 @@
           "type": "boolean",
           "required": true
         }
-      },
-      "description": "Create a gist"
+      }
     },
     "createComment": {
       "url": "/gists/:gist_id/comments",
@@ -1517,15 +1315,13 @@
       "params": {
         "gist_id": {
           "type": "string",
-          "required": true,
-          "description": "Id (SHA1 hash) of the gist."
+          "required": true
         },
         "body": {
           "type": "string",
           "required": true
         }
-      },
-      "description": "Create a comment"
+      }
     },
     "delete": {
       "url": "/gists/:id",
@@ -1535,8 +1331,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a gist"
+      }
     },
     "deleteComment": {
       "url": "/gists/:gist_id/comments/:id",
@@ -1544,15 +1339,13 @@
       "params": {
         "gist_id": {
           "type": "string",
-          "required": true,
-          "description": "Id (SHA1 hash) of the gist."
+          "required": true
         },
         "id": {
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a comment"
+      }
     },
     "edit": {
       "url": "/gists/:id",
@@ -1567,19 +1360,15 @@
         },
         "files": {
           "type": "json",
-          "required": true,
-          "description": "Files that make up this gist. The key of which should be a required string filename and the value another required hash with parameters: 'content'"
+          "required": true
         },
         "content": {
-          "type": "string",
-          "description": "Updated file contents."
+          "type": "string"
         },
         "filename": {
-          "type": "string",
-          "description": "New name for this file."
+          "type": "string"
         }
-      },
-      "description": "Edit a gist"
+      }
     },
     "editComment": {
       "url": "/gists/:gist_id/comments/:id",
@@ -1587,8 +1376,7 @@
       "params": {
         "gist_id": {
           "type": "string",
-          "required": true,
-          "description": "Id (SHA1 hash) of the gist."
+          "required": true
         },
         "id": {
           "type": "string",
@@ -1598,8 +1386,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Edit a comment"
+      }
     },
     "fork": {
       "url": "/gists/:id/forks",
@@ -1609,8 +1396,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Fork a gist"
+      }
     },
     "get": {
       "url": "/gists/:id",
@@ -1620,28 +1406,23 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single gist"
+      }
     },
     "getAll": {
       "url": "/gists",
       "method": "GET",
       "params": {
         "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+          "type": "date"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List the authenticated user's gists or if called anonymously, this will return all public gists"
+      }
     },
     "getComment": {
       "url": "/gists/:gist_id/comments/:id",
@@ -1649,15 +1430,13 @@
       "params": {
         "gist_id": {
           "type": "string",
-          "required": true,
-          "description": "Id (SHA1 hash) of the gist."
+          "required": true
         },
         "id": {
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single comment"
+      }
     },
     "getComments": {
       "url": "/gists/:gist_id/comments",
@@ -1665,11 +1444,9 @@
       "params": {
         "gist_id": {
           "type": "string",
-          "required": true,
-          "description": "Id (SHA1 hash) of the gist."
+          "required": true
         }
-      },
-      "description": "List comments on a gist"
+      }
     },
     "getCommits": {
       "url": "/gists/:id/commits",
@@ -1679,8 +1456,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "List gist commits"
+      }
     },
     "getForUser": {
       "url": "/users/:username/gists",
@@ -1691,20 +1467,16 @@
           "required": true
         },
         "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+          "type": "date"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List a user's gists"
+      }
     },
     "getForks": {
       "url": "/gists/:id/forks",
@@ -1715,27 +1487,22 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List gist forks"
+      }
     },
     "getPublic": {
       "url": "/gists/public",
       "method": "GET",
       "params": {
         "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+          "type": "date"
         }
-      },
-      "description": "List all public gists"
+      }
     },
     "getRevision": {
       "url": "/gists/:id/:sha",
@@ -1749,19 +1516,16 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a specific revision of a gist"
+      }
     },
     "getStarred": {
       "url": "/gists/starred",
       "method": "GET",
       "params": {
         "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+          "type": "date"
         }
-      },
-      "description": "List the authenticated user's starred gists"
+      }
     },
     "star": {
       "url": "/gists/:id/star",
@@ -1771,8 +1535,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Star a gist"
+      }
     },
     "unstar": {
       "url": "/gists/:id/star",
@@ -1782,8 +1545,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Unstar a gist"
+      }
     }
   },
   "gitdata": {
@@ -1808,8 +1570,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Create a Blob"
+      }
     },
     "createCommit": {
       "url": "/repos/:owner/:repo/git/commits",
@@ -1825,18 +1586,15 @@
         },
         "message": {
           "type": "string",
-          "required": true,
-          "description": "String of the commit message"
+          "required": true
         },
         "tree": {
           "type": "string",
-          "required": true,
-          "description": "String of the SHA of the tree object this commit points to"
+          "required": true
         },
         "parents": {
           "type": "string[]",
-          "required": true,
-          "description": "Array of the SHAs of the commits that were the parents of this commit. If omitted or empty, the commit will be written as a root commit. For a single parent, an array of one SHA should be provided, for a merge commit, an array of more than one should be provided."
+          "required": true
         },
         "author": {
           "type": "json"
@@ -1844,8 +1602,7 @@
         "committer": {
           "type": "json"
         }
-      },
-      "description": "Create a Commit"
+      }
     },
     "createReference": {
       "url": "/repos/:owner/:repo/git/refs",
@@ -1861,15 +1618,13 @@
         },
         "ref": {
           "type": "string",
-          "required": true,
-          "description": "The name of the fully qualified reference (ie: refs/heads/master). If it doesn't start with 'refs' and have at least two slashes, it will be rejected. NOTE: After creating the reference, on calling (get|update|delete)Reference, drop the leading 'refs/' when providing the 'ref' param."
+          "required": true
         },
         "sha": {
           "type": "string",
           "required": true
         }
-      },
-      "description": "Create a Reference"
+      }
     },
     "createTag": {
       "url": "/repos/:owner/:repo/git/tags",
@@ -1885,31 +1640,25 @@
         },
         "tag": {
           "type": "string",
-          "required": true,
-          "description": "String of the tag"
+          "required": true
         },
         "message": {
           "type": "string",
-          "required": true,
-          "description": "String of the tag message"
+          "required": true
         },
         "object": {
           "type": "string",
-          "required": true,
-          "description": "String of the SHA of the git object this is tagging"
+          "required": true
         },
         "type": {
           "type": "string",
-          "required": true,
-          "description": "String of the type of the object we’re tagging. Normally this is a commit but it can also be a tree or a blob."
+          "required": true
         },
         "tagger": {
           "type": "json",
-          "required": true,
-          "description": "JSON object that contains the following keys: `name` - String of the name of the author of the tag, `email` - String of the email of the author of the tag, `date` - Timestamp of when this object was tagged"
+          "required": true
         }
-      },
-      "description": "Create a Tag Object"
+      }
     },
     "createTree": {
       "url": "/repos/:owner/:repo/git/trees",
@@ -1925,15 +1674,12 @@
         },
         "tree": {
           "type": "json",
-          "required": true,
-          "description": "Array of Hash objects (of path, mode, type and sha) specifying a tree structure"
+          "required": true
         },
         "base_tree": {
-          "type": "string",
-          "description": "String of the SHA1 of the tree you want to update with new data"
+          "type": "string"
         }
-      },
-      "description": "Create a Tree"
+      }
     },
     "deleteReference": {
       "url": "/repos/:owner/:repo/git/refs/:ref",
@@ -1950,11 +1696,9 @@
         "ref": {
           "type": "string",
           "required": true,
-          "allow-empty": true,
-          "description": "String of the name of the fully qualified reference (ie: heads/master). If it doesn’t have at least one slash, it will be rejected."
+          "allow-empty": true
         }
-      },
-      "description": "Delete a Reference"
+      }
     },
     "getBlob": {
       "url": "/repos/:owner/:repo/git/blobs/:sha",
@@ -1973,16 +1717,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get a Blob"
+      }
     },
     "getCommit": {
       "url": "/repos/:owner/:repo/git/commits/:sha",
@@ -2000,8 +1741,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a Commit"
+      }
     },
     "getCommitSignatureVerification": {
       "url": "/repos/:owner/:repo/git/commits/:sha",
@@ -2019,8 +1759,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a Commit Signature Verification. (In preview period. See README.)"
+      }
     },
     "getReference": {
       "url": "/repos/:owner/:repo/git/refs/:ref",
@@ -2037,11 +1776,9 @@
         "ref": {
           "type": "string",
           "required": true,
-          "allow-empty": true,
-          "description": "String of the name of the fully qualified reference (ie: heads/master). If it doesn’t have at least one slash, it will be rejected."
+          "allow-empty": true
         }
-      },
-      "description": "Get a Reference"
+      }
     },
     "getReferences": {
       "url": "/repos/:owner/:repo/git/refs",
@@ -2056,16 +1793,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get all References"
+      }
     },
     "getTag": {
       "url": "/repos/:owner/:repo/git/tags/:sha",
@@ -2083,8 +1817,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a Tag"
+      }
     },
     "getTagSignatureVerification": {
       "url": "/repos/:owner/:repo/git/tags/:sha",
@@ -2102,8 +1835,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a Tag Signature Verification. (In preview period. See README.)"
+      }
     },
     "getTags": {
       "url": "/repos/:owner/:repo/git/refs/tags",
@@ -2118,16 +1850,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get all tag References"
+      }
     },
     "getTree": {
       "url": "/repos/:owner/:repo/git/trees/:sha",
@@ -2148,8 +1877,7 @@
         "recursive": {
           "type": "boolean"
         }
-      },
-      "description": "Get a Tree"
+      }
     },
     "updateReference": {
       "url": "/repos/:owner/:repo/git/refs/:ref",
@@ -2166,8 +1894,7 @@
         "ref": {
           "type": "string",
           "required": true,
-          "allow-empty": true,
-          "description": "String of the name of the fully qualified reference (ie: heads/master). If it doesn’t have at least one slash, it will be rejected."
+          "allow-empty": true
         },
         "sha": {
           "type": "string",
@@ -2175,11 +1902,9 @@
         },
         "force": {
           "type": "boolean",
-          "default": "false",
-          "description": "Boolean indicating whether to force the update or to make sure the update is a fast-forward update. The default is false, so leaving this out or setting it to false will make sure you’re not overwriting work."
+          "default": "false"
         }
-      },
-      "description": "Update a Reference"
+      }
     }
   },
   "integrations": {
@@ -2199,8 +1924,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Add a single repository to an installation. (In preview period. See README.)"
+      }
     },
     "createInstallationToken": {
       "url": "/installations/:installation_id/access_tokens",
@@ -2215,11 +1939,9 @@
           "required": true
         },
         "user_id": {
-          "type": "string",
-          "description": "The id of the user for whom the app is acting on behalf of."
+          "type": "string"
         }
-      },
-      "description": "Create a new installation token. (In preview period. See README.)"
+      }
     },
     "getInstallationRepositories": {
       "url": "/installation/repositories",
@@ -2230,11 +1952,9 @@
       },
       "params": {
         "user_id": {
-          "type": "string",
-          "description": "The integer ID of a user, to filter results to repositories that are visible to both the installation and the given user."
+          "type": "string"
         }
-      },
-      "description": "List repositories that are accessible to the authenticated installation. (In preview period. See README.)"
+      }
     },
     "getInstallations": {
       "url": "/app/installations",
@@ -2245,16 +1965,13 @@
       },
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List the app's installations. (In preview period. See README.)"
+      }
     },
     "removeRepoFromInstallation": {
       "url": "/installations/:installation_id/repositories/:repository_id",
@@ -2272,8 +1989,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Remove a single repository from an installation. (In preview period. See README.)"
+      }
     }
   },
   "issues": {
@@ -2295,11 +2011,9 @@
         },
         "assignees": {
           "type": "string[]",
-          "required": true,
-          "description": "Logins for the users that should be added to the issue."
+          "required": true
         }
-      },
-      "description": "Add assignees to an issue."
+      }
     },
     "addLabels": {
       "url": "/repos/:owner/:repo/issues/:number/labels",
@@ -2322,8 +2036,7 @@
           "required": true,
           "mapTo": "input"
         }
-      },
-      "description": "Add labels to an issue"
+      }
     },
     "checkAssignee": {
       "url": "/repos/:owner/:repo/assignees/:assignee",
@@ -2339,11 +2052,9 @@
         },
         "assignee": {
           "type": "string",
-          "required": true,
-          "description": "Login for the user that this issue should be assigned to."
+          "required": true
         }
-      },
-      "description": "Check assignee"
+      }
     },
     "create": {
       "url": "/repos/:owner/:repo/issues",
@@ -2368,23 +2079,18 @@
           "type": "string"
         },
         "assignee": {
-          "type": "string",
-          "description": "Login for the user that this issue should be assigned to."
+          "type": "string"
         },
         "milestone": {
-          "type": "number",
-          "description": "Milestone to associate this issue with."
+          "type": "number"
         },
         "labels": {
-          "type": "string[]",
-          "description": "Array of strings - Labels to associate with this issue."
+          "type": "string[]"
         },
         "assignees": {
-          "type": "string[]",
-          "description": "Logins for Users to assign to this issue. NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise."
+          "type": "string[]"
         }
-      },
-      "description": "Create an issue"
+      }
     },
     "createComment": {
       "url": "/repos/:owner/:repo/issues/:number/comments",
@@ -2409,8 +2115,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Create a comment"
+      }
     },
     "createLabel": {
       "url": "/repos/:owner/:repo/labels",
@@ -2430,11 +2135,9 @@
         },
         "color": {
           "type": "string",
-          "required": true,
-          "description": "6 character hex code, without a leading #."
+          "required": true
         }
-      },
-      "description": "Create a label"
+      }
     },
     "createMilestone": {
       "url": "/repos/:owner/:repo/milestones",
@@ -2465,11 +2168,9 @@
           "type": "string"
         },
         "due_on": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+          "type": "date"
         }
-      },
-      "description": "Create a milestone"
+      }
     },
     "deleteComment": {
       "url": "/repos/:owner/:repo/issues/comments/:id",
@@ -2490,8 +2191,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a comment"
+      }
     },
     "deleteLabel": {
       "url": "/repos/:owner/:repo/labels/:name",
@@ -2509,8 +2209,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a label"
+      }
     },
     "deleteMilestone": {
       "url": "/repos/:owner/:repo/milestones/:number",
@@ -2528,8 +2227,7 @@
           "type": "number",
           "required": true
         }
-      },
-      "description": "Delete a milestone"
+      }
     },
     "edit": {
       "url": "/repos/:owner/:repo/issues/:number",
@@ -2557,8 +2255,7 @@
           "type": "string"
         },
         "assignee": {
-          "type": "string",
-          "description": "Login for the user that this issue should be assigned to."
+          "type": "string"
         },
         "state": {
           "type": "string",
@@ -2566,24 +2263,19 @@
             "open",
             "closed"
           ],
-          "default": "open",
-          "description": "open or closed"
+          "default": "open"
         },
         "milestone": {
           "type": "number",
-          "description": "Milestone to associate this issue with.",
           "allow-null": true
         },
         "labels": {
-          "type": "string[]",
-          "description": "Array of strings - Labels to associate with this issue."
+          "type": "string[]"
         },
         "assignees": {
-          "type": "string[]",
-          "description": "Logins for Users to assign to this issue. NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise."
+          "type": "string[]"
         }
-      },
-      "description": "Edit an issue"
+      }
     },
     "editComment": {
       "url": "/repos/:owner/:repo/issues/comments/:id",
@@ -2608,8 +2300,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Edit a comment"
+      }
     },
     "get": {
       "url": "/repos/:owner/:repo/issues/:number",
@@ -2630,8 +2321,7 @@
           "type": "number",
           "required": true
         }
-      },
-      "description": "Get a single issue"
+      }
     },
     "getAll": {
       "url": "/issues",
@@ -2649,8 +2339,7 @@
             "mentioned",
             "subscribed"
           ],
-          "default": "assigned",
-          "description": "Which sort of issue to return."
+          "default": "assigned"
         },
         "state": {
           "type": "string",
@@ -2659,12 +2348,10 @@
             "closed",
             "all"
           ],
-          "default": "open",
-          "description": "State of the issues to return."
+          "default": "open"
         },
         "labels": {
-          "type": "string",
-          "description": "String list of comma separated label names. Example: bug,ui,@high"
+          "type": "string"
         },
         "sort": {
           "type": "string",
@@ -2684,20 +2371,16 @@
           "default": "desc"
         },
         "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+          "type": "date"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List all issues across all the authenticated user's visible repositories including owned repositories, member repositories, and organization repositories"
+      }
     },
     "getAssignees": {
       "url": "/repos/:owner/:repo/assignees",
@@ -2711,8 +2394,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "List assignees"
+      }
     },
     "getComment": {
       "url": "/repos/:owner/:repo/issues/comments/:id",
@@ -2733,8 +2415,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single comment"
+      }
     },
     "getComments": {
       "url": "/repos/:owner/:repo/issues/:number/comments",
@@ -2756,20 +2437,16 @@
           "required": true
         },
         "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+          "type": "date"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List comments on an issue"
+      }
     },
     "getCommentsForRepo": {
       "url": "/repos/:owner/:repo/issues/comments",
@@ -2803,20 +2480,16 @@
           "default": "desc"
         },
         "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+          "type": "date"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List comments in a repository"
+      }
     },
     "getEvent": {
       "url": "/repos/:owner/:repo/issues/events/:id",
@@ -2834,8 +2507,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single event"
+      }
     },
     "getEvents": {
       "url": "/repos/:owner/:repo/issues/:issue_number/events",
@@ -2854,16 +2526,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List events for an issue"
+      }
     },
     "getEventsForRepo": {
       "url": "/repos/:owner/:repo/issues/events",
@@ -2878,16 +2547,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List events for a repository"
+      }
     },
     "getEventsTimeline": {
       "url": "/repos/:owner/:repo/issues/:issue_number/timeline",
@@ -2909,16 +2575,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List events for an issue. (In preview period. See README.)"
+      }
     },
     "getForOrg": {
       "url": "/orgs/:org/issues",
@@ -2948,12 +2611,10 @@
             "closed",
             "all"
           ],
-          "default": "open",
-          "description": "open, closed, or all"
+          "default": "open"
         },
         "labels": {
-          "type": "string",
-          "description": "String list of comma separated Label names. Example: bug,ui,@high"
+          "type": "string"
         },
         "sort": {
           "type": "string",
@@ -2973,20 +2634,16 @@
           "default": "desc"
         },
         "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+          "type": "date"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List all issues for a given organization for the authenticated user"
+      }
     },
     "getForRepo": {
       "url": "/repos/:owner/:repo/issues",
@@ -3014,24 +2671,19 @@
             "closed",
             "all"
           ],
-          "default": "open",
-          "description": "open, closed, or all"
+          "default": "open"
         },
         "assignee": {
-          "type": "string",
-          "description": "String User login, `none` for Issues with no assigned User. `*` for Issues with any assigned User."
+          "type": "string"
         },
         "creator": {
-          "type": "string",
-          "description": "The user that created the issue."
+          "type": "string"
         },
         "mentioned": {
-          "type": "string",
-          "description": "String User login."
+          "type": "string"
         },
         "labels": {
-          "type": "string",
-          "description": "String list of comma separated Label names. Example: bug,ui,@high"
+          "type": "string"
         },
         "sort": {
           "type": "string",
@@ -3051,20 +2703,16 @@
           "default": "desc"
         },
         "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+          "type": "date"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List issues for a repository"
+      }
     },
     "getForUser": {
       "url": "/user/issues",
@@ -3090,12 +2738,10 @@
             "closed",
             "all"
           ],
-          "default": "open",
-          "description": "open, closed, or all"
+          "default": "open"
         },
         "labels": {
-          "type": "string",
-          "description": "String list of comma separated Label names. Example: bug,ui,@high"
+          "type": "string"
         },
         "sort": {
           "type": "string",
@@ -3115,20 +2761,16 @@
           "default": "desc"
         },
         "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+          "type": "date"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List all issues across owned and member repositories for the authenticated user"
+      }
     },
     "getIssueLabels": {
       "url": "/repos/:owner/:repo/issues/:number/labels",
@@ -3146,8 +2788,7 @@
           "type": "number",
           "required": true
         }
-      },
-      "description": "List labels on an issue"
+      }
     },
     "getLabel": {
       "url": "/repos/:owner/:repo/labels/:name",
@@ -3165,8 +2806,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single label"
+      }
     },
     "getLabels": {
       "url": "/repos/:owner/:repo/labels",
@@ -3181,16 +2821,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List all labels for this repository"
+      }
     },
     "getMilestone": {
       "url": "/repos/:owner/:repo/milestones/:number",
@@ -3208,8 +2845,7 @@
           "type": "number",
           "required": true
         }
-      },
-      "description": "Get a single milestone"
+      }
     },
     "getMilestoneLabels": {
       "url": "/repos/:owner/:repo/milestones/:number/labels",
@@ -3227,8 +2863,7 @@
           "type": "number",
           "required": true
         }
-      },
-      "description": "Get labels for every issue in a milestone"
+      }
     },
     "getMilestones": {
       "url": "/repos/:owner/:repo/milestones",
@@ -3257,8 +2892,7 @@
             "due_on",
             "completeness"
           ],
-          "default": "due_on",
-          "description": "due_on, completeness, default: due_on"
+          "default": "due_on"
         },
         "direction": {
           "type": "string",
@@ -3269,16 +2903,13 @@
           "default": "asc"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List milestones for a repository"
+      }
     },
     "lock": {
       "url": "/repos/:owner/:repo/issues/:number/lock",
@@ -3296,8 +2927,7 @@
           "type": "number",
           "required": true
         }
-      },
-      "description": "Users with push access can lock an issue's conversation."
+      }
     },
     "removeAllLabels": {
       "url": "/repos/:owner/:repo/issues/:number/labels",
@@ -3315,8 +2945,7 @@
           "type": "number",
           "required": true
         }
-      },
-      "description": "Remove all labels from an issue"
+      }
     },
     "removeAssigneesFromIssue": {
       "url": "/repos/:owner/:repo/issues/:number/assignees",
@@ -3338,8 +2967,7 @@
           "type": "json",
           "required": true
         }
-      },
-      "description": "Remove assignees from an issue."
+      }
     },
     "removeLabel": {
       "url": "/repos/:owner/:repo/issues/:number/labels/:name",
@@ -3361,8 +2989,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Remove a label from an issue"
+      }
     },
     "replaceAllLabels": {
       "url": "/repos/:owner/:repo/issues/:number/labels",
@@ -3383,11 +3010,9 @@
         "labels": {
           "type": "string[]",
           "required": true,
-          "mapTo": "input",
-          "description": "Sending an empty array ([]) will remove all Labels from the Issue."
+          "mapTo": "input"
         }
-      },
-      "description": "Replace all labels for an issue"
+      }
     },
     "unlock": {
       "url": "/repos/:owner/:repo/issues/:number/lock",
@@ -3405,8 +3030,7 @@
           "type": "number",
           "required": true
         }
-      },
-      "description": "Users with push access can unlock an issue's conversation."
+      }
     },
     "updateLabel": {
       "url": "/repos/:owner/:repo/labels/:oldname",
@@ -3422,21 +3046,17 @@
         },
         "oldname": {
           "type": "string",
-          "required": true,
-          "description": "The old name of the label."
+          "required": true
         },
         "name": {
           "type": "string",
-          "required": true,
-          "description": "The new name of the label."
+          "required": true
         },
         "color": {
           "type": "string",
-          "required": true,
-          "description": "6 character hex code, without a leading #."
+          "required": true
         }
-      },
-      "description": "Update a label"
+      }
     },
     "updateMilestone": {
       "url": "/repos/:owner/:repo/milestones/:number",
@@ -3471,11 +3091,9 @@
           "type": "string"
         },
         "due_on": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+          "type": "date"
         }
-      },
-      "description": "Update a milestone"
+      }
     }
   },
   "migrations": {
@@ -3494,8 +3112,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Cancel an import. (In preview period. See README.)"
+      }
     },
     "deleteMigrationArchive": {
       "url": "/orgs/:org/migrations/:id/archive",
@@ -3512,8 +3129,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a migration archive. (In preview period. See README.)"
+      }
     },
     "getImportCommitAuthors": {
       "url": "/repos/:owner/:repo/import/authors",
@@ -3531,11 +3147,9 @@
           "required": true
         },
         "since": {
-          "type": "string",
-          "description": "Only authors found after this id are returned. Provide the highest author ID you've seen so far. New authors may be added to the list at any point while the importer is performing the raw step."
+          "type": "string"
         }
-      },
-      "description": "Get import commit authors. (In preview period. See README.)"
+      }
     },
     "getImportProgress": {
       "url": "/repos/:owner/:repo/import",
@@ -3552,8 +3166,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get import progress. (In preview period. See README.)"
+      }
     },
     "getLargeImportFiles": {
       "url": "/:owner/:name/import/large_files",
@@ -3570,8 +3183,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "List files larger than 100MB found during the import. (In preview period. See README.)"
+      }
     },
     "getMigrationArchiveLink": {
       "url": "/orgs/:org/migrations/:id/archive",
@@ -3588,8 +3200,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get the URL to a migration archive. (In preview period. See README.)"
+      }
     },
     "getMigrationStatus": {
       "url": "/orgs/:org/migrations/:id",
@@ -3606,8 +3217,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get the status of a migration. (In preview period. See README.)"
+      }
     },
     "getMigrations": {
       "url": "/orgs/:org/migrations",
@@ -3621,16 +3231,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get a list of migrations. (In preview period. See README.)"
+      }
     },
     "mapImportCommitAuthor": {
       "url": "/repos/:owner/:repo/import/authors/:author_id",
@@ -3649,19 +3256,15 @@
         },
         "author_id": {
           "type": "string",
-          "required": true,
-          "description": "The commit author id."
+          "required": true
         },
         "email": {
-          "type": "string",
-          "description": "The new Git author email."
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "description": "The new Git author name."
+          "type": "string"
         }
-      },
-      "description": "Map a commit author. (In preview period. See README.)"
+      }
     },
     "setImportLfsPreference": {
       "url": "/:owner/:name/import/lfs",
@@ -3680,11 +3283,9 @@
         },
         "use_lfs": {
           "type": "string",
-          "required": true,
-          "description": "Can be one of `opt_in` (large files will be stored using Git LFS) or `opt_out` (large files will be removed during the import)."
+          "required": true
         }
-      },
-      "description": "Set import LFS preference. (In preview period. See README.)"
+      }
     },
     "startImport": {
       "url": "/repos/:owner/:repo/import",
@@ -3703,8 +3304,7 @@
         },
         "vcs_url": {
           "type": "string",
-          "required": true,
-          "description": "The URL of the originating repository."
+          "required": true
         },
         "vcs": {
           "type": "string",
@@ -3713,23 +3313,18 @@
             "git",
             "mercurial",
             "tfvc"
-          ],
-          "description": "The originating VCS type. Please be aware that without this parameter, the import job will take additional time to detect the VCS type before beginning the import. This detection step will be reflected in the response."
+          ]
         },
         "vcs_username": {
-          "type": "string",
-          "description": "If authentication is required, the username to provide to vcs_url."
+          "type": "string"
         },
         "vcs_password": {
-          "type": "string",
-          "description": "If authentication is required, the password to provide to vcs_url."
+          "type": "string"
         },
         "tfvc_project": {
-          "type": "string",
-          "description": "For a tfvc import, the name of the project that is being imported."
+          "type": "string"
         }
-      },
-      "description": "Start an import. (In preview period. See README.)"
+      }
     },
     "startMigration": {
       "url": "/orgs/:org/migrations",
@@ -3744,21 +3339,17 @@
         },
         "repositories": {
           "type": "string[]",
-          "required": true,
-          "description": "A list of arrays indicating which repositories should be migrated."
+          "required": true
         },
         "lock_repositories": {
           "type": "boolean",
-          "default": "false",
-          "description": "Indicates whether repositories should be locked (to prevent manipulation) while migrating data. Default: false."
+          "default": "false"
         },
         "exclude_attachments": {
           "type": "boolean",
-          "default": "false",
-          "description": "Indicates whether attachments should be excluded from the migration (to reduce migration archive file size). Default: false."
+          "default": "false"
         }
-      },
-      "description": "Start a migration. (In preview period. See README.)"
+      }
     },
     "unlockRepoLockedForMigration": {
       "url": "/orgs/:org/migrations/:id/repos/:repo_name/lock",
@@ -3779,8 +3370,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Unlock a repository that was locked for migration. (In preview period. See README.)"
+      }
     },
     "updateImport": {
       "url": "/repos/:owner/:repo/import",
@@ -3798,15 +3388,12 @@
           "required": true
         },
         "vcs_username": {
-          "type": "string",
-          "description": "The username to provide to the originating repository."
+          "type": "string"
         },
         "vcs_password": {
-          "type": "string",
-          "description": "The password to provide to the originating repository."
+          "type": "string"
         }
-      },
-      "description": "Update existing import. (In preview period. See README.)"
+      }
     }
   },
   "misc": {
@@ -3819,11 +3406,9 @@
       "params": {
         "key": {
           "type": "string",
-          "required": true,
-          "description": "Ex: contributor_covenant"
+          "required": true
         }
-      },
-      "description": "Get an code of conduct. (In preview period. See README.)"
+      }
     },
     "getCodesOfConduct": {
       "url": "/codes_of_conduct",
@@ -3831,14 +3416,12 @@
       "headers": {
         "accept": "application/vnd.github.scarlet-witch-preview+json"
       },
-      "params": {},
-      "description": "List all codes of conduct. (In preview period. See README.)"
+      "params": {}
     },
     "getEmojis": {
       "url": "/emojis",
       "method": "GET",
-      "params": {},
-      "description": "Lists all the emojis available to use on GitHub."
+      "params": {}
     },
     "getGitignoreTemplate": {
       "url": "/gitignore/templates/:name",
@@ -3846,17 +3429,14 @@
       "params": {
         "name": {
           "type": "string",
-          "required": true,
-          "description": "The name of the .gitignore template to get e.g. 'C'"
+          "required": true
         }
-      },
-      "description": "Get a single gitignore template"
+      }
     },
     "getGitignoreTemplates": {
       "url": "/gitignore/templates",
       "method": "GET",
-      "params": {},
-      "description": "Lists available gitignore templates"
+      "params": {}
     },
     "getLicense": {
       "url": "/licenses/:license",
@@ -3867,11 +3447,9 @@
       "params": {
         "license": {
           "type": "string",
-          "required": true,
-          "description": "Ex: /licenses/mit"
+          "required": true
         }
-      },
-      "description": "Get an individual license. (In preview period. See README.)"
+      }
     },
     "getLicenses": {
       "url": "/licenses",
@@ -3879,20 +3457,17 @@
       "headers": {
         "accept": "application/vnd.github.drax-preview+json"
       },
-      "params": {},
-      "description": "List all licenses. (In preview period. See README.)"
+      "params": {}
     },
     "getMeta": {
       "url": "/meta",
       "method": "GET",
-      "params": {},
-      "description": "This endpoint provides information about GitHub.com, the service. Or, if you access this endpoint on your organization's GitHub Enterprise installation, this endpoint provides information about that installation."
+      "params": {}
     },
     "getRateLimit": {
       "url": "/rate_limit",
       "method": "GET",
-      "params": {},
-      "description": "Get your current rate limit status"
+      "params": {}
     },
     "getRepoCodeOfConduct": {
       "url": "/repos/:owner/:repo/community/code_of_conduct",
@@ -3909,8 +3484,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get the contents of a repository's code of conduct. (In preview period. See README.)"
+      }
     },
     "getRepoLicense": {
       "url": "/repos/:owner/:repo/license",
@@ -3927,8 +3501,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get the contents of a repository's license. (In preview period. See README.)"
+      }
     },
     "renderMarkdown": {
       "url": "/markdown",
@@ -3936,8 +3509,7 @@
       "params": {
         "text": {
           "type": "string",
-          "required": true,
-          "description": "The Markdown text to render"
+          "required": true
         },
         "mode": {
           "type": "string",
@@ -3945,15 +3517,12 @@
             "markdown",
             "gfm"
           ],
-          "default": "markdown",
-          "description": "The rendering mode, `markdown` to render a document as plain Markdown, just like README files are rendered. `gfm` to render a document as user-content, e.g. like user comments or issues are rendered. In GFM mode, hard line breaks are always taken into account, and issue and user mentions are linked accordingly."
+          "default": "markdown"
         },
         "context": {
-          "type": "string",
-          "description": "The repository context. Only taken into account when rendering as `gfm`"
+          "type": "string"
         }
-      },
-      "description": "Render an arbitrary Markdown document"
+      }
     },
     "renderMarkdownRaw": {
       "url": "/markdown/raw",
@@ -3965,11 +3534,9 @@
         "data": {
           "type": "string",
           "required": true,
-          "mapTo": "input",
-          "description": "Raw data to send as the body of the request"
+          "mapTo": "input"
         }
-      },
-      "description": "Render a Markdown document in raw mode"
+      }
     }
   },
   "orgs": {
@@ -3992,11 +3559,9 @@
             "admin",
             "member"
           ],
-          "default": "member",
-          "description": "The role to give the user in the organization."
+          "default": "member"
         }
-      },
-      "description": "Add or update organization membership"
+      }
     },
     "addTeamMembership": {
       "url": "/teams/:id/memberships/:username",
@@ -4019,11 +3584,9 @@
             "member",
             "maintainer"
           ],
-          "default": "member",
-          "description": "The role that this user should have in the team."
+          "default": "member"
         }
-      },
-      "description": "Add team membership"
+      }
     },
     "addTeamRepo": {
       "url": "/teams/:id/repos/:org/:repo",
@@ -4050,11 +3613,9 @@
             "pull",
             "push",
             "admin"
-          ],
-          "description": "`pull` - team members can pull, but not push or administer this repository, `push` - team members can pull and push, but not administer this repository, `admin` - team members can pull, push and administer this repository."
+          ]
         }
-      },
-      "description": "Add team repository"
+      }
     },
     "blockUser": {
       "url": "/orgs/:org/blocks/:username",
@@ -4071,8 +3632,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Block a user. (In preview period. See README.)"
+      }
     },
     "checkBlockedUser": {
       "url": "/orgs/:org/blocks/:username",
@@ -4089,8 +3649,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Check whether you've blocked a user. (In preview period. See README.)"
+      }
     },
     "checkMembership": {
       "url": "/orgs/:org/members/:username",
@@ -4104,8 +3663,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Check membership"
+      }
     },
     "checkPublicMembership": {
       "url": "/orgs/:org/public_members/:username",
@@ -4119,8 +3677,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Check public membership"
+      }
     },
     "checkTeamRepo": {
       "url": "/teams/:id/repos/:owner/:repo",
@@ -4141,8 +3698,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Check if a team manages a repository"
+      }
     },
     "concealMembership": {
       "url": "/orgs/:org/public_members/:username",
@@ -4156,8 +3712,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Conceal a user's membership"
+      }
     },
     "convertMemberToOutsideCollaborator": {
       "url": "/orgs/:org/outside_collaborators/:username",
@@ -4171,8 +3726,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Convert member to outside collaborator."
+      }
     },
     "createHook": {
       "url": "/orgs/:org/hooks",
@@ -4184,25 +3738,20 @@
         },
         "name": {
           "type": "string",
-          "required": true,
-          "description": "Must be passed as \"web\"."
+          "required": true
         },
         "config": {
           "type": "json",
-          "required": true,
-          "description": "Key/value pairs to provide settings for this webhook"
+          "required": true
         },
         "events": {
           "type": "string[]",
-          "default": "[\"push\"]",
-          "description": "Determines what events the hook is triggered for. Default: [\"push\"]."
+          "default": "[\"push\"]"
         },
         "active": {
-          "type": "boolean",
-          "description": "Determines whether the hook is actually triggered on pushes."
+          "type": "boolean"
         }
-      },
-      "description": "Create a hook"
+      }
     },
     "createTeam": {
       "url": "/orgs/:org/teams",
@@ -4220,16 +3769,13 @@
           "required": true
         },
         "description": {
-          "type": "string",
-          "description": "The description of the team."
+          "type": "string"
         },
         "maintainers": {
-          "type": "string[]",
-          "description": "The logins of organization members to add as maintainers of the team."
+          "type": "string[]"
         },
         "repo_names": {
-          "type": "string[]",
-          "description": "The full name (e.g., \"organization-name/repository-name\") of repositories to add the team to."
+          "type": "string[]"
         },
         "privacy": {
           "type": "string",
@@ -4237,15 +3783,12 @@
             "secret",
             "closed"
           ],
-          "default": "secret",
-          "description": "The level of privacy this team should have."
+          "default": "secret"
         },
         "parent_team_id": {
-          "type": "number",
-          "description": "The ID of a team to set as the parent team."
+          "type": "number"
         }
-      },
-      "description": "Create team"
+      }
     },
     "deleteHook": {
       "url": "/orgs/:org/hooks/:id",
@@ -4259,8 +3802,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a hook"
+      }
     },
     "deleteTeam": {
       "url": "/teams/:id",
@@ -4273,8 +3815,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete team"
+      }
     },
     "deleteTeamRepo": {
       "url": "/teams/:id/repos/:owner/:repo",
@@ -4295,8 +3836,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Remove team repository"
+      }
     },
     "editHook": {
       "url": "/orgs/:org/hooks/:id",
@@ -4312,20 +3852,16 @@
         },
         "config": {
           "type": "json",
-          "required": true,
-          "description": "Key/value pairs to provide settings for this webhook"
+          "required": true
         },
         "events": {
           "type": "string[]",
-          "default": "[\"push\"]",
-          "description": "Determines what events the hook is triggered for. Default: [\"push\"]."
+          "default": "[\"push\"]"
         },
         "active": {
-          "type": "boolean",
-          "description": "Determines whether the hook is actually triggered on pushes."
+          "type": "boolean"
         }
-      },
-      "description": "Edit a hook"
+      }
     },
     "editTeam": {
       "url": "/teams/:id",
@@ -4343,8 +3879,7 @@
           "required": true
         },
         "description": {
-          "type": "string",
-          "description": "The description of the team."
+          "type": "string"
         },
         "privacy": {
           "type": "string",
@@ -4352,15 +3887,12 @@
             "secret",
             "closed"
           ],
-          "default": "secret",
-          "description": "The level of privacy this team should have."
+          "default": "secret"
         },
         "parent_team_id": {
-          "type": "number",
-          "description": "The ID of a team to set as the parent team."
+          "type": "number"
         }
-      },
-      "description": "Edit team"
+      }
     },
     "get": {
       "url": "/orgs/:org",
@@ -4371,36 +3903,29 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get an organization"
+      }
     },
     "getAll": {
       "url": "/organizations",
       "method": "GET",
       "params": {
         "since": {
-          "type": "string",
-          "description": "The integer ID of the last Organization that you've seen."
+          "type": "string"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List all organizations"
+      }
     },
     "getBlockedUsers": {
       "url": "/orgs/:org/blocks",
@@ -4414,16 +3939,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List blocked users. (In preview period. See README.)"
+      }
     },
     "getChildTeams": {
       "url": "/teams/:id/teams",
@@ -4437,16 +3959,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List child teams"
+      }
     },
     "getForUser": {
       "url": "/users/:username/orgs",
@@ -4457,16 +3976,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List public organization memberships for the specified user."
+      }
     },
     "getHook": {
       "url": "/orgs/:org/hooks/:id",
@@ -4480,8 +3996,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get single hook"
+      }
     },
     "getHooks": {
       "url": "/orgs/:org/hooks",
@@ -4492,16 +4007,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List hooks"
+      }
     },
     "getMembers": {
       "url": "/orgs/:org/members",
@@ -4517,8 +4029,7 @@
             "all",
             "2fa_disabled"
           ],
-          "default": "all",
-          "description": "Filter members returned in the list."
+          "default": "all"
         },
         "role": {
           "type": "string",
@@ -4527,20 +4038,16 @@
             "admin",
             "member"
           ],
-          "default": "all",
-          "description": "Filter members returned by their role."
+          "default": "all"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Members list"
+      }
     },
     "getOrgMembership": {
       "url": "/orgs/:org/memberships/:username",
@@ -4554,8 +4061,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get organization membership"
+      }
     },
     "getOutsideCollaborators": {
       "url": "/orgs/:org/outside_collaborators",
@@ -4571,20 +4077,16 @@
             "all",
             "2fa_disabled"
           ],
-          "default": "all",
-          "description": "Filter the list of outside collaborators."
+          "default": "all"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List all users who are outside collaborators of an organization."
+      }
     },
     "getPendingOrgInvites": {
       "url": "/orgs/:org/invitations",
@@ -4594,8 +4096,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "List pending organization invites."
+      }
     },
     "getPendingTeamInvites": {
       "url": "/teams/:id/invitations",
@@ -4606,16 +4107,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List pending team invitations."
+      }
     },
     "getPublicMembers": {
       "url": "/orgs/:org/public_members",
@@ -4625,8 +4123,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Public members list"
+      }
     },
     "getTeam": {
       "url": "/teams/:id",
@@ -4639,8 +4136,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get team"
+      }
     },
     "getTeamMembers": {
       "url": "/teams/:id/members",
@@ -4660,20 +4156,16 @@
             "maintainer",
             "all"
           ],
-          "default": "all",
-          "description": "Filters members returned by their role in the team."
+          "default": "all"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List team members"
+      }
     },
     "getTeamMembership": {
       "url": "/teams/:id/memberships/:username",
@@ -4690,8 +4182,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get team membership"
+      }
     },
     "getTeamRepos": {
       "url": "/teams/:id/repos",
@@ -4705,16 +4196,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get team repos"
+      }
     },
     "getTeams": {
       "url": "/orgs/:org/teams",
@@ -4728,16 +4216,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List teams"
+      }
     },
     "pingHook": {
       "url": "/orgs/:org/hooks/:id/pings",
@@ -4751,8 +4236,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Ping a hook"
+      }
     },
     "publicizeMembership": {
       "url": "/orgs/:org/public_members/:username",
@@ -4766,8 +4250,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Publicize a user's membership"
+      }
     },
     "removeMember": {
       "url": "/orgs/:org/members/:username",
@@ -4781,8 +4264,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Remove a member"
+      }
     },
     "removeOrgMembership": {
       "url": "/orgs/:org/memberships/:username",
@@ -4796,8 +4278,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Remove organization membership"
+      }
     },
     "removeOutsideCollaborator": {
       "url": "/orgs/:org/outside_collaborators/:username",
@@ -4811,8 +4292,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Remove outside collaborator."
+      }
     },
     "removeTeamMembership": {
       "url": "/teams/:id/memberships/:username",
@@ -4829,8 +4309,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Remove team membership"
+      }
     },
     "unblockUser": {
       "url": "/orgs/:org/blocks/:username",
@@ -4847,8 +4326,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Unblock a user. (In preview period. See README.)"
+      }
     },
     "update": {
       "url": "/orgs/:org",
@@ -4859,28 +4337,22 @@
           "required": true
         },
         "billing_email": {
-          "type": "string",
-          "description": "Billing email address. This address is not publicized."
+          "type": "string"
         },
         "company": {
-          "type": "string",
-          "description": "The company name."
+          "type": "string"
         },
         "email": {
-          "type": "string",
-          "description": "The publicly visible email address."
+          "type": "string"
         },
         "location": {
-          "type": "string",
-          "description": "The location."
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "description": "The shorthand name of the company."
+          "type": "string"
         },
         "description": {
-          "type": "string",
-          "description": "The description of the company."
+          "type": "string"
         },
         "default_repository_permission": {
           "type": "string",
@@ -4890,16 +4362,13 @@
             "admin",
             "none"
           ],
-          "default": "read",
-          "description": "Default permission level members have for organization repositories."
+          "default": "read"
         },
         "members_can_create_repositories": {
           "type": "boolean",
-          "default": true,
-          "description": "Toggles ability of non-admin organization members to create repositories."
+          "default": true
         }
-      },
-      "description": "Edit an organization"
+      }
     }
   },
   "projects": {
@@ -4921,8 +4390,7 @@
         "body": {
           "type": "string"
         }
-      },
-      "description": "Create an organization project. (In preview period. See README.)"
+      }
     },
     "createProjectCard": {
       "url": "/projects/columns/:column_id/cards",
@@ -4936,19 +4404,15 @@
           "required": true
         },
         "note": {
-          "type": "string",
-          "description": "The note of the card."
+          "type": "string"
         },
         "content_id": {
-          "type": "string",
-          "description": "The id of the Issue or Pull Request to associate with this card."
+          "type": "string"
         },
         "content_type": {
-          "type": "string",
-          "description": "The type of content to associate with this card. Can be either 'Issue' or 'PullRequest'."
+          "type": "string"
         }
-      },
-      "description": "Create a project card. (In preview period. See README.)"
+      }
     },
     "createProjectColumn": {
       "url": "/projects/:project_id/columns",
@@ -4965,8 +4429,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Create a project column. (In preview period. See README.)"
+      }
     },
     "createRepoProject": {
       "url": "/repos/:owner/:repo/projects",
@@ -4990,8 +4453,7 @@
         "body": {
           "type": "string"
         }
-      },
-      "description": "Create a repository project. (In preview period. See README.)"
+      }
     },
     "deleteProject": {
       "url": "/projects/:id",
@@ -5004,8 +4466,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a project. (In preview period. See README.)"
+      }
     },
     "deleteProjectCard": {
       "url": "/projects/columns/cards/:id",
@@ -5018,8 +4479,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a project card. (In preview period. See README.)"
+      }
     },
     "deleteProjectColumn": {
       "url": "/projects/columns/:id",
@@ -5032,8 +4492,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a project column. (In preview period. See README.)"
+      }
     },
     "getOrgProjects": {
       "url": "/orgs/:org/projects",
@@ -5055,8 +4514,7 @@
           ],
           "default": "open"
         }
-      },
-      "description": "List organization projects. (In preview period. See README.)"
+      }
     },
     "getProject": {
       "url": "/projects/:id",
@@ -5069,8 +4527,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a project. (In preview period. See README.)"
+      }
     },
     "getProjectCard": {
       "url": "/projects/columns/cards/:id",
@@ -5083,8 +4540,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get project card. (In preview period. See README.)"
+      }
     },
     "getProjectCards": {
       "url": "/projects/columns/:column_id/cards",
@@ -5097,8 +4553,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "List project cards. (In preview period. See README.)"
+      }
     },
     "getProjectColumn": {
       "url": "/projects/columns/:id",
@@ -5111,8 +4566,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a project column. (In preview period. See README.)"
+      }
     },
     "getProjectColumns": {
       "url": "/projects/:project_id/columns",
@@ -5125,8 +4579,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "List project columns. (In preview period. See README.)"
+      }
     },
     "getRepoProjects": {
       "url": "/repos/:owner/:repo/projects",
@@ -5152,8 +4605,7 @@
           ],
           "default": "open"
         }
-      },
-      "description": "List repository projects. (In preview period. See README.)"
+      }
     },
     "moveProjectCard": {
       "url": "/projects/columns/cards/:id/moves",
@@ -5169,15 +4621,12 @@
         "position": {
           "type": "string",
           "required": true,
-          "validation": "^(top|bottom|after:\\d+)$",
-          "description": "Can be one of top, bottom, or after:<card-id>, where <card-id> is the id value of a card in the same project."
+          "validation": "^(top|bottom|after:\\d+)$"
         },
         "column_id": {
-          "type": "string",
-          "description": "The id value of a column in the same project."
+          "type": "string"
         }
-      },
-      "description": "Move a project card. (In preview period. See README.)"
+      }
     },
     "moveProjectColumn": {
       "url": "/projects/columns/:id/moves",
@@ -5193,11 +4642,9 @@
         "position": {
           "type": "string",
           "required": true,
-          "validation": "^(first|last|after:\\d+)$",
-          "description": "Can be one of first, last, or after:<column-id>, where <column-id> is the id value of a column in the same project."
+          "validation": "^(first|last|after:\\d+)$"
         }
-      },
-      "description": "Move a project column. (In preview period. See README.)"
+      }
     },
     "updateProject": {
       "url": "/projects/:id",
@@ -5226,8 +4673,7 @@
           ],
           "default": "open"
         }
-      },
-      "description": "Update a project. (In preview period. See README.)"
+      }
     },
     "updateProjectCard": {
       "url": "/projects/columns/cards/:id",
@@ -5241,11 +4687,9 @@
           "required": true
         },
         "note": {
-          "type": "string",
-          "description": "The note of the card."
+          "type": "string"
         }
-      },
-      "description": "Update a project card. (In preview period. See README.)"
+      }
     },
     "updateProjectColumn": {
       "url": "/projects/columns/:id",
@@ -5262,8 +4706,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Update a project column. (In preview period. See README.)"
+      }
     }
   },
   "pullRequests": {
@@ -5287,16 +4730,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get if a pull request has been merged"
+      }
     },
     "create": {
       "url": "/repos/:owner/:repo/pulls",
@@ -5312,29 +4752,23 @@
         },
         "head": {
           "type": "string",
-          "required": true,
-          "description": "The branch (or git ref) where your changes are implemented."
+          "required": true
         },
         "base": {
           "type": "string",
-          "required": true,
-          "description": "The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo."
+          "required": true
         },
         "title": {
           "type": "string",
-          "required": true,
-          "description": "The title of the pull request."
+          "required": true
         },
         "body": {
-          "type": "string",
-          "description": "The contents of the pull request."
+          "type": "string"
         },
         "maintainer_can_modify": {
-          "type": "boolean",
-          "description": "Indicates whether maintainers can modify the pull request."
+          "type": "boolean"
         }
-      },
-      "description": "Create a pull request"
+      }
     },
     "createComment": {
       "url": "/repos/:owner/:repo/pulls/:number/comments",
@@ -5371,8 +4805,7 @@
           "type": "number",
           "required": true
         }
-      },
-      "description": "Create a comment"
+      }
     },
     "createCommentReply": {
       "url": "/repos/:owner/:repo/pulls/:number/comments",
@@ -5399,11 +4832,9 @@
         },
         "in_reply_to": {
           "type": "number",
-          "required": true,
-          "description": "The comment id to reply to."
+          "required": true
         }
-      },
-      "description": "Reply to existing pull request comment"
+      }
     },
     "createFromIssue": {
       "url": "/repos/:owner/:repo/pulls",
@@ -5419,21 +4850,17 @@
         },
         "issue": {
           "type": "number",
-          "required": true,
-          "description": "The issue number in this repository to turn into a Pull Request."
+          "required": true
         },
         "head": {
           "type": "string",
-          "required": true,
-          "description": "The branch (or git ref) where your changes are implemented."
+          "required": true
         },
         "base": {
           "type": "string",
-          "required": true,
-          "description": "The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo."
+          "required": true
         }
-      },
-      "description": "Create a pull request from an existing issue"
+      }
     },
     "createReview": {
       "url": "/repos/:owner/:repo/pulls/:number/reviews",
@@ -5452,12 +4879,10 @@
           "required": true
         },
         "commit_id": {
-          "type": "string",
-          "description": "Sha of the commit to comment on."
+          "type": "string"
         },
         "body": {
-          "type": "string",
-          "description": "The body text of the pull request review."
+          "type": "string"
         },
         "event": {
           "type": "string",
@@ -5467,15 +4892,12 @@
             "COMMENT",
             "PENDING"
           ],
-          "default": "PENDING",
-          "description": "The event to perform on the review upon submission, can be one of APPROVE, REQUEST_CHANGES, or COMMENT. If left blank, the review will be in the PENDING state."
+          "default": "PENDING"
         },
         "comments": {
-          "type": "string[]",
-          "description": "An array of draft review comment objects. Draft review comments must include a `path`, `position`, and `body`."
+          "type": "string[]"
         }
-      },
-      "description": "Create a pull request review."
+      }
     },
     "createReviewRequest": {
       "url": "/repos/:owner/:repo/pulls/:number/requested_reviewers",
@@ -5497,15 +4919,12 @@
           "required": true
         },
         "reviewers": {
-          "type": "string[]",
-          "description": "An array of user logins that will be requested."
+          "type": "string[]"
         },
         "team_reviewers": {
-          "type": "string[]",
-          "description": "An array of team slugs that will be requested."
+          "type": "string[]"
         }
-      },
-      "description": "Create a review request. (In preview period. See README.)"
+      }
     },
     "deleteComment": {
       "url": "/repos/:owner/:repo/pulls/comments/:id",
@@ -5526,8 +4945,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a comment"
+      }
     },
     "deletePendingReview": {
       "url": "/repos/:owner/:repo/pulls/:number/reviews/:id",
@@ -5549,8 +4967,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a pending pull request review."
+      }
     },
     "deleteReviewRequest": {
       "url": "/repos/:owner/:repo/pulls/:number/requested_reviewers",
@@ -5572,15 +4989,12 @@
           "required": true
         },
         "reviewers": {
-          "type": "string[]",
-          "description": "An array of user logins that will be requested."
+          "type": "string[]"
         },
         "team_reviewers": {
-          "type": "string[]",
-          "description": "An array of team slugs that will be requested."
+          "type": "string[]"
         }
-      },
-      "description": "Delete a review request. (In preview period. See README.)"
+      }
     },
     "dismissReview": {
       "url": "/repos/:owner/:repo/pulls/:number/reviews/:id/dismissals",
@@ -5603,20 +5017,16 @@
           "required": true
         },
         "message": {
-          "type": "string",
-          "description": "The message for the pull request review dismissal."
+          "type": "string"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Dismiss a pull request review."
+      }
     },
     "editComment": {
       "url": "/repos/:owner/:repo/pulls/comments/:id",
@@ -5641,8 +5051,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Edit a comment"
+      }
     },
     "get": {
       "url": "/repos/:owner/:repo/pulls/:number",
@@ -5660,8 +5069,7 @@
           "type": "number",
           "required": true
         }
-      },
-      "description": "Get a single pull request"
+      }
     },
     "getAll": {
       "url": "/repos/:owner/:repo/pulls",
@@ -5685,12 +5093,10 @@
           "default": "open"
         },
         "head": {
-          "type": "string",
-          "description": "Filter pulls by head user and branch name in the format of user:ref-name. Example: github:new-script-format."
+          "type": "string"
         },
         "base": {
-          "type": "string",
-          "description": "Filter pulls by base branch name. Example: gh-pages."
+          "type": "string"
         },
         "sort": {
           "type": "string",
@@ -5700,8 +5106,7 @@
             "popularity",
             "long-running"
           ],
-          "default": "created",
-          "description": "Possible values are: `created`, `updated`, `popularity`, `long-running`, Default: `created`"
+          "default": "created"
         },
         "direction": {
           "type": "string",
@@ -5712,16 +5117,13 @@
           "default": "desc"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List pull requests"
+      }
     },
     "getComment": {
       "url": "/repos/:owner/:repo/pulls/comments/:id",
@@ -5742,8 +5144,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single comment"
+      }
     },
     "getComments": {
       "url": "/repos/:owner/:repo/pulls/:number/comments",
@@ -5765,16 +5166,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List comments on a pull request"
+      }
     },
     "getCommentsForRepo": {
       "url": "/repos/:owner/:repo/pulls/comments",
@@ -5797,8 +5195,7 @@
             "created",
             "updated"
           ],
-          "default": "created",
-          "description": "Possible values are: `created`, `updated`, Default: `created`"
+          "default": "created"
         },
         "direction": {
           "type": "string",
@@ -5809,20 +5206,16 @@
           "default": "desc"
         },
         "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+          "type": "date"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List comments in a repository"
+      }
     },
     "getCommits": {
       "url": "/repos/:owner/:repo/pulls/:number/commits",
@@ -5841,16 +5234,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List commits on a pull request"
+      }
     },
     "getFiles": {
       "url": "/repos/:owner/:repo/pulls/:number/files",
@@ -5869,16 +5259,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List pull requests files"
+      }
     },
     "getReview": {
       "url": "/repos/:owner/:repo/pulls/:number/reviews/:id",
@@ -5900,8 +5287,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single pull request review."
+      }
     },
     "getReviewComments": {
       "url": "/repos/:owner/:repo/pulls/:number/reviews/:id/comments",
@@ -5924,16 +5310,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get comments for a pull request review."
+      }
     },
     "getReviewRequests": {
       "url": "/repos/:owner/:repo/pulls/:number/requested_reviewers",
@@ -5955,16 +5338,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List review requests. (In preview period. See README.)"
+      }
     },
     "getReviews": {
       "url": "/repos/:owner/:repo/pulls/:number/reviews",
@@ -5983,16 +5363,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List reviews on a pull request."
+      }
     },
     "merge": {
       "url": "/repos/:owner/:repo/pulls/:number/merge",
@@ -6014,16 +5391,13 @@
           "required": true
         },
         "commit_title": {
-          "type": "string",
-          "description": "Title for the automatic commit message. (In preview period. See README.)"
+          "type": "string"
         },
         "commit_message": {
-          "type": "string",
-          "description": "Extra detail to append to automatic commit message."
+          "type": "string"
         },
         "sha": {
-          "type": "string",
-          "description": "SHA that pull request head must match to allow merge"
+          "type": "string"
         },
         "merge_method": {
           "type": "string",
@@ -6032,11 +5406,9 @@
             "squash",
             "rebase"
           ],
-          "default": "merge",
-          "description": "Merge method to use. Possible values are `merge`, `squash`, or `rebase`. (In preview period. See README.)"
+          "default": "merge"
         }
-      },
-      "description": "Merge a pull request (Merge Button)"
+      }
     },
     "submitReview": {
       "url": "/repos/:owner/:repo/pulls/:number/reviews/:id/events",
@@ -6059,8 +5431,7 @@
           "required": true
         },
         "body": {
-          "type": "string",
-          "description": "The body text of the pull request review."
+          "type": "string"
         },
         "event": {
           "type": "string",
@@ -6070,11 +5441,9 @@
             "COMMENT",
             "PENDING"
           ],
-          "default": "PENDING",
-          "description": "The event to perform on the review upon submission, can be one of APPROVE, REQUEST_CHANGES, or COMMENT. If left blank, the review will be in the PENDING state."
+          "default": "PENDING"
         }
-      },
-      "description": "Submit a pull request review."
+      }
     },
     "update": {
       "url": "/repos/:owner/:repo/pulls/:number",
@@ -6093,32 +5462,26 @@
           "required": true
         },
         "title": {
-          "type": "string",
-          "description": "The title of the pull request."
+          "type": "string"
         },
         "body": {
-          "type": "string",
-          "description": "The contents of the pull request."
+          "type": "string"
         },
         "state": {
           "type": "string",
           "enum": [
             "open",
             "closed"
-          ],
-          "description": "open or closed"
+          ]
         },
         "base": {
-          "type": "string",
-          "description": "The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo."
+          "type": "string"
         },
         "maintainer_can_modify": {
           "type": "boolean",
-          "default": "true",
-          "description": "Indicates whether maintainers can modify the pull request."
+          "default": "true"
         }
-      },
-      "description": "Update a pull request"
+      }
     }
   },
   "reactions": {
@@ -6151,11 +5514,9 @@
             "confused",
             "heart",
             "hooray"
-          ],
-          "description": "The reaction type."
+          ]
         }
-      },
-      "description": "Create reaction for a commit comment. (In preview period. See README.)"
+      }
     },
     "createForIssue": {
       "url": "/repos/:owner/:repo/issues/:number/reactions",
@@ -6186,11 +5547,9 @@
             "confused",
             "heart",
             "hooray"
-          ],
-          "description": "The reaction type."
+          ]
         }
-      },
-      "description": "Create reaction for an issue. (In preview period. See README.)"
+      }
     },
     "createForIssueComment": {
       "url": "/repos/:owner/:repo/issues/comments/:id/reactions",
@@ -6221,11 +5580,9 @@
             "confused",
             "heart",
             "hooray"
-          ],
-          "description": "The reaction type."
+          ]
         }
-      },
-      "description": "Create reaction for an issue comment. (In preview period. See README.)"
+      }
     },
     "createForPullRequestReviewComment": {
       "url": "/repos/:owner/:repo/pulls/comments/:id/reactions",
@@ -6256,11 +5613,9 @@
             "confused",
             "heart",
             "hooray"
-          ],
-          "description": "The reaction type."
+          ]
         }
-      },
-      "description": "Create reaction for a pull request review comment. (In preview period. See README.)"
+      }
     },
     "delete": {
       "url": "/reactions/:id",
@@ -6273,8 +5628,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a reaction. (In preview period. See README.)"
+      }
     },
     "getForCommitComment": {
       "url": "/repos/:owner/:repo/comments/:id/reactions",
@@ -6304,11 +5658,9 @@
             "confused",
             "heart",
             "hooray"
-          ],
-          "description": "Indicates which type of reaction to return."
+          ]
         }
-      },
-      "description": "List reactions for a commit comment. (In preview period. See README.)"
+      }
     },
     "getForIssue": {
       "url": "/repos/:owner/:repo/issues/:number/reactions",
@@ -6338,11 +5690,9 @@
             "confused",
             "heart",
             "hooray"
-          ],
-          "description": "Indicates which type of reaction to return."
+          ]
         }
-      },
-      "description": "List reactions for an issue. (In preview period. See README.)"
+      }
     },
     "getForIssueComment": {
       "url": "/repos/:owner/:repo/issues/comments/:id/reactions",
@@ -6372,11 +5722,9 @@
             "confused",
             "heart",
             "hooray"
-          ],
-          "description": "Indicates which type of reaction to return."
+          ]
         }
-      },
-      "description": "List reactions for an issue comment. (In preview period. See README.)"
+      }
     },
     "getForPullRequestReviewComment": {
       "url": "/repos/:owner/:repo/pulls/comments/:id/reactions",
@@ -6406,11 +5754,9 @@
             "confused",
             "heart",
             "hooray"
-          ],
-          "description": "Indicates which type of reaction to return."
+          ]
         }
-      },
-      "description": "List reactions for a pull request review comment. (In preview period. See README.)"
+      }
     }
   },
   "repos": {
@@ -6437,11 +5783,9 @@
             "push",
             "admin"
           ],
-          "default": "push",
-          "description": "`pull` - can pull, but not push to or administer this repository, `push` - can pull and push, but not administer this repository, `admin` - can pull, push and administer this repository."
+          "default": "push"
         }
-      },
-      "description": "Add user as a collaborator"
+      }
     },
     "addDeployKey": {
       "url": "/repos/:owner/:repo/keys",
@@ -6464,11 +5808,9 @@
           "required": true
         },
         "read_only": {
-          "type": "boolean",
-          "description": "If true, the key will only be able to read repository contents. Otherwise, the key will be able to read and write."
+          "type": "boolean"
         }
-      },
-      "description": "Add a new deploy key."
+      }
     },
     "addProtectedBranchAdminEnforcement": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins",
@@ -6487,16 +5829,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Add admin enforcement of protected branch."
+      }
     },
     "addProtectedBranchRequiredStatusChecksContexts": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
@@ -6517,11 +5856,9 @@
         "contexts": {
           "type": "string[]",
           "required": true,
-          "mapTo": "input",
-          "description": "An array of protected branch required status checks contexts (e.g. continuous-integration/jenkins)."
+          "mapTo": "input"
         }
-      },
-      "description": "Add required status checks contexts of protected branch."
+      }
     },
     "addProtectedBranchTeamRestrictions": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
@@ -6542,11 +5879,9 @@
         "teams": {
           "type": "string[]",
           "required": true,
-          "mapTo": "input",
-          "description": "An array of team slugs (e.g. justice-league)."
+          "mapTo": "input"
         }
-      },
-      "description": "Add team restrictions of protected branch."
+      }
     },
     "addProtectedBranchUserRestrictions": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
@@ -6567,11 +5902,9 @@
         "users": {
           "type": "string[]",
           "required": true,
-          "mapTo": "input",
-          "description": "An array of team slugs (e.g. justice-league)."
+          "mapTo": "input"
         }
-      },
-      "description": "Add user restrictions of protected branch."
+      }
     },
     "checkCollaborator": {
       "url": "/repos/:owner/:repo/collaborators/:username",
@@ -6589,8 +5922,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Check if user is a collaborator."
+      }
     },
     "compareCommits": {
       "url": "/repos/:owner/:repo/compare/:base...:head",
@@ -6606,16 +5938,13 @@
         },
         "base": {
           "type": "string",
-          "required": true,
-          "description": "The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo."
+          "required": true
         },
         "head": {
           "type": "string",
-          "required": true,
-          "description": "The branch (or git ref) where your changes are implemented."
+          "required": true
         }
-      },
-      "description": "Compare two commits."
+      }
     },
     "create": {
       "url": "/user/repos",
@@ -6633,58 +5962,46 @@
         },
         "private": {
           "type": "boolean",
-          "default": "false",
-          "description": "True to create a private repository, false to create a public one. Creating private repositories requires a paid GitHub account. Default is false."
+          "default": "false"
         },
         "has_issues": {
           "type": "boolean",
-          "default": "true",
-          "description": "True to enable issues for this repository, false to disable them. Default is true."
+          "default": "true"
         },
         "has_projects": {
           "type": "boolean",
-          "default": "true",
-          "description": "True to enable projects for this repository, false to disable them. Default is true."
+          "default": "true"
         },
         "has_wiki": {
           "type": "boolean",
-          "default": "true",
-          "description": "True to enable the wiki for this repository, false to disable it. Default is true."
+          "default": "true"
         },
         "team_id": {
-          "type": "number",
-          "description": "The id of the team that will be granted access to this repository. This is only valid when creating a repository in an organization."
+          "type": "number"
         },
         "auto_init": {
           "type": "boolean",
-          "default": "false",
-          "description": "True to create an initial commit with empty README. Default is false"
+          "default": "false"
         },
         "gitignore_template": {
-          "type": "string",
-          "description": "Desired language or platform .gitignore template to apply. Ignored if auto_init parameter is not provided."
+          "type": "string"
         },
         "license_template": {
-          "type": "string",
-          "description": "Desired LICENSE template to apply. Use the name of the template without the extension. For example, \"mit\" or \"mozilla\"."
+          "type": "string"
         },
         "allow_squash_merge": {
           "type": "boolean",
-          "default": "true",
-          "description": "Either true to allow squash-merging pull requests, or false to prevent squash-merging. Default: true. (In preview period. See README.)"
+          "default": "true"
         },
         "allow_merge_commit": {
           "type": "boolean",
-          "default": "true",
-          "description": "Either true to allow merging pull requests with a merge commit, or false to prevent merging pull requests with merge commits. Default: true. (In preview period. See README.)"
+          "default": "true"
         },
         "allow_rebase_merge": {
           "type": "boolean",
-          "default": "true",
-          "description": "Either true to allow rebase-merging pull requests, or false to prevent rebase-merging. Default: true. (In preview period. See README.)"
+          "default": "true"
         }
-      },
-      "description": "Create a new repository for the authenticated user."
+      }
     },
     "createCommitComment": {
       "url": "/repos/:owner/:repo/commits/:sha/comments",
@@ -6707,15 +6024,12 @@
           "required": true
         },
         "path": {
-          "type": "string",
-          "description": "Relative path of the file to comment on."
+          "type": "string"
         },
         "position": {
-          "type": "number",
-          "description": "Line index in the diff to comment on."
+          "type": "number"
         }
-      },
-      "description": "Create a commit comment."
+      }
     },
     "createDeployment": {
       "url": "/repos/:owner/:repo/deployments",
@@ -6734,49 +6048,39 @@
         },
         "ref": {
           "type": "string",
-          "required": true,
-          "description": "The ref to deploy. This can be a branch, tag, or sha."
+          "required": true
         },
         "task": {
           "type": "string",
-          "default": "deploy",
-          "description": "The named task to execute. e.g. deploy or deploy:migrations. Default: deploy"
+          "default": "deploy"
         },
         "auto_merge": {
           "type": "boolean",
-          "default": "true",
-          "description": "Optional parameter to merge the default branch into the requested ref if it is behind the default branch. Default: true"
+          "default": "true"
         },
         "required_contexts": {
-          "type": "string[]",
-          "description": "Optional array of status contexts verified against commit status checks. If this parameter is omitted from the parameters then all unique contexts will be verified before a deployment is created. To bypass checking entirely pass an empty array. Defaults to all unique contexts."
+          "type": "string[]"
         },
         "payload": {
           "type": "string",
-          "default": "\"\"",
-          "description": "Optional JSON payload with extra information about the deployment. Default: \"\""
+          "default": "\"\""
         },
         "environment": {
           "type": "string",
-          "default": "none",
-          "description": "The name of the environment that was deployed to. e.g. staging or production. Default: none."
+          "default": "none"
         },
         "description": {
           "type": "string",
-          "default": "\"\"",
-          "description": "Optional short description. Default: \"\""
+          "default": "\"\""
         },
         "transient_environment": {
           "type": "boolean",
-          "default": false,
-          "description": "Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future. Default: false. (In preview period. See README.)"
+          "default": false
         },
         "production_environment": {
-          "type": "boolean",
-          "description": "Specifies if the given environment is a one that end-users directly interact with. Default: true when environment is `production` and false otherwise. (In preview period. See README.)"
+          "type": "boolean"
         }
-      },
-      "description": "Create a deployment. (In preview period. See README.)"
+      }
     },
     "createDeploymentStatus": {
       "url": "/repos/:owner/:repo/deployments/:id/statuses",
@@ -6798,36 +6102,29 @@
           "required": true
         },
         "state": {
-          "type": "string",
-          "description": "The state of the status. Can be one of pending, success, error, or failure."
+          "type": "string"
         },
         "target_url": {
           "type": "string",
-          "default": "\"\"",
-          "description": "The target URL to associate with this status. This URL should contain output to keep the user updated while the task is running or serve as historical information for what happened in the deployment. Default: \"\""
+          "default": "\"\""
         },
         "log_url": {
           "type": "string",
-          "default": "\"\"",
-          "description": "Functionally equivalent to target_url. Default: \"\". (In preview period. See README.)"
+          "default": "\"\""
         },
         "description": {
           "type": "string",
-          "default": "\"\"",
-          "description": "A short description of the status. Default: \"\""
+          "default": "\"\""
         },
         "environment_url": {
           "type": "string",
-          "default": "\"\"",
-          "description": "URL for accessing the deployment environment. Default: \"\". (In preview period. See README.)"
+          "default": "\"\""
         },
         "auto_inactive": {
           "type": "boolean",
-          "default": true,
-          "description": "When true the new `inactive` status is added to all other non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment. Default: true. (In preview period. See README.)"
+          "default": true
         }
-      },
-      "description": "Create a deployment status. (In preview period. See README.)"
+      }
     },
     "createFile": {
       "url": "/repos/:owner/:repo/contents/:path",
@@ -6843,22 +6140,18 @@
         },
         "path": {
           "type": "string",
-          "required": true,
-          "description": "The content path."
+          "required": true
         },
         "message": {
           "type": "string",
-          "required": true,
-          "description": "The commit message."
+          "required": true
         },
         "content": {
           "type": "string",
-          "required": true,
-          "description": "The new file content, Base64 encoded."
+          "required": true
         },
         "branch": {
-          "type": "string",
-          "description": "The branch name. If not provided, uses the repository’s default branch (usually master)."
+          "type": "string"
         },
         "committer": {
           "type": "json"
@@ -6866,8 +6159,7 @@
         "author": {
           "type": "json"
         }
-      },
-      "description": "Create a new file in the given repository."
+      }
     },
     "createForOrg": {
       "url": "/orgs/:org/repos",
@@ -6889,58 +6181,46 @@
         },
         "private": {
           "type": "boolean",
-          "default": "false",
-          "description": "True to create a private repository, false to create a public one. Creating private repositories requires a paid GitHub account. Default is false."
+          "default": "false"
         },
         "has_issues": {
           "type": "boolean",
-          "default": "true",
-          "description": "True to enable issues for this repository, false to disable them. Default is true."
+          "default": "true"
         },
         "has_projects": {
           "type": "boolean",
-          "default": "true",
-          "description": "True to enable projects for this repository, false to disable them. Default is true."
+          "default": "true"
         },
         "has_wiki": {
           "type": "boolean",
-          "default": "true",
-          "description": "True to enable the wiki for this repository, false to disable it. Default is true."
+          "default": "true"
         },
         "team_id": {
-          "type": "number",
-          "description": "The id of the team that will be granted access to this repository. This is only valid when creating a repository in an organization."
+          "type": "number"
         },
         "auto_init": {
           "type": "boolean",
-          "default": "false",
-          "description": "True to create an initial commit with empty README. Default is false"
+          "default": "false"
         },
         "gitignore_template": {
-          "type": "string",
-          "description": "Desired language or platform .gitignore template to apply. Ignored if auto_init parameter is not provided."
+          "type": "string"
         },
         "license_template": {
-          "type": "string",
-          "description": "Desired LICENSE template to apply. Use the name of the template without the extension. For example, \"mit\" or \"mozilla\"."
+          "type": "string"
         },
         "allow_squash_merge": {
           "type": "boolean",
-          "default": "true",
-          "description": "Either true to allow squash-merging pull requests, or false to prevent squash-merging. Default: true. (In preview period. See README.)"
+          "default": "true"
         },
         "allow_merge_commit": {
           "type": "boolean",
-          "default": "true",
-          "description": "Either true to allow merging pull requests with a merge commit, or false to prevent merging pull requests with merge commits. Default: true. (In preview period. See README.)"
+          "default": "true"
         },
         "allow_rebase_merge": {
           "type": "boolean",
-          "default": "true",
-          "description": "Either true to allow rebase-merging pull requests, or false to prevent rebase-merging. Default: true. (In preview period. See README.)"
+          "default": "true"
         }
-      },
-      "description": "Create a new repository for an organization."
+      }
     },
     "createHook": {
       "url": "/repos/:owner/:repo/hooks",
@@ -6960,20 +6240,16 @@
         },
         "config": {
           "type": "json",
-          "required": true,
-          "description": "A Hash containing key/value pairs to provide settings for this hook. These settings vary between the services and are defined in the github-services repo. Booleans are stored internally as `1` for true, and `0` for false. Any JSON true/false values will be converted automatically."
+          "required": true
         },
         "events": {
           "type": "string[]",
-          "default": "[\"push\"]",
-          "description": "Determines what events the hook is triggered for. Default: `['push']`."
+          "default": "[\"push\"]"
         },
         "active": {
-          "type": "boolean",
-          "description": "Determines whether the hook is actually triggered on pushes."
+          "type": "boolean"
         }
-      },
-      "description": "Create a hook."
+      }
     },
     "createRelease": {
       "url": "/repos/:owner/:repo/releases",
@@ -6989,12 +6265,10 @@
         },
         "tag_name": {
           "type": "string",
-          "required": true,
-          "description": "String of the tag"
+          "required": true
         },
         "target_commitish": {
-          "type": "string",
-          "description": "Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch (usually master)."
+          "type": "string"
         },
         "name": {
           "type": "string"
@@ -7004,16 +6278,13 @@
         },
         "draft": {
           "type": "boolean",
-          "default": "false",
-          "description": "true to create a draft (unpublished) release, false to create a published one. Default: false"
+          "default": "false"
         },
         "prerelease": {
           "type": "boolean",
-          "default": "false",
-          "description": "true to identify the release as a prerelease. false to identify the release as a full release. Default: false"
+          "default": "false"
         }
-      },
-      "description": "Create a release."
+      }
     },
     "createStatus": {
       "url": "/repos/:owner/:repo/statuses/:sha",
@@ -7039,23 +6310,18 @@
             "success",
             "error",
             "failure"
-          ],
-          "description": "State of the status - can be one of pending, success, error, or failure."
+          ]
         },
         "target_url": {
-          "type": "string",
-          "description": "Target url to associate with this status. This URL will be linked from the GitHub UI to allow users to easily see the ‘source’ of the Status."
+          "type": "string"
         },
         "description": {
-          "type": "string",
-          "description": "Short description of the status."
+          "type": "string"
         },
         "context": {
-          "type": "string",
-          "description": "A string label to differentiate this status from the status of other systems."
+          "type": "string"
         }
-      },
-      "description": "Create a status."
+      }
     },
     "delete": {
       "url": "/repos/:owner/:repo",
@@ -7072,8 +6338,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a repository."
+      }
     },
     "deleteAsset": {
       "url": "/repos/:owner/:repo/releases/assets/:id",
@@ -7091,8 +6356,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a release asset."
+      }
     },
     "deleteCommitComment": {
       "url": "/repos/:owner/:repo/comments/:id",
@@ -7110,8 +6374,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a commit comment."
+      }
     },
     "deleteDeployKey": {
       "url": "/repos/:owner/:repo/keys/:id",
@@ -7129,8 +6392,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Remove a deploy key."
+      }
     },
     "deleteDownload": {
       "url": "/repos/:owner/:repo/downloads/:id",
@@ -7148,8 +6410,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a download."
+      }
     },
     "deleteFile": {
       "url": "/repos/:owner/:repo/contents/:path",
@@ -7165,22 +6426,18 @@
         },
         "path": {
           "type": "string",
-          "required": true,
-          "description": "The content path."
+          "required": true
         },
         "message": {
           "type": "string",
-          "required": true,
-          "description": "The commit message."
+          "required": true
         },
         "sha": {
           "type": "string",
-          "required": true,
-          "description": "The blob SHA of the file being removed."
+          "required": true
         },
         "branch": {
-          "type": "string",
-          "description": "The branch name. If not provided, uses the repository’s default branch (usually master)."
+          "type": "string"
         },
         "committer": {
           "type": "json"
@@ -7188,8 +6445,7 @@
         "author": {
           "type": "json"
         }
-      },
-      "description": "Delete a file."
+      }
     },
     "deleteHook": {
       "url": "/repos/:owner/:repo/hooks/:id",
@@ -7207,8 +6463,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Deleate a hook."
+      }
     },
     "deleteInvite": {
       "url": "/repos/:owner/:repo/invitations/:invitation_id",
@@ -7226,8 +6481,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a repository invitation."
+      }
     },
     "deleteRelease": {
       "url": "/repos/:owner/:repo/releases/:id",
@@ -7245,8 +6499,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a release"
+      }
     },
     "edit": {
       "url": "/repos/:owner/:repo",
@@ -7275,45 +6528,36 @@
         },
         "private": {
           "type": "boolean",
-          "default": "false",
-          "description": "True to create a private repository, false to create a public one. Creating private repositories requires a paid GitHub account. Default is false."
+          "default": "false"
         },
         "has_issues": {
           "type": "boolean",
-          "default": "true",
-          "description": "True to enable issues for this repository, false to disable them. Default is true."
+          "default": "true"
         },
         "has_projects": {
           "type": "boolean",
-          "default": "true",
-          "description": "True to enable projects for this repository, false to disable them. Default is true."
+          "default": "true"
         },
         "has_wiki": {
           "type": "boolean",
-          "default": "true",
-          "description": "True to enable the wiki for this repository, false to disable it. Default is true."
+          "default": "true"
         },
         "default_branch": {
-          "type": "string",
-          "description": "Updates the default branch for this repository."
+          "type": "string"
         },
         "allow_squash_merge": {
           "type": "boolean",
-          "default": "true",
-          "description": "Either true to allow squash-merging pull requests, or false to prevent squash-merging. Default: true. (In preview period. See README.)"
+          "default": "true"
         },
         "allow_merge_commit": {
           "type": "boolean",
-          "default": "true",
-          "description": "Either true to allow merging pull requests with a merge commit, or false to prevent merging pull requests with merge commits. Default: true. (In preview period. See README.)"
+          "default": "true"
         },
         "allow_rebase_merge": {
           "type": "boolean",
-          "default": "true",
-          "description": "Either true to allow rebase-merging pull requests, or false to prevent rebase-merging. Default: true. (In preview period. See README.)"
+          "default": "true"
         }
-      },
-      "description": "Update a repo."
+      }
     },
     "editAsset": {
       "url": "/repos/:owner/:repo/releases/assets/:id",
@@ -7336,11 +6580,9 @@
           "required": true
         },
         "label": {
-          "type": "string",
-          "description": "An alternate short description of the asset. Used in place of the filename."
+          "type": "string"
         }
-      },
-      "description": "Edit a release asset."
+      }
     },
     "editHook": {
       "url": "/repos/:owner/:repo/hooks/:id",
@@ -7364,28 +6606,22 @@
         },
         "config": {
           "type": "json",
-          "required": true,
-          "description": "A Hash containing key/value pairs to provide settings for this hook. Modifying this will replace the entire config object. These settings vary between the services and are defined in the github-services repo. Booleans are stored internally as `1` for true, and `0` for false. Any JSON true/false values will be converted automatically."
+          "required": true
         },
         "events": {
           "type": "string[]",
-          "default": "[\"push\"]",
-          "description": "Determines what events the hook is triggered for. This replaces the entire array of events. Default: `['push']`."
+          "default": "[\"push\"]"
         },
         "add_events": {
-          "type": "string[]",
-          "description": "Determines a list of events to be added to the list of events that the Hook triggers for."
+          "type": "string[]"
         },
         "remove_events": {
-          "type": "string[]",
-          "description": "Determines a list of events to be removed from the list of events that the Hook triggers for."
+          "type": "string[]"
         },
         "active": {
-          "type": "boolean",
-          "description": "Determines whether the hook is actually triggered on pushes."
+          "type": "boolean"
         }
-      },
-      "description": "Edit a hook."
+      }
     },
     "editRelease": {
       "url": "/repos/:owner/:repo/releases/:id",
@@ -7405,12 +6641,10 @@
         },
         "tag_name": {
           "type": "string",
-          "required": true,
-          "description": "String of the tag"
+          "required": true
         },
         "target_commitish": {
-          "type": "string",
-          "description": "Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch (usually master)."
+          "type": "string"
         },
         "name": {
           "type": "string"
@@ -7420,16 +6654,13 @@
         },
         "draft": {
           "type": "boolean",
-          "default": "false",
-          "description": "true to create a draft (unpublished) release, false to create a published one. Default: false"
+          "default": "false"
         },
         "prerelease": {
           "type": "boolean",
-          "default": "false",
-          "description": "true to identify the release as a prerelease. false to identify the release as a full release. Default: false"
+          "default": "false"
         }
-      },
-      "description": "Edit a release."
+      }
     },
     "fork": {
       "url": "/repos/:owner/:repo/forks",
@@ -7444,11 +6675,9 @@
           "required": true
         },
         "organization": {
-          "type": "string",
-          "description": "Optional parameter to specify the organization name if forking into an organization."
+          "type": "string"
         }
-      },
-      "description": "Create a fork."
+      }
     },
     "get": {
       "url": "/repos/:owner/:repo",
@@ -7465,8 +6694,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a repo for a user."
+      }
     },
     "getAll": {
       "url": "/user/repos",
@@ -7479,13 +6707,11 @@
             "public",
             "private"
           ],
-          "default": "all",
-          "description": "Can be one of `all`, `public`, or `private`. Default: `all`."
+          "default": "all"
         },
         "affiliation": {
           "type": "string",
-          "default": "owner,collaborator,organization_member",
-          "description": "Comma-separated list of values. Can include: `owner`, `collaborator`, `organization_member`."
+          "default": "owner,collaborator,organization_member"
         },
         "type": {
           "type": "string",
@@ -7496,8 +6722,7 @@
             "private",
             "member"
           ],
-          "default": "all",
-          "description": "Possible values: `all`, `owner`, `public`, `private`, `member`. Default: `all`."
+          "default": "all"
         },
         "sort": {
           "type": "string",
@@ -7507,8 +6732,7 @@
             "pushed",
             "full_name"
           ],
-          "default": "full_name",
-          "description": "Possible values: `created`, `updated`, `pushed`, `full_name`. Default: `full_name`."
+          "default": "full_name"
         },
         "direction": {
           "type": "string",
@@ -7519,16 +6743,13 @@
           "default": "desc"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List your repositories"
+      }
     },
     "getAllCommitComments": {
       "url": "/repos/:owner/:repo/comments",
@@ -7543,16 +6764,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List commit comments for a repository."
+      }
     },
     "getArchiveLink": {
       "url": "/repos/:owner/:repo/:archive_format/:ref",
@@ -7573,15 +6791,12 @@
             "tarball",
             "zipball"
           ],
-          "default": "tarball",
-          "description": "Either tarball or zipball, Deafult: tarball."
+          "default": "tarball"
         },
         "ref": {
-          "type": "string",
-          "description": "A valid Git reference. Default: the repository’s default branch (usually master)."
+          "type": "string"
         }
-      },
-      "description": "Get archive link."
+      }
     },
     "getAsset": {
       "url": "/repos/:owner/:repo/releases/assets/:id",
@@ -7599,8 +6814,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single release asset."
+      }
     },
     "getAssets": {
       "url": "/repos/:owner/:repo/releases/:id/assets",
@@ -7618,8 +6832,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "List assets for a release."
+      }
     },
     "getBranch": {
       "url": "/repos/:owner/:repo/branches/:branch",
@@ -7638,16 +6851,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get branch."
+      }
     },
     "getBranchProtection": {
       "url": "/repos/:owner/:repo/branches/:branch/protection",
@@ -7666,16 +6876,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get branch protection."
+      }
     },
     "getBranches": {
       "url": "/repos/:owner/:repo/branches",
@@ -7690,20 +6897,16 @@
           "required": true
         },
         "protected": {
-          "type": "boolean",
-          "description": "Set to true to only return protected branches"
+          "type": "boolean"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List branches."
+      }
     },
     "getById": {
       "url": "/repositories/:id",
@@ -7711,11 +6914,9 @@
       "params": {
         "id": {
           "type": "string",
-          "required": true,
-          "description": "Numerical ID of the repository."
+          "required": true
         }
-      },
-      "description": "Get a single repo by id."
+      }
     },
     "getClones": {
       "url": "/repos/:owner/:repo/traffic/clones",
@@ -7730,16 +6931,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get the total number of clones and breakdown per day or week for the last 14 days."
+      }
     },
     "getCollaborators": {
       "url": "/repos/:owner/:repo/collaborators",
@@ -7760,20 +6958,16 @@
             "all",
             "direct"
           ],
-          "default": "all",
-          "description": "Filter collaborators returned by their affiliation."
+          "default": "all"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List collaborators"
+      }
     },
     "getCombinedStatusForRef": {
       "url": "/repos/:owner/:repo/commits/:ref/status",
@@ -7789,20 +6983,16 @@
         },
         "ref": {
           "type": "string",
-          "required": true,
-          "description": "Ref to fetch the status for. It can be a SHA, a branch name, or a tag name."
+          "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get the combined status for a specific ref."
+      }
     },
     "getCommit": {
       "url": "/repos/:owner/:repo/commits/:sha",
@@ -7823,8 +7013,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single commit."
+      }
     },
     "getCommitComment": {
       "url": "/repos/:owner/:repo/comments/:id",
@@ -7842,8 +7031,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single commit comment."
+      }
     },
     "getCommitComments": {
       "url": "/repos/:owner/:repo/commits/:ref/comments",
@@ -7862,16 +7050,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List comments for a single commit."
+      }
     },
     "getCommits": {
       "url": "/repos/:owner/:repo/commits",
@@ -7886,36 +7071,28 @@
           "required": true
         },
         "sha": {
-          "type": "string",
-          "description": "Sha or branch to start listing commits from."
+          "type": "string"
         },
         "path": {
-          "type": "string",
-          "description": "Only commits containing this file path will be returned."
+          "type": "string"
         },
         "author": {
-          "type": "string",
-          "description": "GitHub login or email address by which to filter by commit author."
+          "type": "string"
         },
         "since": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+          "type": "date"
         },
         "until": {
-          "type": "date",
-          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+          "type": "date"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List commits on a repository."
+      }
     },
     "getCommunityProfileMetrics": {
       "url": "/repos/:owner/:name/community/profile",
@@ -7932,8 +7109,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Retrieve community profile metrics."
+      }
     },
     "getContent": {
       "url": "/repos/:owner/:repo/contents/:path",
@@ -7950,15 +7126,12 @@
         "path": {
           "type": "string",
           "required": true,
-          "allow-empty": true,
-          "description": "The content path."
+          "allow-empty": true
         },
         "ref": {
-          "type": "string",
-          "description": "The String name of the Commit/Branch/Tag. Defaults to master."
+          "type": "string"
         }
-      },
-      "description": "Get the contents of a file or directory in a repository."
+      }
     },
     "getContributors": {
       "url": "/repos/:owner/:repo/contributors",
@@ -7973,20 +7146,16 @@
           "required": true
         },
         "anon": {
-          "type": "boolean",
-          "description": "Set to 1 or true to include anonymous contributors in results."
+          "type": "boolean"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get contributors for the specified repository."
+      }
     },
     "getDeployKey": {
       "url": "/repos/:owner/:repo/keys/:id",
@@ -8004,8 +7173,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a deploy key."
+      }
     },
     "getDeployKeys": {
       "url": "/repos/:owner/:repo/keys",
@@ -8020,16 +7188,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List deploy keys."
+      }
     },
     "getDeployment": {
       "url": "/repos/:owner/:repo/deployments/:deployment_id",
@@ -8045,11 +7210,9 @@
         },
         "deployment_id": {
           "type": "string",
-          "required": true,
-          "description": "The deployment id."
+          "required": true
         }
-      },
-      "description": "Get a single Deployment. (In preview period. See README.)"
+      }
     },
     "getDeploymentStatus": {
       "url": "/repos/:owner/:repo/deployments/:id/statuses/:status_id",
@@ -8065,16 +7228,13 @@
         },
         "id": {
           "type": "string",
-          "required": true,
-          "description": "The Deployment ID to list the statuses from."
+          "required": true
         },
         "status_id": {
           "type": "string",
-          "required": true,
-          "description": "The Deployment Status ID."
+          "required": true
         }
-      },
-      "description": "List deployment statuses. (In preview period. See README.)"
+      }
     },
     "getDeploymentStatuses": {
       "url": "/repos/:owner/:repo/deployments/:id/statuses",
@@ -8095,8 +7255,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "List deployment statuses. (In preview period. See README.)"
+      }
     },
     "getDeployments": {
       "url": "/repos/:owner/:repo/deployments",
@@ -8115,35 +7274,28 @@
         },
         "sha": {
           "type": "string",
-          "default": "none",
-          "description": "The short or long sha that was recorded at creation time. Default: none."
+          "default": "none"
         },
         "ref": {
           "type": "string",
-          "default": "none",
-          "description": "The name of the ref. This can be a branch, tag, or sha. Default: none."
+          "default": "none"
         },
         "task": {
           "type": "string",
-          "default": "none",
-          "description": "The name of the task for the deployment. e.g. deploy or deploy:migrations. Default: none."
+          "default": "none"
         },
         "environment": {
           "type": "string",
-          "default": "none",
-          "description": "The name of the environment that was deployed to. e.g. staging or production. Default: none."
+          "default": "none"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List deployments."
+      }
     },
     "getDownload": {
       "url": "/repos/:owner/:repo/downloads/:id",
@@ -8161,8 +7313,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single download."
+      }
     },
     "getDownloads": {
       "url": "/repos/:owner/:repo/downloads",
@@ -8177,16 +7328,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List downloads for a repository."
+      }
     },
     "getForOrg": {
       "url": "/orgs/:org/repos",
@@ -8206,20 +7354,16 @@
             "sources",
             "member"
           ],
-          "default": "all",
-          "description": "Possible values: `all`, `public`, `private`, `forks`, `sources`, `member`. Default: `all`."
+          "default": "all"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List repositories for the specified org."
+      }
     },
     "getForUser": {
       "url": "/users/:username/repos",
@@ -8236,8 +7380,7 @@
             "owner",
             "member"
           ],
-          "default": "owner",
-          "description": "Possible values: `all`, `owner`, `member`. Default: `owner`."
+          "default": "owner"
         },
         "sort": {
           "type": "string",
@@ -8247,8 +7390,7 @@
             "pushed",
             "full_name"
           ],
-          "default": "full_name",
-          "description": "Possible values: `created`, `updated`, `pushed`, `full_name`. Default: `full_name`."
+          "default": "full_name"
         },
         "direction": {
           "type": "string",
@@ -8259,16 +7401,13 @@
           "default": "desc"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List public repositories for the specified user."
+      }
     },
     "getForks": {
       "url": "/repos/:owner/:repo/forks",
@@ -8289,20 +7428,16 @@
             "oldest",
             "stargazers"
           ],
-          "default": "newest",
-          "description": "Possible values: `newest`, `oldest`, `stargazers`, default: `newest`."
+          "default": "newest"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List forks."
+      }
     },
     "getHook": {
       "url": "/repos/:owner/:repo/hooks/:id",
@@ -8320,8 +7455,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get single hook."
+      }
     },
     "getHooks": {
       "url": "/repos/:owner/:repo/hooks",
@@ -8336,16 +7470,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List hooks."
+      }
     },
     "getInvites": {
       "url": "/repos/:owner/:repo/invitations",
@@ -8359,8 +7490,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "List invitations for a repository."
+      }
     },
     "getLanguages": {
       "url": "/repos/:owner/:repo/languages",
@@ -8375,16 +7505,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get languages for the specified repository."
+      }
     },
     "getLatestPagesBuild": {
       "url": "/repos/:owner/:repo/pages/builds/latest",
@@ -8401,8 +7528,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get latest Pages build. (In preview period. See README.)"
+      }
     },
     "getLatestRelease": {
       "url": "/repos/:owner/:repo/releases/latest",
@@ -8416,8 +7542,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get the latest release."
+      }
     },
     "getPages": {
       "url": "/repos/:owner/:repo/pages",
@@ -8435,16 +7560,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get information about a Pages site. (In preview period. See README.)"
+      }
     },
     "getPagesBuild": {
       "url": "/repos/:owner/:repo/pages/builds/:id",
@@ -8465,8 +7587,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a specific Pages build. (In preview period. See README.)"
+      }
     },
     "getPagesBuilds": {
       "url": "/repos/:owner/:repo/pages/builds",
@@ -8484,16 +7605,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List Pages builds. (In preview period. See README.)"
+      }
     },
     "getPaths": {
       "url": "/repos/:owner/:repo/traffic/popular/paths",
@@ -8508,16 +7626,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get the top 10 popular contents over the last 14 days."
+      }
     },
     "getProtectedBranchAdminEnforcement": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins",
@@ -8536,16 +7651,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get admin enforcement of protected branch."
+      }
     },
     "getProtectedBranchPullRequestReviewEnforcement": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews",
@@ -8564,16 +7676,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get pull request review enforcement of protected branch."
+      }
     },
     "getProtectedBranchRequiredStatusChecks": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks",
@@ -8592,16 +7701,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get required status checks of protected branch."
+      }
     },
     "getProtectedBranchRequiredStatusChecksContexts": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
@@ -8620,16 +7726,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List required status checks contexts of protected branch."
+      }
     },
     "getProtectedBranchRestrictions": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions",
@@ -8648,16 +7751,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get restrictions of protected branch."
+      }
     },
     "getProtectedBranchTeamRestrictions": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
@@ -8676,16 +7776,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List team restrictions of protected branch."
+      }
     },
     "getProtectedBranchUserRestrictions": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
@@ -8704,36 +7801,29 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List user restrictions of protected branch."
+      }
     },
     "getPublic": {
       "url": "/repositories",
       "method": "GET",
       "params": {
         "since": {
-          "type": "string",
-          "description": "The integer ID of the last Repository that you've seen."
+          "type": "string"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List all public repositories"
+      }
     },
     "getReadme": {
       "url": "/repos/:owner/:repo/readme",
@@ -8748,11 +7838,9 @@
           "required": true
         },
         "ref": {
-          "type": "string",
-          "description": "The name of the commit/branch/tag. Default: the repository’s default branch (usually master)"
+          "type": "string"
         }
-      },
-      "description": "Get the README for the given repository."
+      }
     },
     "getReferrers": {
       "url": "/repos/:owner/:repo/traffic/popular/referrers",
@@ -8767,16 +7855,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get the top 10 referrers over the last 14 days."
+      }
     },
     "getRelease": {
       "url": "/repos/:owner/:repo/releases/:id",
@@ -8794,8 +7879,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single release."
+      }
     },
     "getReleaseByTag": {
       "url": "/repos/:owner/:repo/releases/tags/:tag",
@@ -8811,11 +7895,9 @@
         },
         "tag": {
           "type": "string",
-          "required": true,
-          "description": "String of the tag"
+          "required": true
         }
-      },
-      "description": "Get a release by tag name."
+      }
     },
     "getReleases": {
       "url": "/repos/:owner/:repo/releases",
@@ -8830,16 +7912,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List releases for a repository."
+      }
     },
     "getShaOfCommitRef": {
       "url": "/repos/:owner/:repo/commits/:ref",
@@ -8856,11 +7935,9 @@
         "ref": {
           "type": "string",
           "required": true,
-          "allow-empty": true,
-          "description": "String of the name of the fully qualified reference (ie: heads/master). If it doesn’t have at least one slash, it will be rejected."
+          "allow-empty": true
         }
-      },
-      "description": "Get the SHA-1 of a commit reference."
+      }
     },
     "getStatsCodeFrequency": {
       "url": "/repos/:owner/:repo/stats/code_frequency",
@@ -8874,8 +7951,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get the number of additions and deletions per week."
+      }
     },
     "getStatsCommitActivity": {
       "url": "/repos/:owner/:repo/stats/commit_activity",
@@ -8889,8 +7965,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get the last year of commit activity data."
+      }
     },
     "getStatsContributors": {
       "url": "/repos/:owner/:repo/stats/contributors",
@@ -8904,8 +7979,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get contributors list with additions, deletions, and commit counts."
+      }
     },
     "getStatsParticipation": {
       "url": "/repos/:owner/:repo/stats/participation",
@@ -8919,8 +7993,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get the weekly commit count for the repository owner and everyone else."
+      }
     },
     "getStatsPunchCard": {
       "url": "/repos/:owner/:repo/stats/punch_card",
@@ -8934,8 +8007,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get the number of commits per hour in each day."
+      }
     },
     "getStatuses": {
       "url": "/repos/:owner/:repo/commits/:ref/statuses",
@@ -8951,20 +8023,16 @@
         },
         "ref": {
           "type": "string",
-          "required": true,
-          "description": "Ref to list the statuses from. It can be a SHA, a branch name, or a tag name."
+          "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List statuses for a specfic ref."
+      }
     },
     "getTags": {
       "url": "/repos/:owner/:repo/tags",
@@ -8979,16 +8047,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get tags for the specified repository."
+      }
     },
     "getTeams": {
       "url": "/repos/:owner/:repo/teams",
@@ -9003,16 +8068,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get teams for the specified repository."
+      }
     },
     "getTopics": {
       "url": "/repos/:owner/:repo/topics",
@@ -9030,16 +8092,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List all topics for a repository. (In preview period. See README.)"
+      }
     },
     "getViews": {
       "url": "/repos/:owner/:repo/traffic/views",
@@ -9054,16 +8113,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get the total number of views and breakdown per day or week for the last 14 days."
+      }
     },
     "merge": {
       "url": "/repos/:owner/:repo/merges",
@@ -9079,20 +8135,16 @@
         },
         "base": {
           "type": "string",
-          "required": true,
-          "description": "The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo."
+          "required": true
         },
         "head": {
           "type": "string",
-          "required": true,
-          "description": "The branch (or git ref) where your changes are implemented."
+          "required": true
         },
         "commit_message": {
-          "type": "string",
-          "description": "Commit message to use for the merge commit. If omitted, a default message will be used."
+          "type": "string"
         }
-      },
-      "description": "Perform a merge."
+      }
     },
     "pingHook": {
       "url": "/repos/:owner/:repo/hooks/:id/pings",
@@ -9110,8 +8162,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Ping a hook."
+      }
     },
     "removeBranchProtection": {
       "url": "/repos/:owner/:repo/branches/:branch/protection",
@@ -9129,8 +8180,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Remove branch protection."
+      }
     },
     "removeCollaborator": {
       "url": "/repos/:owner/:repo/collaborators/:username",
@@ -9148,8 +8198,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Remove user as a collaborator."
+      }
     },
     "removeProtectedBranchAdminEnforcement": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins",
@@ -9167,8 +8216,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Remove admin enforcement of protected branch."
+      }
     },
     "removeProtectedBranchPullRequestReviewEnforcement": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews",
@@ -9186,8 +8234,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Remove pull request review enforcement of protected branch."
+      }
     },
     "removeProtectedBranchRequiredStatusChecks": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks",
@@ -9205,8 +8252,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Remove required status checks of protected branch."
+      }
     },
     "removeProtectedBranchRequiredStatusChecksContexts": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
@@ -9227,11 +8273,9 @@
         "contexts": {
           "type": "string[]",
           "required": true,
-          "mapTo": "input",
-          "description": "An array of protected branch required status checks contexts (e.g. continuous-integration/jenkins)."
+          "mapTo": "input"
         }
-      },
-      "description": "Remove required status checks contexts of protected branch."
+      }
     },
     "removeProtectedBranchRestrictions": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions",
@@ -9249,8 +8293,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Remove restrictions of protected branch."
+      }
     },
     "removeProtectedBranchTeamRestrictions": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
@@ -9271,11 +8314,9 @@
         "teams": {
           "type": "string[]",
           "required": true,
-          "mapTo": "input",
-          "description": "An array of team slugs (e.g. justice-league)."
+          "mapTo": "input"
         }
-      },
-      "description": "Remove team restrictions of protected branch."
+      }
     },
     "removeProtectedBranchUserRestrictions": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
@@ -9296,11 +8337,9 @@
         "users": {
           "type": "string[]",
           "required": true,
-          "mapTo": "input",
-          "description": "An array of team slugs (e.g. justice-league)."
+          "mapTo": "input"
         }
-      },
-      "description": "Remove user restrictions of protected branch."
+      }
     },
     "replaceProtectedBranchRequiredStatusChecksContexts": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
@@ -9321,11 +8360,9 @@
         "contexts": {
           "type": "string[]",
           "required": true,
-          "mapTo": "input",
-          "description": "An array of protected branch required status checks contexts (e.g. continuous-integration/jenkins)."
+          "mapTo": "input"
         }
-      },
-      "description": "Replace required status checks contexts of protected branch."
+      }
     },
     "replaceProtectedBranchTeamRestrictions": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
@@ -9346,11 +8383,9 @@
         "teams": {
           "type": "string[]",
           "required": true,
-          "mapTo": "input",
-          "description": "An array of team slugs (e.g. justice-league)."
+          "mapTo": "input"
         }
-      },
-      "description": "Replace team restrictions of protected branch."
+      }
     },
     "replaceProtectedBranchUserRestrictions": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
@@ -9371,11 +8406,9 @@
         "users": {
           "type": "string[]",
           "required": true,
-          "mapTo": "input",
-          "description": "An array of team slugs (e.g. justice-league)."
+          "mapTo": "input"
         }
-      },
-      "description": "Replace user restrictions of protected branch."
+      }
     },
     "replaceTopics": {
       "url": "/repos/:owner/:repo/topics",
@@ -9394,11 +8427,9 @@
         },
         "names": {
           "type": "string[]",
-          "required": true,
-          "description": "An array of topics to add to the repository. Pass one or more topics to replace the set of existing topics. Send an empty array ([]) to clear all topics from the repository."
+          "required": true
         }
-      },
-      "description": "Replace all topics for a repository. (In preview period. See README.)"
+      }
     },
     "requestPageBuild": {
       "url": "/repos/:owner/:repo/pages/builds",
@@ -9415,8 +8446,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Request a page build. (In preview period. See README.)"
+      }
     },
     "reviewUserPermissionLevel": {
       "url": "/repos/:owner/:repo/collaborators/:username/permission",
@@ -9434,8 +8464,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Review a user's permission level."
+      }
     },
     "testHook": {
       "url": "/repos/:owner/:repo/hooks/:id/tests",
@@ -9453,8 +8482,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Test a [push] hook."
+      }
     },
     "updateBranchProtection": {
       "url": "/repos/:owner/:repo/branches/:branch/protection",
@@ -9475,43 +8503,35 @@
         "required_status_checks": {
           "type": "json",
           "required": true,
-          "allow-null": true,
-          "description": "JSON object that contains the following keys: `include_admins` - Enforce required status checks for repository administrators, `strict` - Require branches to be up to date before merging, `contexts` - The list of status checks to require in order to merge into this branch. This object can have the value of `null` for disabled."
+          "allow-null": true
         },
         "required_pull_request_reviews": {
           "type": "json",
           "required": true,
-          "allow-null": true,
-          "description": "JSON object that contains the following keys: `include_admins` - Enforce required status checks for repository administrators."
+          "allow-null": true
         },
         "dismissal_restrictions": {
           "type": "json",
-          "allow-null": true,
-          "description": "JSON object that contains the following keys: `users` - The list of user logins with dismissal access, `teams` - The list of team slugs with dismissal access. This object can have the value of `null` for disabled."
+          "allow-null": true
         },
         "restrictions": {
           "type": "json",
           "required": true,
-          "allow-null": true,
-          "description": "JSON object that contains the following keys: `users` - The list of user logins with push access, `teams` - The list of team slugs with push access. This object can have the value of `null` for disabled."
+          "allow-null": true
         },
         "enforce_admins": {
           "type": "boolean",
           "required": true,
-          "allow-null": false,
-          "description": "Enforces required status checks for repository administrators."
+          "allow-null": false
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Update branch protection."
+      }
     },
     "updateCommitComment": {
       "url": "/repos/:owner/:repo/comments/:id",
@@ -9533,8 +8553,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Update a commit comment."
+      }
     },
     "updateFile": {
       "url": "/repos/:owner/:repo/contents/:path",
@@ -9550,27 +8569,22 @@
         },
         "path": {
           "type": "string",
-          "required": true,
-          "description": "The content path."
+          "required": true
         },
         "message": {
           "type": "string",
-          "required": true,
-          "description": "The commit message."
+          "required": true
         },
         "content": {
           "type": "string",
-          "required": true,
-          "description": "The updated file content, Base64 encoded."
+          "required": true
         },
         "sha": {
           "type": "string",
-          "required": true,
-          "description": "The blob SHA of the file being replaced."
+          "required": true
         },
         "branch": {
-          "type": "string",
-          "description": "The branch name. If not provided, uses the repository’s default branch (usually master)."
+          "type": "string"
         },
         "committer": {
           "type": "json"
@@ -9578,8 +8592,7 @@
         "author": {
           "type": "json"
         }
-      },
-      "description": "Update a file."
+      }
     },
     "updateInvite": {
       "url": "/repos/:owner/:repo/invitations/:invitation_id",
@@ -9603,11 +8616,9 @@
             "read",
             "write",
             "admin"
-          ],
-          "description": "The permissions that the associated user will have on the repository."
+          ]
         }
-      },
-      "description": "Update a repository invitation."
+      }
     },
     "updateProtectedBranchPullRequestReviewEnforcement": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews",
@@ -9627,19 +8638,15 @@
         },
         "dismissal_restrictions": {
           "type": "json",
-          "allow-null": true,
-          "description": "JSON object that contains the following keys: `users` - The list of user logins with dismissal access, `teams` - The list of team slugs with dismissal access. This object can have the value of `null` for disabled."
+          "allow-null": true
         },
         "dismiss_stale_reviews": {
-          "type": "boolean",
-          "description": "Dismiss approved reviews automatically when a new commit is pushed."
+          "type": "boolean"
         },
         "require_code_owner_reviews": {
-          "type": "boolean",
-          "description": "Blocks merge until code owners have reviewed."
+          "type": "boolean"
         }
-      },
-      "description": "Update pull request review enforcement of protected branch."
+      }
     },
     "updateProtectedBranchRequiredStatusChecks": {
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks",
@@ -9658,15 +8665,12 @@
           "required": true
         },
         "strict": {
-          "type": "boolean",
-          "description": "Require branches to be up to date before merging."
+          "type": "boolean"
         },
         "contexts": {
-          "type": "string[]",
-          "description": "The list of status checks to require in order to merge into this branch."
+          "type": "string[]"
         }
-      },
-      "description": "Update required status checks of protected branch."
+      }
     },
     "uploadAsset": {
       "method": "POST",
@@ -9674,38 +8678,31 @@
       "params": {
         "url": {
           "type": "string",
-          "required": true,
-          "description": "This endpoint makes use of a Hypermedia relation (https://developer.github.com/v3/#hypermedia) to determine which URL to access. This endpoint is provided by a URI template in the release's API response (https://developer.github.com/v3/repos/releases/#get-a-single-release). You need to use an HTTP client which supports SNI (https://en.wikipedia.org/wiki/Server_Name_Indication) to make calls to this endpoint."
+          "required": true
         },
         "file": {
           "type": "string | object",
           "required": true,
-          "mapTo": "input",
-          "description": "A file read stream, a String or a Buffer."
+          "mapTo": "input"
         },
         "contentType": {
           "type": "string",
           "required": true,
-          "mapTo": "headers.content-type",
-          "description": "The content type of the asset. This should be set in the Header. Example: 'application/zip'. For a list of acceptable types, refer this list of media types (https://www.iana.org/assignments/media-types/media-types.xhtml)"
+          "mapTo": "headers.content-type"
         },
         "contentLength": {
           "type": "number",
           "required": true,
-          "mapTo": "headers.content-length",
-          "description": "File size in bytes."
+          "mapTo": "headers.content-length"
         },
         "name": {
           "type": "string",
-          "required": true,
-          "description": "The file name of the asset. This should be set in a URI query parameter."
+          "required": true
         },
         "label": {
-          "type": "string",
-          "description": "An alternate short description of the asset. Used in place of the filename. This should be set in a URI query parameter."
+          "type": "string"
         }
-      },
-      "description": "Upload a release asset."
+      }
     }
   },
   "search": {
@@ -9715,15 +8712,13 @@
       "params": {
         "q": {
           "type": "string",
-          "required": true,
-          "description": "Search Term"
+          "required": true
         },
         "sort": {
           "type": "string",
           "enum": [
             "indexed"
-          ],
-          "description": "The sort field. Can only be indexed, which indicates how recently a file has been indexed by the GitHub search infrastructure. Default: results are sorted by best match."
+          ]
         },
         "order": {
           "type": "string",
@@ -9731,20 +8726,16 @@
             "asc",
             "desc"
           ],
-          "default": "desc",
-          "description": "asc or desc"
+          "default": "desc"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Search code."
+      }
     },
     "commits": {
       "url": "/search/commits",
@@ -9755,16 +8746,14 @@
       "params": {
         "q": {
           "type": "string",
-          "required": true,
-          "description": "Search Term"
+          "required": true
         },
         "sort": {
           "type": "string",
           "enum": [
             "author-date",
             "committer-date"
-          ],
-          "description": "The sort field. Can be author-date or committer-date. Default: best match."
+          ]
         },
         "order": {
           "type": "string",
@@ -9772,20 +8761,16 @@
             "asc",
             "desc"
           ],
-          "default": "desc",
-          "description": "asc or desc"
+          "default": "desc"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Search commits. (In preview period. See README.)"
+      }
     },
     "issues": {
       "url": "/search/issues",
@@ -9793,8 +8778,7 @@
       "params": {
         "q": {
           "type": "string",
-          "required": true,
-          "description": "Search Term"
+          "required": true
         },
         "sort": {
           "type": "string",
@@ -9802,8 +8786,7 @@
             "comments",
             "created",
             "updated"
-          ],
-          "description": "The sort field. Can be comments, created, or updated. Default: results are sorted by best match."
+          ]
         },
         "order": {
           "type": "string",
@@ -9811,20 +8794,16 @@
             "asc",
             "desc"
           ],
-          "default": "desc",
-          "description": "asc or desc"
+          "default": "desc"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Search issues."
+      }
     },
     "repos": {
       "url": "/search/repositories",
@@ -9835,8 +8814,7 @@
       "params": {
         "q": {
           "type": "string",
-          "required": true,
-          "description": "Search Term"
+          "required": true
         },
         "sort": {
           "type": "string",
@@ -9844,8 +8822,7 @@
             "stars",
             "forks",
             "updated"
-          ],
-          "description": "stars, forks, or updated"
+          ]
         },
         "order": {
           "type": "string",
@@ -9853,20 +8830,16 @@
             "asc",
             "desc"
           ],
-          "default": "desc",
-          "description": "asc or desc"
+          "default": "desc"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Search repositories."
+      }
     },
     "users": {
       "url": "/search/users",
@@ -9874,8 +8847,7 @@
       "params": {
         "q": {
           "type": "string",
-          "required": true,
-          "description": "Search Term"
+          "required": true
         },
         "sort": {
           "type": "string",
@@ -9883,8 +8855,7 @@
             "followers",
             "repositories",
             "joined"
-          ],
-          "description": "The sort field. Can be followers, repositories, or joined. Default: results are sorted by best match."
+          ]
         },
         "order": {
           "type": "string",
@@ -9892,20 +8863,16 @@
             "asc",
             "desc"
           ],
-          "default": "desc",
-          "description": "asc or desc"
+          "default": "desc"
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Search users."
+      }
     }
   },
   "users": {
@@ -9917,8 +8884,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Accept a repository invitation."
+      }
     },
     "addEmails": {
       "url": "/user/emails",
@@ -9927,11 +8893,9 @@
         "emails": {
           "type": "string[]",
           "required": true,
-          "mapTo": "input",
-          "description": "You can post a single email address or an array of addresses."
+          "mapTo": "input"
         }
-      },
-      "description": "Add email address(es)."
+      }
     },
     "addRepoToInstallation": {
       "url": "/user/installations/:installation_id/repositories/:repository_id",
@@ -9948,8 +8912,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Add a single repository to an installation. (In preview period. See README.)"
+      }
     },
     "blockUser": {
       "url": "/user/blocks/:username",
@@ -9962,8 +8925,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Block a user. (In preview period. See README.)"
+      }
     },
     "checkBlockedUser": {
       "url": "/user/blocks/:username",
@@ -9976,8 +8938,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Check whether you've blocked a user. (In preview period. See README.)"
+      }
     },
     "checkFollowing": {
       "url": "/user/following/:username",
@@ -9987,8 +8948,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Check if you are following a user"
+      }
     },
     "checkIfOneFollowersOther": {
       "url": "/users/:username/following/:target_user",
@@ -10002,8 +8962,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Check if one user follows another"
+      }
     },
     "createGpgKey": {
       "url": "/user/gpg_keys",
@@ -10014,11 +8973,9 @@
       "params": {
         "armored_public_key": {
           "type": "string",
-          "required": true,
-          "description": "GPG key contents"
+          "required": true
         }
-      },
-      "description": "Create a GPG key. (In preview period. See README.)"
+      }
     },
     "createKey": {
       "url": "/user/keys",
@@ -10032,8 +8989,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Create a public key"
+      }
     },
     "declineRepoInvite": {
       "url": "/user/repository_invitations/:invitation_id",
@@ -10043,8 +8999,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Decline a repository invitation."
+      }
     },
     "deleteEmails": {
       "url": "/user/emails",
@@ -10053,11 +9008,9 @@
         "emails": {
           "type": "string[]",
           "required": true,
-          "mapTo": "input",
-          "description": "You can post a single email address or an array of addresses."
+          "mapTo": "input"
         }
-      },
-      "description": "Delete email address(es)."
+      }
     },
     "deleteGpgKey": {
       "url": "/user/gpg_keys/:id",
@@ -10070,8 +9023,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a GPG key. (In preview period. See README.)"
+      }
     },
     "deleteKey": {
       "url": "/user/keys/:id",
@@ -10081,8 +9033,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Delete a public key"
+      }
     },
     "demote": {
       "url": "/users/:username/site_admin",
@@ -10092,8 +9043,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Demote a site administrator to an ordinary user"
+      }
     },
     "editOrgMembership": {
       "url": "/user/memberships/orgs/:org",
@@ -10108,11 +9058,9 @@
           "required": true,
           "enum": [
             "active"
-          ],
-          "description": "The state that the membership should be in. Only \"active\" will be accepted."
+          ]
         }
-      },
-      "description": "Edit your organization membership."
+      }
     },
     "followUser": {
       "url": "/user/following/:username",
@@ -10122,25 +9070,21 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Follow a user"
+      }
     },
     "get": {
       "url": "/user",
       "method": "GET",
-      "params": {},
-      "description": "Get the authenticated user"
+      "params": {}
     },
     "getAll": {
       "url": "/users",
       "method": "GET",
       "params": {
         "since": {
-          "type": "number",
-          "description": "The integer ID of the last User that you’ve seen."
+          "type": "number"
         }
-      },
-      "description": "Get all users"
+      }
     },
     "getBlockedUsers": {
       "url": "/user/blocks",
@@ -10148,8 +9092,7 @@
       "headers": {
         "accept": "application/vnd.github.giant-sentry-fist-preview+json"
       },
-      "params": {},
-      "description": "List blocked users. (In preview period. See README.)"
+      "params": {}
     },
     "getById": {
       "url": "/user/:id",
@@ -10157,43 +9100,35 @@
       "params": {
         "id": {
           "type": "string",
-          "required": true,
-          "description": "Numerical ID of the user."
+          "required": true
         }
-      },
-      "description": "Get a single user by GitHub ID. This method uses numerical user ID. Use users.getForUser method if you need to get a user by username."
+      }
     },
     "getEmails": {
       "url": "/user/emails",
       "method": "GET",
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List email addresses for a user."
+      }
     },
     "getFollowers": {
       "url": "/user/followers",
       "method": "GET",
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List the authenticated user's followers"
+      }
     },
     "getFollowersForUser": {
       "url": "/users/:username/followers",
@@ -10204,32 +9139,26 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List a user's followers"
+      }
     },
     "getFollowing": {
       "url": "/user/following",
       "method": "GET",
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List who the authenticated user is following"
+      }
     },
     "getFollowingForUser": {
       "url": "/users/:username/following",
@@ -10240,16 +9169,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List who a user is following"
+      }
     },
     "getForUser": {
       "url": "/users/:username",
@@ -10259,8 +9185,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single user"
+      }
     },
     "getGpgKey": {
       "url": "/user/gpg_keys/:id",
@@ -10273,8 +9198,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single GPG key. (In preview period. See README.)"
+      }
     },
     "getGpgKeys": {
       "url": "/user/gpg_keys",
@@ -10284,16 +9208,13 @@
       },
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List your GPG keys. (In preview period. See README.)"
+      }
     },
     "getGpgKeysForUser": {
       "url": "/users/:username/gpg_keys",
@@ -10307,16 +9228,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Lists the GPG keys for a user. This information is accessible by anyone. (In preview period. See README.)"
+      }
     },
     "getInstallationRepos": {
       "url": "/user/installations/:installation_id/repositories",
@@ -10327,16 +9245,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List repositories accessible to the user for an installation. (In preview period. See README.)"
+      }
     },
     "getInstallations": {
       "url": "/user/installations",
@@ -10346,16 +9261,13 @@
       },
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List installations. (In preview period. See README.)"
+      }
     },
     "getKey": {
       "url": "/user/keys/:id",
@@ -10365,24 +9277,20 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get a single public key"
+      }
     },
     "getKeys": {
       "url": "/user/keys",
       "method": "GET",
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List your public keys"
+      }
     },
     "getKeysForUser": {
       "url": "/users/:username/keys",
@@ -10393,16 +9301,13 @@
           "required": true
         },
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List public keys for a user"
+      }
     },
     "getMarketplacePurchases": {
       "url": "/user/marketplace_purchases",
@@ -10412,16 +9317,13 @@
       },
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get a user's Marketplace purchases. (In preview period. See README.)"
+      }
     },
     "getMarketplaceStubbedPurchases": {
       "url": "/user/marketplace_purchases/stubbed",
@@ -10431,16 +9333,13 @@
       },
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get a user's stubbed Marketplace purchases. (In preview period. See README.)"
+      }
     },
     "getOrgMembership": {
       "url": "/user/memberships/orgs/:org",
@@ -10450,8 +9349,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Get your organization membership"
+      }
     },
     "getOrgMemberships": {
       "url": "/user/memberships/orgs",
@@ -10462,49 +9360,40 @@
           "enum": [
             "active",
             "pending"
-          ],
-          "description": "Indicates the state of the memberships to return. Can be either active or pending. If not specified, both active and pending memberships are returned."
+          ]
         }
-      },
-      "description": "List your organization memberships"
+      }
     },
     "getOrgs": {
       "url": "/user/orgs",
       "method": "GET",
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List organizations for the authenticated user."
+      }
     },
     "getPublicEmails": {
       "url": "/user/public_emails",
       "method": "GET",
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "List public email addresses for a user."
+      }
     },
     "getRepoInvites": {
       "url": "/user/repository_invitations",
       "method": "GET",
-      "params": {},
-      "description": "List a user's repository invitations."
+      "params": {}
     },
     "getTeams": {
       "url": "/user/teams",
@@ -10514,16 +9403,13 @@
       },
       "params": {
         "page": {
-          "type": "number",
-          "description": "Page number of the results to fetch."
+          "type": "number"
         },
         "per_page": {
           "type": "number",
-          "default": "30",
-          "description": "A custom page size up to 100. Default is 30."
+          "default": "30"
         }
-      },
-      "description": "Get your teams."
+      }
     },
     "promote": {
       "url": "/users/:username/site_admin",
@@ -10533,8 +9419,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Promote an ordinary user to a site administrator"
+      }
     },
     "removeRepoFromInstallation": {
       "url": "/user/installations/:installation_id/repositories/:repository_id",
@@ -10551,8 +9436,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Remove a single repository from an installation. (In preview period. See README.)"
+      }
     },
     "suspend": {
       "url": "/users/:username/suspended",
@@ -10562,14 +9446,12 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Suspend a user"
+      }
     },
     "togglePrimaryEmailVisibility": {
       "url": "/user/email/visibility",
       "method": "PATCH",
-      "params": {},
-      "description": "Toggle primary email visibility."
+      "params": {}
     },
     "unblockUser": {
       "url": "/user/blocks/:username",
@@ -10582,8 +9464,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Unblock a user. (In preview period. See README.)"
+      }
     },
     "unfollowUser": {
       "url": "/user/following/:username",
@@ -10593,8 +9474,7 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Unfollow a user"
+      }
     },
     "unsuspend": {
       "url": "/users/:username/suspended",
@@ -10604,43 +9484,34 @@
           "type": "string",
           "required": true
         }
-      },
-      "description": "Unsuspend a user"
+      }
     },
     "update": {
       "url": "/user",
       "method": "PATCH",
       "params": {
         "name": {
-          "type": "string",
-          "description": "The new name of the user"
+          "type": "string"
         },
         "email": {
-          "type": "string",
-          "description": "Publicly visible email address."
+          "type": "string"
         },
         "blog": {
-          "type": "string",
-          "description": "The new blog URL of the user."
+          "type": "string"
         },
         "company": {
-          "type": "string",
-          "description": "The new company of the user."
+          "type": "string"
         },
         "location": {
-          "type": "string",
-          "description": "The new location of the user."
+          "type": "string"
         },
         "hireable": {
-          "type": "boolean",
-          "description": "The new hiring availability of the user."
+          "type": "boolean"
         },
         "bio": {
-          "type": "string",
-          "description": "The new short biography of the user."
+          "type": "string"
         }
-      },
-      "description": "Update the authenticated user"
+      }
     }
   }
 }

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -2952,11 +2952,9 @@
       "method": "PATCH",
       "params": {
         "color": {
-          "required": true,
           "type": "string"
         },
         "name": {
-          "required": true,
           "type": "string"
         },
         "oldname": {

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -2866,9 +2866,9 @@
     "removeAssigneesFromIssue": {
       "method": "DELETE",
       "params": {
-        "body": {
+        "assignees": {
           "required": true,
-          "type": "json"
+          "type": "string[]"
         },
         "number": {
           "required": true,

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -3177,7 +3177,7 @@
       }
     },
     "getLargeImportFiles": {
-      "url": "/:owner/:name/import/large_files",
+      "url": "/repos/:owner/:repo/import/large_files",
       "method": "GET",
       "headers": {
         "accept": "application/vnd.github.barred-rock-preview"
@@ -3188,6 +3188,10 @@
           "required": true
         },
         "name": {
+          "alias": "repo",
+          "deprecated": "`name` parameter has been renamed to `repo`"
+        },
+        "repo": {
           "type": "string",
           "required": true
         }
@@ -3275,7 +3279,7 @@
       }
     },
     "setImportLfsPreference": {
-      "url": "/:owner/:name/import/lfs",
+      "url": "/repos/:owner/:repo/import/lfs",
       "method": "PATCH",
       "headers": {
         "accept": "application/vnd.github.barred-rock-preview"
@@ -3286,6 +3290,10 @@
           "required": true
         },
         "name": {
+          "alias": "repo",
+          "deprecated": "`name` parameter has been renamed to `repo`"
+        },
+        "repo": {
           "type": "string",
           "required": true
         },

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -3002,7 +3002,6 @@
           "type": "string"
         },
         "title": {
-          "required": true,
           "type": "string"
         }
       },

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -592,9 +592,6 @@
         "installation_id": {
           "required": true,
           "type": "string"
-        },
-        "user_id": {
-          "type": "string"
         }
       },
       "url": "/installations/:installation_id/access_tokens"
@@ -635,11 +632,7 @@
         "accept": "application/vnd.github.machine-man-preview"
       },
       "method": "GET",
-      "params": {
-        "user_id": {
-          "type": "string"
-        }
-      },
+      "params": {},
       "url": "/installation/repositories"
     },
     "getInstallations": {
@@ -1891,9 +1884,6 @@
         "installation_id": {
           "required": true,
           "type": "string"
-        },
-        "user_id": {
-          "type": "string"
         }
       },
       "url": "/installations/:installation_id/access_tokens"
@@ -1904,11 +1894,7 @@
         "accept": "application/vnd.github.machine-man-preview"
       },
       "method": "GET",
-      "params": {
-        "user_id": {
-          "type": "string"
-        }
-      },
+      "params": {},
       "url": "/installation/repositories"
     },
     "getInstallations": {

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -1829,7 +1829,15 @@
     "getReference": {
       "method": "GET",
       "params": {
+        "owner": {
+          "required": true,
+          "type": "string"
+        },
         "ref": {
+          "required": true,
+          "type": "string"
+        },
+        "repo": {
           "required": true,
           "type": "string"
         }

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -234,7 +234,7 @@
           "type": "boolean"
         },
         "since": {
-          "type": "date"
+          "type": "string"
         }
       },
       "url": "/notifications"
@@ -260,7 +260,7 @@
           "type": "string"
         },
         "since": {
-          "type": "date"
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/notifications"
@@ -1355,7 +1355,7 @@
           "type": "number"
         },
         "since": {
-          "type": "date"
+          "type": "string"
         }
       },
       "url": "/gists"
@@ -1404,7 +1404,7 @@
           "type": "number"
         },
         "since": {
-          "type": "date"
+          "type": "string"
         },
         "username": {
           "required": true,
@@ -1433,7 +1433,7 @@
       "method": "GET",
       "params": {
         "since": {
-          "type": "date"
+          "type": "string"
         }
       },
       "url": "/gists/public"
@@ -1456,7 +1456,7 @@
       "method": "GET",
       "params": {
         "since": {
-          "type": "date"
+          "type": "string"
         }
       },
       "url": "/gists/starred"
@@ -2061,7 +2061,7 @@
           "type": "string"
         },
         "due_on": {
-          "type": "date"
+          "type": "string"
         },
         "owner": {
           "required": true,
@@ -2269,7 +2269,7 @@
           "type": "number"
         },
         "since": {
-          "type": "date"
+          "type": "string"
         },
         "sort": {
           "enum": [
@@ -2350,7 +2350,7 @@
           "type": "string"
         },
         "since": {
-          "type": "date"
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/:number/comments"
@@ -2383,7 +2383,7 @@
           "type": "string"
         },
         "since": {
-          "type": "date"
+          "type": "string"
         },
         "sort": {
           "enum": [
@@ -2529,7 +2529,7 @@
           "type": "number"
         },
         "since": {
-          "type": "date"
+          "type": "string"
         },
         "sort": {
           "enum": [
@@ -2594,7 +2594,7 @@
           "type": "string"
         },
         "since": {
-          "type": "date"
+          "type": "string"
         },
         "sort": {
           "enum": [
@@ -2648,7 +2648,7 @@
           "type": "number"
         },
         "since": {
-          "type": "date"
+          "type": "string"
         },
         "sort": {
           "enum": [
@@ -2955,7 +2955,7 @@
           "type": "string"
         },
         "due_on": {
-          "type": "date"
+          "type": "string"
         },
         "number": {
           "required": true,
@@ -5063,7 +5063,7 @@
           "type": "string"
         },
         "since": {
-          "type": "date"
+          "type": "string"
         },
         "sort": {
           "enum": [
@@ -6853,10 +6853,10 @@
           "type": "string"
         },
         "since": {
-          "type": "date"
+          "type": "string"
         },
         "until": {
-          "type": "date"
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/commits"

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -1,24 +1,19 @@
 {
   "activity": {
     "checkNotificationThreadSubscription": {
-      "url": "/notifications/threads/:id/subscription",
       "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/notifications/threads/:id/subscription"
     },
     "checkStarringRepo": {
-      "url": "/user/starred/:owner/:repo",
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -28,21 +23,25 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/user/starred/:owner/:repo"
     },
     "deleteNotificationThreadSubscription": {
-      "url": "/notifications/threads/:id/subscription",
       "method": "DELETE",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/notifications/threads/:id/subscription"
     },
     "getEvents": {
-      "url": "/events",
       "method": "GET",
       "params": {
         "page": {
@@ -52,10 +51,10 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/events"
     },
     "getEventsForOrg": {
-      "url": "/orgs/:org/events",
       "method": "GET",
       "params": {
         "org": {
@@ -69,17 +68,13 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/orgs/:org/events"
     },
     "getEventsForRepo": {
-      "url": "/repos/:owner/:repo/events",
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -89,18 +84,18 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/events"
     },
     "getEventsForRepoIssues": {
-      "url": "/repos/:owner/:repo/issues/events",
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -110,55 +105,55 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/issues/events"
     },
     "getEventsForRepoNetwork": {
-      "url": "/networks/:owner/:repo/events",
       "method": "GET",
       "params": {
         "owner": {
           "type": "string",
           "required": true
         },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
         "repo": {
           "type": "string",
           "required": true
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
         }
-      }
+      },
+      "url": "/networks/:owner/:repo/events"
     },
     "getEventsForUser": {
-      "url": "/users/:username/events",
       "method": "GET",
       "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        },
         "page": {
           "type": "number"
         },
         "per_page": {
           "type": "number",
           "default": "30"
-        }
-      }
-    },
-    "getEventsForUserOrg": {
-      "url": "/users/:username/events/orgs/:org",
-      "method": "GET",
-      "params": {
+        },
         "username": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/users/:username/events"
+    },
+    "getEventsForUserOrg": {
+      "method": "GET",
+      "params": {
         "org": {
           "type": "string",
           "required": true
@@ -169,82 +164,89 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "username": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/users/:username/events/orgs/:org"
     },
     "getEventsForUserPublic": {
-      "url": "/users/:username/events/public",
       "method": "GET",
       "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        },
         "page": {
           "type": "number"
         },
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "username": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/users/:username/events/public"
     },
     "getEventsReceived": {
-      "url": "/users/:username/received_events",
       "method": "GET",
       "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        },
         "page": {
           "type": "number"
         },
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "username": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/users/:username/received_events"
     },
     "getEventsReceivedPublic": {
-      "url": "/users/:username/received_events/public",
       "method": "GET",
       "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        },
         "page": {
           "type": "number"
         },
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "username": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/users/:username/received_events/public"
     },
     "getFeeds": {
-      "url": "/feeds",
       "method": "GET",
-      "params": {}
+      "params": {},
+      "url": "/feeds"
     },
     "getNotificationThread": {
-      "url": "/notifications/threads/:id",
       "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/notifications/threads/:id"
     },
     "getNotifications": {
-      "url": "/notifications",
       "method": "GET",
       "params": {
         "all": {
           "type": "boolean",
           "default": "false"
+        },
+        "before": {
+          "type": "string"
         },
         "participating": {
           "type": "boolean",
@@ -252,49 +254,42 @@
         },
         "since": {
           "type": "date"
-        },
-        "before": {
-          "type": "string"
         }
-      }
+      },
+      "url": "/notifications"
     },
     "getNotificationsForUser": {
-      "url": "/repos/:owner/:repo/notifications",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "all": {
           "type": "boolean",
           "default": "false"
+        },
+        "before": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string",
+          "required": true
         },
         "participating": {
           "type": "boolean",
           "default": "false"
         },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
         "since": {
           "type": "date"
-        },
-        "before": {
-          "type": "string"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/notifications"
     },
     "getRepoSubscription": {
-      "url": "/repos/:owner/:repo/subscription",
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -304,21 +299,21 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/subscription"
     },
     "getStargazersForRepo": {
-      "url": "/repos/:owner/:repo/stargazers",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.v3.star+json"
       },
+      "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -328,24 +323,20 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/stargazers"
     },
     "getStarredRepos": {
-      "url": "/user/starred",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.v3.star+json"
       },
+      "method": "GET",
       "params": {
-        "sort": {
-          "type": "string",
-          "enum": [
-            "created",
-            "updated"
-          ],
-          "default": "created"
-        },
         "direction": {
           "type": "string",
           "enum": [
@@ -360,28 +351,24 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "sort": {
+          "type": "string",
+          "enum": [
+            "created",
+            "updated"
+          ],
+          "default": "created"
         }
-      }
+      },
+      "url": "/user/starred"
     },
     "getStarredReposForUser": {
-      "url": "/users/:username/starred",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.v3.star+json"
       },
+      "method": "GET",
       "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        },
-        "sort": {
-          "type": "string",
-          "enum": [
-            "created",
-            "updated"
-          ],
-          "default": "created"
-        },
         "direction": {
           "type": "string",
           "enum": [
@@ -396,30 +383,25 @@
         "per_page": {
           "type": "number",
           "default": "30"
-        }
-      }
-    },
-    "getWatchedRepos": {
-      "url": "/user/subscriptions",
-      "method": "GET",
-      "params": {
-        "page": {
-          "type": "number"
         },
-        "per_page": {
-          "type": "number",
-          "default": "30"
-        }
-      }
-    },
-    "getWatchedReposForUser": {
-      "url": "/users/:username/subscriptions",
-      "method": "GET",
-      "params": {
+        "sort": {
+          "type": "string",
+          "enum": [
+            "created",
+            "updated"
+          ],
+          "default": "created"
+        },
         "username": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/users/:username/starred"
+    },
+    "getWatchedRepos": {
+      "method": "GET",
+      "params": {
         "page": {
           "type": "number"
         },
@@ -427,53 +409,74 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/user/subscriptions"
+    },
+    "getWatchedReposForUser": {
+      "method": "GET",
+      "params": {
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
+        "username": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/users/:username/subscriptions"
     },
     "getWatchersForRepo": {
-      "url": "/repos/:owner/:repo/subscribers",
       "method": "GET",
       "params": {
         "owner": {
           "type": "string",
           "required": true
         },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "page": {
           "type": "number"
         },
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/subscribers"
     },
     "markNotificationThreadAsRead": {
-      "url": "/notifications/threads/:id",
       "method": "PATCH",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/notifications/threads/:id"
     },
     "markNotificationsAsRead": {
-      "url": "/notifications",
       "method": "PUT",
       "params": {
         "last_read_at": {
           "type": "string",
           "default": "Time.now"
         }
-      }
+      },
+      "url": "/notifications"
     },
     "markNotificationsAsReadForRepo": {
-      "url": "/repos/:owner/:repo/notifications",
       "method": "PUT",
       "params": {
+        "last_read_at": {
+          "type": "string",
+          "default": "Time.now"
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -481,33 +484,32 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "last_read_at": {
-          "type": "string",
-          "default": "Time.now"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/notifications"
     },
     "setNotificationThreadSubscription": {
-      "url": "/notifications/threads/:id/subscription",
       "method": "PUT",
       "params": {
         "id": {
           "type": "string",
           "required": true
         },
-        "subscribed": {
-          "type": "boolean"
-        },
         "ignored": {
           "type": "boolean"
+        },
+        "subscribed": {
+          "type": "boolean"
         }
-      }
+      },
+      "url": "/notifications/threads/:id/subscription"
     },
     "setRepoSubscription": {
-      "url": "/repos/:owner/:repo/subscription",
       "method": "PUT",
       "params": {
+        "ignored": {
+          "type": "boolean"
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -518,14 +520,11 @@
         },
         "subscribed": {
           "type": "boolean"
-        },
-        "ignored": {
-          "type": "boolean"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/subscription"
     },
     "starRepo": {
-      "url": "/user/starred/:owner/:repo",
       "method": "PUT",
       "params": {
         "owner": {
@@ -536,10 +535,10 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/starred/:owner/:repo"
     },
     "unstarRepo": {
-      "url": "/user/starred/:owner/:repo",
       "method": "DELETE",
       "params": {
         "owner": {
@@ -550,10 +549,10 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/starred/:owner/:repo"
     },
     "unwatchRepo": {
-      "url": "/repos/:owner/:repo/subscription",
       "method": "DELETE",
       "params": {
         "owner": {
@@ -564,16 +563,16 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/subscription"
     }
   },
   "apps": {
     "addRepoToInstallation": {
-      "url": "/user/installations/:installation_id/repositories/:repository_id",
-      "method": "PUT",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
+      "method": "PUT",
       "params": {
         "installation_id": {
           "type": "string",
@@ -583,40 +582,40 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/installations/:installation_id/repositories/:repository_id"
     },
     "checkMarketplaceListingAccount": {
-      "url": "/marketplace_listing/accounts/:id",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.valkyrie-preview+json"
       },
+      "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/marketplace_listing/accounts/:id"
     },
     "checkMarketplaceListingStubbedAccount": {
-      "url": "/marketplace_listing/stubbed/accounts/:id",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.valkyrie-preview+json"
       },
+      "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/marketplace_listing/stubbed/accounts/:id"
     },
     "createInstallationToken": {
-      "url": "/installations/:installation_id/access_tokens",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
+      "method": "POST",
       "params": {
         "installation_id": {
           "type": "string",
@@ -625,57 +624,57 @@
         "user_id": {
           "type": "string"
         }
-      }
+      },
+      "url": "/installations/:installation_id/access_tokens"
     },
     "get": {
-      "url": "/app",
       "method": "GET",
-      "params": {}
+      "params": {},
+      "url": "/app"
     },
     "getForSlug": {
-      "url": "/apps/:app_slug",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
+      "method": "GET",
       "params": {
         "app_slug": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/apps/:app_slug"
     },
     "getInstallation": {
-      "url": "/app/installations/:installation_id",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
+      "method": "GET",
       "params": {
         "installation_id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/app/installations/:installation_id"
     },
     "getInstallationRepositories": {
-      "url": "/installation/repositories",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
+      "method": "GET",
       "params": {
         "user_id": {
           "type": "string"
         }
-      }
+      },
+      "url": "/installation/repositories"
     },
     "getInstallations": {
-      "url": "/app/installations",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
+      "method": "GET",
       "params": {
         "page": {
           "type": "number"
@@ -684,14 +683,14 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/app/installations"
     },
     "getMarketplaceListingPlanAccounts": {
-      "url": "/marketplace_listing/plans/:id/accounts",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.valkyrie-preview+json"
       },
+      "method": "GET",
       "params": {
         "id": {
           "type": "string",
@@ -704,14 +703,14 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/marketplace_listing/plans/:id/accounts"
     },
     "getMarketplaceListingPlans": {
-      "url": "/marketplace_listing/plans",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.valkyrie-preview+json"
       },
+      "method": "GET",
       "params": {
         "page": {
           "type": "number"
@@ -720,14 +719,14 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/marketplace_listing/plans"
     },
     "getMarketplaceListingStubbedPlanAccounts": {
-      "url": "/marketplace_listing/stubbed/plans/:id/accounts",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.valkyrie-preview+json"
       },
+      "method": "GET",
       "params": {
         "id": {
           "type": "string",
@@ -740,14 +739,14 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/marketplace_listing/stubbed/plans/:id/accounts"
     },
     "getMarketplaceListingStubbedPlans": {
-      "url": "/marketplace_listing/stubbed/plans",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.valkyrie-preview+json"
       },
+      "method": "GET",
       "params": {
         "page": {
           "type": "number"
@@ -756,14 +755,14 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/marketplace_listing/stubbed/plans"
     },
     "removeRepoFromInstallation": {
-      "url": "/user/installations/:installation_id/repositories/:repository_id",
-      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
+      "method": "DELETE",
       "params": {
         "installation_id": {
           "type": "string",
@@ -773,36 +772,27 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/installations/:installation_id/repositories/:repository_id"
     }
   },
   "authorization": {
     "check": {
-      "url": "/applications/:client_id/tokens/:access_token",
       "method": "GET",
       "params": {
-        "client_id": {
-          "type": "string"
-        },
         "access_token": {
           "type": "string",
           "required": true
+        },
+        "client_id": {
+          "type": "string"
         }
-      }
+      },
+      "url": "/applications/:client_id/tokens/:access_token"
     },
     "create": {
-      "url": "/authorizations",
       "method": "POST",
       "params": {
-        "scopes": {
-          "type": "string[]"
-        },
-        "note": {
-          "type": "string"
-        },
-        "note_url": {
-          "type": "string"
-        },
         "client_id": {
           "type": "string"
         },
@@ -811,41 +801,50 @@
         },
         "fingerprint": {
           "type": "string"
+        },
+        "note": {
+          "type": "string"
+        },
+        "note_url": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "string[]"
         }
-      }
+      },
+      "url": "/authorizations"
     },
     "delete": {
-      "url": "/authorizations/:id",
       "method": "DELETE",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/authorizations/:id"
     },
     "deleteGrant": {
-      "url": "/applications/grants/:id",
       "method": "DELETE",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/applications/grants/:id"
     },
     "get": {
-      "url": "/authorizations/:id",
       "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/authorizations/:id"
     },
     "getAll": {
-      "url": "/authorizations",
       "method": "GET",
       "params": {
         "page": {
@@ -855,10 +854,10 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/authorizations"
     },
     "getGrant": {
-      "url": "/applications/grants/:id",
       "method": "GET",
       "params": {
         "id": {
@@ -872,10 +871,10 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/applications/grants/:id"
     },
     "getGrants": {
-      "url": "/applications/grants",
       "method": "GET",
       "params": {
         "page": {
@@ -885,10 +884,10 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/applications/grants"
     },
     "getOrCreateAuthorizationForApp": {
-      "url": "/authorizations/clients/:client_id",
       "method": "PUT",
       "params": {
         "client_id": {
@@ -898,8 +897,8 @@
           "type": "string",
           "required": true
         },
-        "scopes": {
-          "type": "string[]"
+        "fingerprint": {
+          "type": "string"
         },
         "note": {
           "type": "string"
@@ -907,146 +906,158 @@
         "note_url": {
           "type": "string"
         },
-        "fingerprint": {
-          "type": "string"
+        "scopes": {
+          "type": "string[]"
         }
-      }
+      },
+      "url": "/authorizations/clients/:client_id"
     },
     "getOrCreateAuthorizationForAppAndFingerprint": {
-      "url": "/authorizations/clients/:client_id/:fingerprint",
       "method": "PUT",
       "params": {
         "client_id": {
-          "type": "string"
-        },
-        "fingerprint": {
           "type": "string"
         },
         "client_secret": {
           "type": "string",
           "required": true
         },
-        "scopes": {
-          "type": "string[]"
+        "fingerprint": {
+          "type": "string"
         },
         "note": {
           "type": "string"
         },
         "note_url": {
           "type": "string"
+        },
+        "scopes": {
+          "type": "string[]"
         }
-      }
+      },
+      "url": "/authorizations/clients/:client_id/:fingerprint"
     },
     "reset": {
-      "url": "/applications/:client_id/tokens/:access_token",
       "method": "POST",
       "params": {
-        "client_id": {
-          "type": "string"
-        },
         "access_token": {
           "type": "string",
           "required": true
+        },
+        "client_id": {
+          "type": "string"
         }
-      }
+      },
+      "url": "/applications/:client_id/tokens/:access_token"
     },
     "revoke": {
-      "url": "/applications/:client_id/tokens/:access_token",
       "method": "DELETE",
       "params": {
-        "client_id": {
-          "type": "string"
-        },
         "access_token": {
           "type": "string",
           "required": true
+        },
+        "client_id": {
+          "type": "string"
         }
-      }
+      },
+      "url": "/applications/:client_id/tokens/:access_token"
     },
     "revokeGrant": {
-      "url": "/applications/:client_id/grants/:access_token",
       "method": "DELETE",
       "params": {
-        "client_id": {
-          "type": "string"
-        },
         "access_token": {
           "type": "string",
           "required": true
+        },
+        "client_id": {
+          "type": "string"
         }
-      }
+      },
+      "url": "/applications/:client_id/grants/:access_token"
     },
     "update": {
-      "url": "/authorizations/:id",
       "method": "PATCH",
       "params": {
+        "add_scopes": {
+          "type": "string[]"
+        },
+        "fingerprint": {
+          "type": "string"
+        },
         "id": {
           "type": "string",
           "required": true
         },
-        "scopes": {
-          "type": "string[]"
+        "note": {
+          "type": "string"
         },
-        "add_scopes": {
-          "type": "string[]"
+        "note_url": {
+          "type": "string"
         },
         "remove_scopes": {
           "type": "string[]"
         },
-        "note": {
-          "type": "string"
-        },
-        "note_url": {
-          "type": "string"
-        },
-        "fingerprint": {
-          "type": "string"
+        "scopes": {
+          "type": "string[]"
         }
-      }
+      },
+      "url": "/authorizations/:id"
     }
   },
   "enterprise": {
     "createOrg": {
-      "url": "/admin/organizations",
       "method": "POST",
       "params": {
-        "login": {
+        "admin": {
           "type": "string",
           "required": true
         },
-        "admin": {
+        "login": {
           "type": "string",
           "required": true
         },
         "profile_name": {
           "type": "string"
         }
-      }
+      },
+      "url": "/admin/organizations"
     },
     "createPreReceiveEnvironment": {
-      "url": "/admin/pre-receive-environments",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.eye-scream-preview"
       },
+      "method": "POST",
       "params": {
-        "name": {
-          "type": "string",
-          "required": true
-        },
         "image_url": {
           "type": "string",
           "required": true
+        },
+        "name": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/admin/pre-receive-environments"
     },
     "createPreReceiveHook": {
-      "url": "/admin/pre-receive-hooks",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.eye-scream-preview"
       },
+      "method": "POST",
       "params": {
+        "allow_downstream_configuration": {
+          "type": "boolean",
+          "default": "false"
+        },
+        "enforcement": {
+          "type": "string",
+          "default": "disabled"
+        },
+        "environment": {
+          "type": "json",
+          "required": true
+        },
         "name": {
           "type": "string",
           "required": true
@@ -1058,146 +1069,134 @@
         "script_repository": {
           "type": "json",
           "required": true
-        },
-        "environment": {
-          "type": "json",
-          "required": true
-        },
-        "enforcement": {
-          "type": "string",
-          "default": "disabled"
-        },
-        "allow_downstream_configuration": {
-          "type": "boolean",
-          "default": "false"
         }
-      }
+      },
+      "url": "/admin/pre-receive-hooks"
     },
     "deletePreReceiveEnvironment": {
-      "url": "/admin/pre-receive-environments/:id",
       "method": "DELETE",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/admin/pre-receive-environments/:id"
     },
     "deletePreReceiveHook": {
-      "url": "/admin/pre_receive_hooks/:id",
       "method": "DELETE",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/admin/pre_receive_hooks/:id"
     },
     "editPreReceiveEnvironment": {
-      "url": "/admin/pre-receive-environments/:id",
       "method": "PATCH",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
-        },
-        "name": {
           "type": "string",
           "required": true
         },
         "image_url": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "editPreReceiveHook": {
-      "url": "/admin/pre_receive_hooks/:id",
-      "method": "PATCH",
-      "params": {
-        "id": {
+        },
+        "name": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/admin/pre-receive-environments/:id"
+    },
+    "editPreReceiveHook": {
+      "method": "PATCH",
+      "params": {
         "hook": {
           "type": "json",
           "required": true,
           "mapTo": "input"
+        },
+        "id": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/admin/pre_receive_hooks/:id"
     },
     "getLicense": {
-      "url": "/enterprise/settings/license",
       "method": "GET",
-      "params": {}
+      "params": {},
+      "url": "/enterprise/settings/license"
     },
     "getPreReceiveEnvironment": {
-      "url": "/admin/pre-receive-environments/:id",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.eye-scream-preview"
       },
+      "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/admin/pre-receive-environments/:id"
     },
     "getPreReceiveEnvironmentDownloadStatus": {
-      "url": "/admin/pre-receive-environments/:id/downloads/latest",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.eye-scream-preview"
       },
+      "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/admin/pre-receive-environments/:id/downloads/latest"
     },
     "getPreReceiveEnvironments": {
-      "url": "/admin/pre-receive-environments",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.eye-scream-preview"
       },
-      "params": {}
+      "method": "GET",
+      "params": {},
+      "url": "/admin/pre-receive-environments"
     },
     "getPreReceiveHook": {
-      "url": "/admin/pre-receive-hooks/:id",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.eye-scream-preview"
       },
+      "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/admin/pre-receive-hooks/:id"
     },
     "getPreReceiveHooks": {
-      "url": "/admin/pre-receive-hooks",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.eye-scream-preview"
       },
-      "params": {}
+      "method": "GET",
+      "params": {},
+      "url": "/admin/pre-receive-hooks"
     },
     "queueIndexingJob": {
-      "url": "/staff/indexing_jobs",
       "method": "POST",
       "params": {
         "target": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/staff/indexing_jobs"
     },
     "stats": {
-      "url": "/enterprise/stats/:type",
       "method": "GET",
       "params": {
         "type": {
@@ -1217,124 +1216,124 @@
             "all"
           ]
         }
-      }
+      },
+      "url": "/enterprise/stats/:type"
     },
     "syncLdapForTeam": {
-      "url": "/admin/ldap/teams/:team_id/sync",
       "method": "POST",
       "params": {
         "team_id": {
           "type": "number",
           "required": true
         }
-      }
+      },
+      "url": "/admin/ldap/teams/:team_id/sync"
     },
     "syncLdapForUser": {
-      "url": "/admin/ldap/users/:username/sync",
       "method": "POST",
       "params": {
         "username": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/admin/ldap/users/:username/sync"
     },
     "triggerPreReceiveEnvironmentDownload": {
-      "url": "/admin/pre-receive-environments/:id/downloads",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.eye-scream-preview"
       },
+      "method": "POST",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/admin/pre-receive-environments/:id/downloads"
     },
     "updateLdapForTeam": {
-      "url": "/admin/ldap/teams/:team_id/mapping",
       "method": "PATCH",
       "params": {
+        "ldap_dn": {
+          "type": "string",
+          "required": true
+        },
         "team_id": {
           "type": "number",
           "required": true
-        },
+        }
+      },
+      "url": "/admin/ldap/teams/:team_id/mapping"
+    },
+    "updateLdapForUser": {
+      "method": "PATCH",
+      "params": {
         "ldap_dn": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "updateLdapForUser": {
-      "url": "/admin/ldap/users/:username/mapping",
-      "method": "PATCH",
-      "params": {
+        },
         "username": {
           "type": "string",
           "required": true
-        },
-        "ldap_dn": {
-          "type": "string",
-          "required": true
         }
-      }
+      },
+      "url": "/admin/ldap/users/:username/mapping"
     }
   },
   "gists": {
     "checkStar": {
-      "url": "/gists/:id/star",
       "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/gists/:id/star"
     },
     "create": {
-      "url": "/gists",
       "method": "POST",
       "params": {
+        "description": {
+          "type": "string"
+        },
         "files": {
           "type": "json",
           "required": true
-        },
-        "description": {
-          "type": "string"
         },
         "public": {
           "type": "boolean",
           "required": true
         }
-      }
+      },
+      "url": "/gists"
     },
     "createComment": {
-      "url": "/gists/:gist_id/comments",
       "method": "POST",
       "params": {
-        "gist_id": {
-          "type": "string",
-          "required": true
-        },
         "body": {
           "type": "string",
           "required": true
+        },
+        "gist_id": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/gists/:gist_id/comments"
     },
     "delete": {
-      "url": "/gists/:id",
       "method": "DELETE",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/gists/:id"
     },
     "deleteComment": {
-      "url": "/gists/:gist_id/comments/:id",
       "method": "DELETE",
       "params": {
         "gist_id": {
@@ -1345,35 +1344,39 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/gists/:gist_id/comments/:id"
     },
     "edit": {
-      "url": "/gists/:id",
       "method": "PATCH",
       "params": {
-        "id": {
-          "type": "string",
-          "required": true
+        "content": {
+          "type": "string"
         },
         "description": {
+          "type": "string"
+        },
+        "filename": {
           "type": "string"
         },
         "files": {
           "type": "json",
           "required": true
         },
-        "content": {
-          "type": "string"
-        },
-        "filename": {
-          "type": "string"
+        "id": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/gists/:id"
     },
     "editComment": {
-      "url": "/gists/:gist_id/comments/:id",
       "method": "PATCH",
       "params": {
+        "body": {
+          "type": "string",
+          "required": true
+        },
         "gist_id": {
           "type": "string",
           "required": true
@@ -1381,51 +1384,47 @@
         "id": {
           "type": "string",
           "required": true
-        },
-        "body": {
-          "type": "string",
-          "required": true
         }
-      }
+      },
+      "url": "/gists/:gist_id/comments/:id"
     },
     "fork": {
-      "url": "/gists/:id/forks",
       "method": "POST",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/gists/:id/forks"
     },
     "get": {
-      "url": "/gists/:id",
       "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/gists/:id"
     },
     "getAll": {
-      "url": "/gists",
       "method": "GET",
       "params": {
-        "since": {
-          "type": "date"
-        },
         "page": {
           "type": "number"
         },
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "since": {
+          "type": "date"
         }
-      }
+      },
+      "url": "/gists"
     },
     "getComment": {
-      "url": "/gists/:gist_id/comments/:id",
       "method": "GET",
       "params": {
         "gist_id": {
@@ -1436,50 +1435,50 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/gists/:gist_id/comments/:id"
     },
     "getComments": {
-      "url": "/gists/:gist_id/comments",
       "method": "GET",
       "params": {
         "gist_id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/gists/:gist_id/comments"
     },
     "getCommits": {
-      "url": "/gists/:id/commits",
       "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/gists/:id/commits"
     },
     "getForUser": {
-      "url": "/users/:username/gists",
       "method": "GET",
       "params": {
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
+        "since": {
+          "type": "date"
+        },
         "username": {
           "type": "string",
           "required": true
-        },
-        "since": {
-          "type": "date"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
         }
-      }
+      },
+      "url": "/users/:username/gists"
     },
     "getForks": {
-      "url": "/gists/:id/forks",
       "method": "GET",
       "params": {
         "id": {
@@ -1493,19 +1492,19 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/gists/:id/forks"
     },
     "getPublic": {
-      "url": "/gists/public",
       "method": "GET",
       "params": {
         "since": {
           "type": "date"
         }
-      }
+      },
+      "url": "/gists/public"
     },
     "getRevision": {
-      "url": "/gists/:id/:sha",
       "method": "GET",
       "params": {
         "id": {
@@ -1516,51 +1515,43 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/gists/:id/:sha"
     },
     "getStarred": {
-      "url": "/gists/starred",
       "method": "GET",
       "params": {
         "since": {
           "type": "date"
         }
-      }
+      },
+      "url": "/gists/starred"
     },
     "star": {
-      "url": "/gists/:id/star",
       "method": "PUT",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/gists/:id/star"
     },
     "unstar": {
-      "url": "/gists/:id/star",
       "method": "DELETE",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/gists/:id/star"
     }
   },
   "gitdata": {
     "createBlob": {
-      "url": "/repos/:owner/:repo/git/blobs",
       "method": "POST",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "content": {
           "type": "string",
           "required": true,
@@ -1569,13 +1560,7 @@
         "encoding": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "createCommit": {
-      "url": "/repos/:owner/:repo/git/commits",
-      "method": "POST",
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -1583,12 +1568,24 @@
         "repo": {
           "type": "string",
           "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/git/blobs"
+    },
+    "createCommit": {
+      "method": "POST",
+      "params": {
+        "author": {
+          "type": "json"
+        },
+        "committer": {
+          "type": "json"
         },
         "message": {
           "type": "string",
           "required": true
         },
-        "tree": {
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -1596,23 +1593,21 @@
           "type": "string[]",
           "required": true
         },
-        "author": {
-          "type": "json"
-        },
-        "committer": {
-          "type": "json"
-        }
-      }
-    },
-    "createReference": {
-      "url": "/repos/:owner/:repo/git/refs",
-      "method": "POST",
-      "params": {
-        "owner": {
+        "repo": {
           "type": "string",
           "required": true
         },
-        "repo": {
+        "tree": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/git/commits"
+    },
+    "createReference": {
+      "method": "POST",
+      "params": {
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -1620,16 +1615,28 @@
           "type": "string",
           "required": true
         },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
         "sha": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/git/refs"
     },
     "createTag": {
-      "url": "/repos/:owner/:repo/git/tags",
       "method": "POST",
       "params": {
+        "message": {
+          "type": "string",
+          "required": true
+        },
+        "object": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -1642,28 +1649,23 @@
           "type": "string",
           "required": true
         },
-        "message": {
-          "type": "string",
-          "required": true
-        },
-        "object": {
-          "type": "string",
+        "tagger": {
+          "type": "json",
           "required": true
         },
         "type": {
           "type": "string",
           "required": true
-        },
-        "tagger": {
-          "type": "json",
-          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/git/tags"
     },
     "createTree": {
-      "url": "/repos/:owner/:repo/git/trees",
       "method": "POST",
       "params": {
+        "base_tree": {
+          "type": "string"
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -1675,44 +1677,33 @@
         "tree": {
           "type": "json",
           "required": true
-        },
-        "base_tree": {
-          "type": "string"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/git/trees"
     },
     "deleteReference": {
-      "url": "/repos/:owner/:repo/git/refs/:ref",
       "method": "DELETE",
       "params": {
         "owner": {
           "type": "string",
           "required": true
         },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "ref": {
           "type": "string",
           "required": true,
           "allow-empty": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/git/refs/:ref"
     },
     "getBlob": {
-      "url": "/repos/:owner/:repo/git/blobs/:sha",
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "sha": {
           "type": "string",
           "required": true
         },
@@ -1722,11 +1713,19 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "sha": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/git/blobs/:sha"
     },
     "getCommit": {
-      "url": "/repos/:owner/:repo/git/commits/:sha",
       "method": "GET",
       "params": {
         "owner": {
@@ -1741,10 +1740,10 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/git/commits/:sha"
     },
     "getCommitSignatureVerification": {
-      "url": "/repos/:owner/:repo/git/commits/:sha",
       "method": "GET",
       "params": {
         "owner": {
@@ -1759,17 +1758,13 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/git/commits/:sha"
     },
     "getReference": {
-      "url": "/repos/:owner/:repo/git/refs/:ref",
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -1777,18 +1772,18 @@
           "type": "string",
           "required": true,
           "allow-empty": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/git/refs/:ref"
     },
     "getReferences": {
-      "url": "/repos/:owner/:repo/git/refs",
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -1798,11 +1793,15 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/git/refs"
     },
     "getTag": {
-      "url": "/repos/:owner/:repo/git/tags/:sha",
       "method": "GET",
       "params": {
         "owner": {
@@ -1817,10 +1816,10 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/git/tags/:sha"
     },
     "getTagSignatureVerification": {
-      "url": "/repos/:owner/:repo/git/tags/:sha",
       "method": "GET",
       "params": {
         "owner": {
@@ -1835,17 +1834,13 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/git/tags/:sha"
     },
     "getTags": {
-      "url": "/repos/:owner/:repo/git/refs/tags",
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -1855,39 +1850,43 @@
         "per_page": {
           "type": "number",
           "default": "30"
-        }
-      }
-    },
-    "getTree": {
-      "url": "/repos/:owner/:repo/git/trees/:sha",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
         },
         "repo": {
           "type": "string",
           "required": true
-        },
-        "sha": {
+        }
+      },
+      "url": "/repos/:owner/:repo/git/refs/tags"
+    },
+    "getTree": {
+      "method": "GET",
+      "params": {
+        "owner": {
           "type": "string",
           "required": true
         },
         "recursive": {
           "type": "boolean"
-        }
-      }
-    },
-    "updateReference": {
-      "url": "/repos/:owner/:repo/git/refs/:ref",
-      "method": "PATCH",
-      "params": {
-        "owner": {
+        },
+        "repo": {
           "type": "string",
           "required": true
         },
-        "repo": {
+        "sha": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/git/trees/:sha"
+    },
+    "updateReference": {
+      "method": "PATCH",
+      "params": {
+        "force": {
+          "type": "boolean",
+          "default": "false"
+        },
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -1896,25 +1895,25 @@
           "required": true,
           "allow-empty": true
         },
-        "sha": {
+        "repo": {
           "type": "string",
           "required": true
         },
-        "force": {
-          "type": "boolean",
-          "default": "false"
+        "sha": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/git/refs/:ref"
     }
   },
   "integrations": {
     "addRepoToInstallation": {
-      "url": "/user/installations/:installation_id/repositories/:repository_id",
-      "method": "PUT",
       "deprecated": "`integrations` has been renamed to `apps`",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
+      "method": "PUT",
       "params": {
         "installation_id": {
           "type": "string",
@@ -1924,15 +1923,15 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/installations/:installation_id/repositories/:repository_id"
     },
     "createInstallationToken": {
-      "url": "/installations/:installation_id/access_tokens",
-      "method": "POST",
       "deprecated": "`integrations` has been renamed to `apps`",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
+      "method": "POST",
       "params": {
         "installation_id": {
           "type": "string",
@@ -1941,28 +1940,28 @@
         "user_id": {
           "type": "string"
         }
-      }
+      },
+      "url": "/installations/:installation_id/access_tokens"
     },
     "getInstallationRepositories": {
-      "url": "/installation/repositories",
-      "method": "GET",
       "deprecated": "`integrations` has been renamed to `apps`",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
+      "method": "GET",
       "params": {
         "user_id": {
           "type": "string"
         }
-      }
+      },
+      "url": "/installation/repositories"
     },
     "getInstallations": {
-      "url": "/app/installations",
-      "method": "GET",
       "deprecated": "`integrations` has been renamed to `apps`",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
+      "method": "GET",
       "params": {
         "page": {
           "type": "number"
@@ -1971,15 +1970,15 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/app/installations"
     },
     "removeRepoFromInstallation": {
-      "url": "/user/installations/:installation_id/repositories/:repository_id",
-      "method": "DELETE",
       "deprecated": "`integrations` has been renamed to `apps`",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
+      "method": "DELETE",
       "params": {
         "installation_id": {
           "type": "string",
@@ -1989,36 +1988,22 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/installations/:installation_id/repositories/:repository_id"
     }
   },
   "issues": {
     "addAssigneesToIssue": {
-      "url": "/repos/:owner/:repo/issues/:number/assignees",
       "method": "POST",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
         "assignees": {
           "type": "string[]",
           "required": true
-        }
-      }
-    },
-    "addLabels": {
-      "url": "/repos/:owner/:repo/issues/:number/labels",
-      "method": "POST",
-      "params": {
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -2026,22 +2011,22 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/issues/:number/assignees"
+    },
+    "addLabels": {
+      "method": "POST",
+      "params": {
         "labels": {
           "type": "string[]",
           "required": true,
           "mapTo": "input"
-        }
-      }
-    },
-    "checkAssignee": {
-      "url": "/repos/:owner/:repo/assignees/:assignee",
-      "method": "GET",
-      "params": {
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -2049,20 +2034,49 @@
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/issues/:number/labels"
+    },
+    "checkAssignee": {
+      "method": "GET",
+      "params": {
         "assignee": {
           "type": "string",
           "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/assignees/:assignee"
     },
     "create": {
-      "url": "/repos/:owner/:repo/issues",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.squirrel-girl-preview"
       },
+      "method": "POST",
       "params": {
+        "assignee": {
+          "type": "string"
+        },
+        "assignees": {
+          "type": "string[]"
+        },
+        "body": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "string[]"
+        },
+        "milestone": {
+          "type": "number"
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -2074,36 +2088,17 @@
         "title": {
           "type": "string",
           "required": true
-        },
-        "body": {
-          "type": "string"
-        },
-        "assignee": {
-          "type": "string"
-        },
-        "milestone": {
-          "type": "number"
-        },
-        "labels": {
-          "type": "string[]"
-        },
-        "assignees": {
-          "type": "string[]"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/issues"
     },
     "createComment": {
-      "url": "/repos/:owner/:repo/issues/:number/comments",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.squirrel-girl-preview"
       },
+      "method": "POST",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
+        "body": {
           "type": "string",
           "required": true
         },
@@ -2111,21 +2106,21 @@
           "type": "number",
           "required": true
         },
-        "body": {
-          "type": "string",
-          "required": true
-        }
-      }
-    },
-    "createLabel": {
-      "url": "/repos/:owner/:repo/labels",
-      "method": "POST",
-      "params": {
         "owner": {
           "type": "string",
           "required": true
         },
         "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/issues/:number/comments"
+    },
+    "createLabel": {
+      "method": "POST",
+      "params": {
+        "color": {
           "type": "string",
           "required": true
         },
@@ -2133,16 +2128,6 @@
           "type": "string",
           "required": true
         },
-        "color": {
-          "type": "string",
-          "required": true
-        }
-      }
-    },
-    "createMilestone": {
-      "url": "/repos/:owner/:repo/milestones",
-      "method": "POST",
-      "params": {
         "owner": {
           "type": "string",
           "required": true
@@ -2150,8 +2135,24 @@
         "repo": {
           "type": "string",
           "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/labels"
+    },
+    "createMilestone": {
+      "method": "POST",
+      "params": {
+        "description": {
+          "type": "string"
         },
-        "title": {
+        "due_on": {
+          "type": "date"
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
           "type": "string",
           "required": true
         },
@@ -2164,39 +2165,23 @@
           ],
           "default": "open"
         },
-        "description": {
-          "type": "string"
-        },
-        "due_on": {
-          "type": "date"
+        "title": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/milestones"
     },
     "deleteComment": {
-      "url": "/repos/:owner/:repo/issues/comments/:id",
-      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.squirrel-girl-preview"
       },
+      "method": "DELETE",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "id": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "deleteLabel": {
-      "url": "/repos/:owner/:repo/labels/:name",
-      "method": "DELETE",
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -2204,17 +2189,17 @@
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/issues/comments/:id"
+    },
+    "deleteLabel": {
+      "method": "DELETE",
+      "params": {
         "name": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "deleteMilestone": {
-      "url": "/repos/:owner/:repo/milestones/:number",
-      "method": "DELETE",
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -2222,40 +2207,61 @@
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/labels/:name"
+    },
+    "deleteMilestone": {
+      "method": "DELETE",
+      "params": {
         "number": {
           "type": "number",
           "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/milestones/:number"
     },
     "edit": {
-      "url": "/repos/:owner/:repo/issues/:number",
-      "method": "PATCH",
       "headers": {
         "accept": "application/vnd.github.squirrel-girl-preview"
       },
+      "method": "PATCH",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "title": {
+        "assignee": {
           "type": "string"
+        },
+        "assignees": {
+          "type": "string[]"
         },
         "body": {
           "type": "string"
         },
-        "assignee": {
-          "type": "string"
+        "labels": {
+          "type": "string[]"
+        },
+        "milestone": {
+          "type": "number",
+          "allow-null": true
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         },
         "state": {
           "type": "string",
@@ -2265,30 +2271,19 @@
           ],
           "default": "open"
         },
-        "milestone": {
-          "type": "number",
-          "allow-null": true
-        },
-        "labels": {
-          "type": "string[]"
-        },
-        "assignees": {
-          "type": "string[]"
+        "title": {
+          "type": "string"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/issues/:number"
     },
     "editComment": {
-      "url": "/repos/:owner/:repo/issues/comments/:id",
-      "method": "PATCH",
       "headers": {
         "accept": "application/vnd.github.squirrel-girl-preview"
       },
+      "method": "PATCH",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
+        "body": {
           "type": "string",
           "required": true
         },
@@ -2296,19 +2291,6 @@
           "type": "string",
           "required": true
         },
-        "body": {
-          "type": "string",
-          "required": true
-        }
-      }
-    },
-    "get": {
-      "url": "/repos/:owner/:repo/issues/:number",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
         "owner": {
           "type": "string",
           "required": true
@@ -2316,20 +2298,45 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/issues/comments/:id"
     },
-    "getAll": {
-      "url": "/issues",
-      "method": "GET",
+    "get": {
       "headers": {
         "accept": "application/vnd.github.squirrel-girl-preview"
       },
+      "method": "GET",
       "params": {
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/issues/:number"
+    },
+    "getAll": {
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "method": "GET",
+      "params": {
+        "direction": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "default": "desc"
+        },
         "filter": {
           "type": "string",
           "enum": [
@@ -2341,17 +2348,18 @@
           ],
           "default": "assigned"
         },
-        "state": {
-          "type": "string",
-          "enum": [
-            "open",
-            "closed",
-            "all"
-          ],
-          "default": "open"
-        },
         "labels": {
           "type": "string"
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
+        "since": {
+          "type": "date"
         },
         "sort": {
           "type": "string",
@@ -2362,6 +2370,90 @@
           ],
           "default": "created"
         },
+        "state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "closed",
+            "all"
+          ],
+          "default": "open"
+        }
+      },
+      "url": "/issues"
+    },
+    "getAssignees": {
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/assignees"
+    },
+    "getComment": {
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "method": "GET",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/issues/comments/:id"
+    },
+    "getComments": {
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "method": "GET",
+      "params": {
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "since": {
+          "type": "date"
+        }
+      },
+      "url": "/repos/:owner/:repo/issues/:number/comments"
+    },
+    "getCommentsForRepo": {
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "method": "GET",
+      "params": {
         "direction": {
           "type": "string",
           "enum": [
@@ -2370,8 +2462,9 @@
           ],
           "default": "desc"
         },
-        "since": {
-          "type": "date"
+        "owner": {
+          "type": "string",
+          "required": true
         },
         "page": {
           "type": "number"
@@ -2379,89 +2472,13 @@
         "per_page": {
           "type": "number",
           "default": "30"
-        }
-      }
-    },
-    "getAssignees": {
-      "url": "/repos/:owner/:repo/assignees",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
         },
         "repo": {
           "type": "string",
-          "required": true
-        }
-      }
-    },
-    "getComment": {
-      "url": "/repos/:owner/:repo/issues/comments/:id",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      }
-    },
-    "getComments": {
-      "url": "/repos/:owner/:repo/issues/:number/comments",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
           "required": true
         },
         "since": {
           "type": "date"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
-        }
-      }
-    },
-    "getCommentsForRepo": {
-      "url": "/repos/:owner/:repo/issues/comments",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
         },
         "sort": {
           "type": "string",
@@ -2470,7 +2487,116 @@
             "updated"
           ],
           "default": "created"
+        }
+      },
+      "url": "/repos/:owner/:repo/issues/comments"
+    },
+    "getEvent": {
+      "method": "GET",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
         },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/issues/events/:id"
+    },
+    "getEvents": {
+      "method": "GET",
+      "params": {
+        "issue_number": {
+          "alias": "number",
+          "deprecated": "`issue_number` parameter has been renamed to `number`"
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/issues/:number/events"
+    },
+    "getEventsForRepo": {
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/issues/events"
+    },
+    "getEventsTimeline": {
+      "headers": {
+        "accept": "application/vnd.github.mockingbird-preview"
+      },
+      "method": "GET",
+      "params": {
+        "issue_number": {
+          "alias": "number",
+          "deprecated": "`issue_number` parameter has been renamed to `number`"
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/issues/:number/timeline"
+    },
+    "getForOrg": {
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "method": "GET",
+      "params": {
         "direction": {
           "type": "string",
           "enum": [
@@ -2478,129 +2604,6 @@
             "desc"
           ],
           "default": "desc"
-        },
-        "since": {
-          "type": "date"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
-        }
-      }
-    },
-    "getEvent": {
-      "url": "/repos/:owner/:repo/issues/events/:id",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      }
-    },
-    "getEvents": {
-      "url": "/repos/:owner/:repo/issues/:number/events",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "issue_number": {
-          "alias": "number",
-          "deprecated": "`issue_number` parameter has been renamed to `number`"
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
-        }
-      }
-    },
-    "getEventsForRepo": {
-      "url": "/repos/:owner/:repo/issues/events",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
-        }
-      }
-    },
-    "getEventsTimeline": {
-      "url": "/repos/:owner/:repo/issues/:number/timeline",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.mockingbird-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "issue_number": {
-          "alias": "number",
-          "deprecated": "`issue_number` parameter has been renamed to `number`"
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
-        }
-      }
-    },
-    "getForOrg": {
-      "url": "/orgs/:org/issues",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
         },
         "filter": {
           "type": "string",
@@ -2612,17 +2615,22 @@
             "subscribed"
           ]
         },
-        "state": {
-          "type": "string",
-          "enum": [
-            "open",
-            "closed",
-            "all"
-          ],
-          "default": "open"
-        },
         "labels": {
           "type": "string"
+        },
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
+        "since": {
+          "type": "date"
         },
         "sort": {
           "type": "string",
@@ -2633,45 +2641,6 @@
           ],
           "default": "created"
         },
-        "direction": {
-          "type": "string",
-          "enum": [
-            "asc",
-            "desc"
-          ],
-          "default": "desc"
-        },
-        "since": {
-          "type": "date"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
-        }
-      }
-    },
-    "getForRepo": {
-      "url": "/repos/:owner/:repo/issues",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "milestone": {
-          "type": "string",
-          "validation": "^([0-9]+|none|\\*)$"
-        },
         "state": {
           "type": "string",
           "enum": [
@@ -2680,18 +2649,57 @@
             "all"
           ],
           "default": "open"
-        },
+        }
+      },
+      "url": "/orgs/:org/issues"
+    },
+    "getForRepo": {
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "method": "GET",
+      "params": {
         "assignee": {
           "type": "string"
         },
         "creator": {
           "type": "string"
         },
-        "mentioned": {
-          "type": "string"
+        "direction": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "default": "desc"
         },
         "labels": {
           "type": "string"
+        },
+        "mentioned": {
+          "type": "string"
+        },
+        "milestone": {
+          "type": "string",
+          "validation": "^([0-9]+|none|\\*)$"
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "since": {
+          "type": "date"
         },
         "sort": {
           "type": "string",
@@ -2702,6 +2710,24 @@
           ],
           "default": "created"
         },
+        "state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "closed",
+            "all"
+          ],
+          "default": "open"
+        }
+      },
+      "url": "/repos/:owner/:repo/issues"
+    },
+    "getForUser": {
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "method": "GET",
+      "params": {
         "direction": {
           "type": "string",
           "enum": [
@@ -2710,25 +2736,6 @@
           ],
           "default": "desc"
         },
-        "since": {
-          "type": "date"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
-        }
-      }
-    },
-    "getForUser": {
-      "url": "/user/issues",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
         "filter": {
           "type": "string",
           "enum": [
@@ -2739,17 +2746,18 @@
             "subscribed"
           ]
         },
-        "state": {
-          "type": "string",
-          "enum": [
-            "open",
-            "closed",
-            "all"
-          ],
-          "default": "open"
-        },
         "labels": {
           "type": "string"
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
+        "since": {
+          "type": "date"
         },
         "sort": {
           "type": "string",
@@ -2760,131 +2768,6 @@
           ],
           "default": "created"
         },
-        "direction": {
-          "type": "string",
-          "enum": [
-            "asc",
-            "desc"
-          ],
-          "default": "desc"
-        },
-        "since": {
-          "type": "date"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
-        }
-      }
-    },
-    "getIssueLabels": {
-      "url": "/repos/:owner/:repo/issues/:number/labels",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        }
-      }
-    },
-    "getLabel": {
-      "url": "/repos/:owner/:repo/labels/:name",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "name": {
-          "type": "string",
-          "required": true
-        }
-      }
-    },
-    "getLabels": {
-      "url": "/repos/:owner/:repo/labels",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
-        }
-      }
-    },
-    "getMilestone": {
-      "url": "/repos/:owner/:repo/milestones/:number",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        }
-      }
-    },
-    "getMilestoneLabels": {
-      "url": "/repos/:owner/:repo/milestones/:number/labels",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        }
-      }
-    },
-    "getMilestones": {
-      "url": "/repos/:owner/:repo/milestones",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "state": {
           "type": "string",
           "enum": [
@@ -2893,6 +2776,128 @@
             "all"
           ],
           "default": "open"
+        }
+      },
+      "url": "/user/issues"
+    },
+    "getIssueLabels": {
+      "method": "GET",
+      "params": {
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/issues/:number/labels"
+    },
+    "getLabel": {
+      "method": "GET",
+      "params": {
+        "name": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/labels/:name"
+    },
+    "getLabels": {
+      "method": "GET",
+      "params": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/labels"
+    },
+    "getMilestone": {
+      "method": "GET",
+      "params": {
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/milestones/:number"
+    },
+    "getMilestoneLabels": {
+      "method": "GET",
+      "params": {
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/milestones/:number/labels"
+    },
+    "getMilestones": {
+      "method": "GET",
+      "params": {
+        "direction": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "default": "asc"
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         },
         "sort": {
           "type": "string",
@@ -2902,27 +2907,25 @@
           ],
           "default": "due_on"
         },
-        "direction": {
+        "state": {
           "type": "string",
           "enum": [
-            "asc",
-            "desc"
+            "open",
+            "closed",
+            "all"
           ],
-          "default": "asc"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
+          "default": "open"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/milestones"
     },
     "lock": {
-      "url": "/repos/:owner/:repo/issues/:number/lock",
       "method": "PUT",
       "params": {
+        "number": {
+          "type": "number",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -2930,57 +2933,39 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/issues/:number/lock"
     },
     "removeAllLabels": {
-      "url": "/repos/:owner/:repo/issues/:number/labels",
       "method": "DELETE",
       "params": {
+        "number": {
+          "type": "number",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
         },
         "repo": {
           "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/issues/:number/labels"
     },
     "removeAssigneesFromIssue": {
-      "url": "/repos/:owner/:repo/issues/:number/assignees",
       "method": "DELETE",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
         "body": {
           "type": "json",
           "required": true
-        }
-      }
-    },
-    "removeLabel": {
-      "url": "/repos/:owner/:repo/issues/:number/labels/:name",
-      "method": "DELETE",
-      "params": {
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -2988,21 +2973,21 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/issues/:number/assignees"
+    },
+    "removeLabel": {
+      "method": "DELETE",
+      "params": {
         "name": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "replaceAllLabels": {
-      "url": "/repos/:owner/:repo/issues/:number/labels",
-      "method": "PUT",
-      "params": {
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -3010,45 +2995,59 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/issues/:number/labels/:name"
+    },
+    "replaceAllLabels": {
+      "method": "PUT",
+      "params": {
         "labels": {
           "type": "string[]",
           "required": true,
           "mapTo": "input"
-        }
-      }
-    },
-    "unlock": {
-      "url": "/repos/:owner/:repo/issues/:number/lock",
-      "method": "DELETE",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
         },
         "number": {
           "type": "number",
           "required": true
-        }
-      }
-    },
-    "updateLabel": {
-      "url": "/repos/:owner/:repo/labels/:oldname",
-      "method": "PATCH",
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
         },
         "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/issues/:number/labels"
+    },
+    "unlock": {
+      "method": "DELETE",
+      "params": {
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/issues/:number/lock"
+    },
+    "updateLabel": {
+      "method": "PATCH",
+      "params": {
+        "color": {
+          "type": "string",
+          "required": true
+        },
+        "name": {
           "type": "string",
           "required": true
         },
@@ -3056,20 +3055,6 @@
           "type": "string",
           "required": true
         },
-        "name": {
-          "type": "string",
-          "required": true
-        },
-        "color": {
-          "type": "string",
-          "required": true
-        }
-      }
-    },
-    "updateMilestone": {
-      "url": "/repos/:owner/:repo/milestones/:number",
-      "method": "PATCH",
-      "params": {
         "owner": {
           "type": "string",
           "required": true
@@ -3077,12 +3062,28 @@
         "repo": {
           "type": "string",
           "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/labels/:oldname"
+    },
+    "updateMilestone": {
+      "method": "PATCH",
+      "params": {
+        "description": {
+          "type": "string"
+        },
+        "due_on": {
+          "type": "date"
         },
         "number": {
           "type": "number",
           "required": true
         },
-        "title": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
           "type": "string",
           "required": true
         },
@@ -3095,22 +3096,20 @@
           ],
           "default": "open"
         },
-        "description": {
-          "type": "string"
-        },
-        "due_on": {
-          "type": "date"
+        "title": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/milestones/:number"
     }
   },
   "migrations": {
     "cancelImport": {
-      "url": "/repos/:owner/:repo/import",
-      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.barred-rock-preview"
       },
+      "method": "DELETE",
       "params": {
         "owner": {
           "type": "string",
@@ -3120,31 +3119,31 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/import"
     },
     "deleteMigrationArchive": {
-      "url": "/orgs/:org/migrations/:id/archive",
-      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.wyandotte-preview+json"
       },
+      "method": "DELETE",
       "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
         "id": {
           "type": "string",
           "required": true
+        },
+        "org": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/migrations/:id/archive"
     },
     "getImportCommitAuthors": {
-      "url": "/repos/:owner/:repo/import/authors",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.barred-rock-preview"
       },
+      "method": "GET",
       "params": {
         "owner": {
           "type": "string",
@@ -3157,14 +3156,14 @@
         "since": {
           "type": "string"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/import/authors"
     },
     "getImportProgress": {
-      "url": "/repos/:owner/:repo/import",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.barred-rock-preview"
       },
+      "method": "GET",
       "params": {
         "owner": {
           "type": "string",
@@ -3174,69 +3173,69 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/import"
     },
     "getLargeImportFiles": {
-      "url": "/repos/:owner/:repo/import/large_files",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.barred-rock-preview"
       },
+      "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
         "name": {
           "alias": "repo",
           "deprecated": "`name` parameter has been renamed to `repo`"
         },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
         "repo": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/import/large_files"
     },
     "getMigrationArchiveLink": {
-      "url": "/orgs/:org/migrations/:id/archive",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.wyandotte-preview+json"
       },
+      "method": "GET",
       "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
         "id": {
           "type": "string",
           "required": true
+        },
+        "org": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/migrations/:id/archive"
     },
     "getMigrationStatus": {
-      "url": "/orgs/:org/migrations/:id",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.wyandotte-preview+json"
       },
+      "method": "GET",
       "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
         "id": {
           "type": "string",
           "required": true
+        },
+        "org": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/migrations/:id"
     },
     "getMigrations": {
-      "url": "/orgs/:org/migrations",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.wyandotte-preview+json"
       },
+      "method": "GET",
       "params": {
         "org": {
           "type": "string",
@@ -3249,23 +3248,15 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/orgs/:org/migrations"
     },
     "mapImportCommitAuthor": {
-      "url": "/repos/:owner/:repo/import/authors/:author_id",
-      "method": "PATCH",
       "headers": {
         "accept": "application/vnd.github.barred-rock-preview"
       },
+      "method": "PATCH",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "author_id": {
           "type": "string",
           "required": true
@@ -3275,23 +3266,31 @@
         },
         "name": {
           "type": "string"
-        }
-      }
-    },
-    "setImportLfsPreference": {
-      "url": "/repos/:owner/:repo/import/lfs",
-      "method": "PATCH",
-      "headers": {
-        "accept": "application/vnd.github.barred-rock-preview"
-      },
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
         },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/import/authors/:author_id"
+    },
+    "setImportLfsPreference": {
+      "headers": {
+        "accept": "application/vnd.github.barred-rock-preview"
+      },
+      "method": "PATCH",
+      "params": {
         "name": {
           "alias": "repo",
           "deprecated": "`name` parameter has been renamed to `repo`"
+        },
+        "owner": {
+          "type": "string",
+          "required": true
         },
         "repo": {
           "type": "string",
@@ -3301,14 +3300,14 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/import/lfs"
     },
     "startImport": {
-      "url": "/repos/:owner/:repo/import",
-      "method": "PUT",
       "headers": {
         "accept": "application/vnd.github.barred-rock-preview"
       },
+      "method": "PUT",
       "params": {
         "owner": {
           "type": "string",
@@ -3318,9 +3317,8 @@
           "type": "string",
           "required": true
         },
-        "vcs_url": {
-          "type": "string",
-          "required": true
+        "tfvc_project": {
+          "type": "string"
         },
         "vcs": {
           "type": "string",
@@ -3331,24 +3329,33 @@
             "tfvc"
           ]
         },
-        "vcs_username": {
-          "type": "string"
-        },
         "vcs_password": {
           "type": "string"
         },
-        "tfvc_project": {
+        "vcs_url": {
+          "type": "string",
+          "required": true
+        },
+        "vcs_username": {
           "type": "string"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/import"
     },
     "startMigration": {
-      "url": "/orgs/:org/migrations",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.wyandotte-preview+json"
       },
+      "method": "POST",
       "params": {
+        "exclude_attachments": {
+          "type": "boolean",
+          "default": "false"
+        },
+        "lock_repositories": {
+          "type": "boolean",
+          "default": "false"
+        },
         "org": {
           "type": "string",
           "required": true
@@ -3356,29 +3363,21 @@
         "repositories": {
           "type": "string[]",
           "required": true
-        },
-        "lock_repositories": {
-          "type": "boolean",
-          "default": "false"
-        },
-        "exclude_attachments": {
-          "type": "boolean",
-          "default": "false"
         }
-      }
+      },
+      "url": "/orgs/:org/migrations"
     },
     "unlockRepoLockedForMigration": {
-      "url": "/orgs/:org/migrations/:id/repos/:repo_name/lock",
-      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.wyandotte-preview+json"
       },
+      "method": "DELETE",
       "params": {
-        "org": {
+        "id": {
           "type": "string",
           "required": true
         },
-        "id": {
+        "org": {
           "type": "string",
           "required": true
         },
@@ -3386,14 +3385,14 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/migrations/:id/repos/:repo_name/lock"
     },
     "updateImport": {
-      "url": "/repos/:owner/:repo/import",
-      "method": "PATCH",
       "headers": {
         "accept": "application/vnd.github.barred-rock-preview"
       },
+      "method": "PATCH",
       "params": {
         "owner": {
           "type": "string",
@@ -3403,94 +3402,94 @@
           "type": "string",
           "required": true
         },
-        "vcs_username": {
-          "type": "string"
-        },
         "vcs_password": {
           "type": "string"
+        },
+        "vcs_username": {
+          "type": "string"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/import"
     }
   },
   "misc": {
     "getCodeOfConduct": {
-      "url": "/codes_of_conduct/:key",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.scarlet-witch-preview+json"
       },
+      "method": "GET",
       "params": {
         "key": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/codes_of_conduct/:key"
     },
     "getCodesOfConduct": {
-      "url": "/codes_of_conduct",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.scarlet-witch-preview+json"
       },
-      "params": {}
+      "method": "GET",
+      "params": {},
+      "url": "/codes_of_conduct"
     },
     "getEmojis": {
-      "url": "/emojis",
       "method": "GET",
-      "params": {}
+      "params": {},
+      "url": "/emojis"
     },
     "getGitignoreTemplate": {
-      "url": "/gitignore/templates/:name",
       "method": "GET",
       "params": {
         "name": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/gitignore/templates/:name"
     },
     "getGitignoreTemplates": {
-      "url": "/gitignore/templates",
       "method": "GET",
-      "params": {}
+      "params": {},
+      "url": "/gitignore/templates"
     },
     "getLicense": {
-      "url": "/licenses/:license",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.drax-preview+json"
       },
+      "method": "GET",
       "params": {
         "license": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/licenses/:license"
     },
     "getLicenses": {
-      "url": "/licenses",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.drax-preview+json"
       },
-      "params": {}
+      "method": "GET",
+      "params": {},
+      "url": "/licenses"
     },
     "getMeta": {
-      "url": "/meta",
       "method": "GET",
-      "params": {}
+      "params": {},
+      "url": "/meta"
     },
     "getRateLimit": {
-      "url": "/rate_limit",
       "method": "GET",
-      "params": {}
+      "params": {},
+      "url": "/rate_limit"
     },
     "getRepoCodeOfConduct": {
-      "url": "/repos/:owner/:repo/community/code_of_conduct",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.scarlet-witch-preview+json"
       },
+      "method": "GET",
       "params": {
         "owner": {
           "type": "string",
@@ -3500,14 +3499,14 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/community/code_of_conduct"
     },
     "getRepoLicense": {
-      "url": "/repos/:owner/:repo/license",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.drax-preview+json"
       },
+      "method": "GET",
       "params": {
         "owner": {
           "type": "string",
@@ -3517,15 +3516,14 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/license"
     },
     "renderMarkdown": {
-      "url": "/markdown",
       "method": "POST",
       "params": {
-        "text": {
-          "type": "string",
-          "required": true
+        "context": {
+          "type": "string"
         },
         "mode": {
           "type": "string",
@@ -3535,36 +3533,33 @@
           ],
           "default": "markdown"
         },
-        "context": {
-          "type": "string"
+        "text": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/markdown"
     },
     "renderMarkdownRaw": {
-      "url": "/markdown/raw",
-      "method": "POST",
       "headers": {
         "content-type": "text/plain; charset=utf-8"
       },
+      "method": "POST",
       "params": {
         "data": {
           "type": "string",
           "required": true,
           "mapTo": "input"
         }
-      }
+      },
+      "url": "/markdown/raw"
     }
   },
   "orgs": {
     "addOrgMembership": {
-      "url": "/orgs/:org/memberships/:username",
       "method": "PUT",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
           "type": "string",
           "required": true
         },
@@ -3576,21 +3571,21 @@
             "member"
           ],
           "default": "member"
+        },
+        "username": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/memberships/:username"
     },
     "addTeamMembership": {
-      "url": "/teams/:id/memberships/:username",
-      "method": "PUT",
       "headers": {
         "accept": "application/vnd.github.hellcat-preview+json"
       },
+      "method": "PUT",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
           "type": "string",
           "required": true
         },
@@ -3601,25 +3596,25 @@
             "maintainer"
           ],
           "default": "member"
+        },
+        "username": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/teams/:id/memberships/:username"
     },
     "addTeamRepo": {
-      "url": "/teams/:id/repos/:org/:repo",
-      "method": "PUT",
       "headers": {
         "accept": "application/vnd.github.hellcat-preview+json"
       },
+      "method": "PUT",
       "params": {
         "id": {
           "type": "string",
           "required": true
         },
         "org": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -3630,15 +3625,19 @@
             "push",
             "admin"
           ]
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/teams/:id/repos/:org/:repo"
     },
     "blockUser": {
-      "url": "/orgs/:org/blocks/:username",
-      "method": "PUT",
       "headers": {
         "accept": "application/vnd.github.giant-sentry-fist-preview+json"
       },
+      "method": "PUT",
       "params": {
         "org": {
           "type": "string",
@@ -3648,14 +3647,14 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/blocks/:username"
     },
     "checkBlockedUser": {
-      "url": "/orgs/:org/blocks/:username",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.giant-sentry-fist-preview+json"
       },
+      "method": "GET",
       "params": {
         "org": {
           "type": "string",
@@ -3665,10 +3664,10 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/blocks/:username"
     },
     "checkMembership": {
-      "url": "/orgs/:org/members/:username",
       "method": "GET",
       "params": {
         "org": {
@@ -3679,10 +3678,10 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/members/:username"
     },
     "checkPublicMembership": {
-      "url": "/orgs/:org/public_members/:username",
       "method": "GET",
       "params": {
         "org": {
@@ -3693,14 +3692,14 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/public_members/:username"
     },
     "checkTeamRepo": {
-      "url": "/teams/:id/repos/:owner/:repo",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.hellcat-preview+json"
       },
+      "method": "GET",
       "params": {
         "id": {
           "type": "string",
@@ -3714,10 +3713,10 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/teams/:id/repos/:owner/:repo"
     },
     "concealMembership": {
-      "url": "/orgs/:org/public_members/:username",
       "method": "DELETE",
       "params": {
         "org": {
@@ -3728,10 +3727,10 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/public_members/:username"
     },
     "convertMemberToOutsideCollaborator": {
-      "url": "/orgs/:org/outside_collaborators/:username",
       "method": "PUT",
       "params": {
         "org": {
@@ -3742,19 +3741,14 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/outside_collaborators/:username"
     },
     "createHook": {
-      "url": "/orgs/:org/hooks",
       "method": "POST",
       "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "name": {
-          "type": "string",
-          "required": true
+        "active": {
+          "type": "boolean"
         },
         "config": {
           "type": "json",
@@ -3764,34 +3758,39 @@
           "type": "string[]",
           "default": "[\"push\"]"
         },
-        "active": {
-          "type": "boolean"
-        }
-      }
-    },
-    "createTeam": {
-      "url": "/orgs/:org/teams",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.hellcat-preview+json"
-      },
-      "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
         "name": {
           "type": "string",
           "required": true
         },
+        "org": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/orgs/:org/hooks"
+    },
+    "createTeam": {
+      "headers": {
+        "accept": "application/vnd.github.hellcat-preview+json"
+      },
+      "method": "POST",
+      "params": {
         "description": {
           "type": "string"
         },
         "maintainers": {
           "type": "string[]"
         },
-        "repo_names": {
-          "type": "string[]"
+        "name": {
+          "type": "string",
+          "required": true
+        },
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "parent_team_id": {
+          "type": "number"
         },
         "privacy": {
           "type": "string",
@@ -3801,44 +3800,44 @@
           ],
           "default": "secret"
         },
-        "parent_team_id": {
-          "type": "number"
+        "repo_names": {
+          "type": "string[]"
         }
-      }
+      },
+      "url": "/orgs/:org/teams"
     },
     "deleteHook": {
-      "url": "/orgs/:org/hooks/:id",
       "method": "DELETE",
       "params": {
-        "org": {
+        "id": {
           "type": "string",
           "required": true
         },
-        "id": {
+        "org": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/hooks/:id"
     },
     "deleteTeam": {
-      "url": "/teams/:id",
-      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.hellcat-preview+json"
       },
+      "method": "DELETE",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/teams/:id"
     },
     "deleteTeamRepo": {
-      "url": "/teams/:id/repos/:owner/:repo",
-      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.hellcat-preview+json"
       },
+      "method": "DELETE",
       "params": {
         "id": {
           "type": "string",
@@ -3852,19 +3851,14 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/teams/:id/repos/:owner/:repo"
     },
     "editHook": {
-      "url": "/orgs/:org/hooks/:id",
       "method": "PATCH",
       "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
+        "active": {
+          "type": "boolean"
         },
         "config": {
           "type": "json",
@@ -3874,18 +3868,26 @@
           "type": "string[]",
           "default": "[\"push\"]"
         },
-        "active": {
-          "type": "boolean"
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "org": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/hooks/:id"
     },
     "editTeam": {
-      "url": "/teams/:id",
-      "method": "PATCH",
       "headers": {
         "accept": "application/vnd.github.hellcat-preview+json"
       },
+      "method": "PATCH",
       "params": {
+        "description": {
+          "type": "string"
+        },
         "id": {
           "type": "string",
           "required": true
@@ -3894,8 +3896,8 @@
           "type": "string",
           "required": true
         },
-        "description": {
-          "type": "string"
+        "parent_team_id": {
+          "type": "number"
         },
         "privacy": {
           "type": "string",
@@ -3904,14 +3906,11 @@
             "closed"
           ],
           "default": "secret"
-        },
-        "parent_team_id": {
-          "type": "number"
         }
-      }
+      },
+      "url": "/teams/:id"
     },
     "get": {
-      "url": "/orgs/:org",
       "method": "GET",
       "params": {
         "org": {
@@ -3925,30 +3924,30 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/orgs/:org"
     },
     "getAll": {
-      "url": "/organizations",
       "method": "GET",
       "params": {
-        "since": {
-          "type": "string"
-        },
         "page": {
           "type": "number"
         },
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "since": {
+          "type": "string"
         }
-      }
+      },
+      "url": "/organizations"
     },
     "getBlockedUsers": {
-      "url": "/orgs/:org/blocks",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.giant-sentry-fist-preview+json"
       },
+      "method": "GET",
       "params": {
         "org": {
           "type": "string",
@@ -3961,14 +3960,14 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/orgs/:org/blocks"
     },
     "getChildTeams": {
-      "url": "/teams/:id/teams",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.hellcat-preview+json"
       },
+      "method": "GET",
       "params": {
         "id": {
           "type": "string",
@@ -3981,41 +3980,41 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/teams/:id/teams"
     },
     "getForUser": {
-      "url": "/users/:username/orgs",
       "method": "GET",
       "params": {
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
         "username": {
           "type": "string",
           "required": true
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
         }
-      }
+      },
+      "url": "/users/:username/orgs"
     },
     "getHook": {
-      "url": "/orgs/:org/hooks/:id",
       "method": "GET",
       "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
         "id": {
           "type": "string",
           "required": true
+        },
+        "org": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/hooks/:id"
     },
     "getHooks": {
-      "url": "/orgs/:org/hooks",
       "method": "GET",
       "params": {
         "org": {
@@ -4029,16 +4028,12 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/orgs/:org/hooks"
     },
     "getMembers": {
-      "url": "/orgs/:org/members",
       "method": "GET",
       "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
         "filter": {
           "type": "string",
           "enum": [
@@ -4046,6 +4041,17 @@
             "2fa_disabled"
           ],
           "default": "all"
+        },
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
         },
         "role": {
           "type": "string",
@@ -4055,18 +4061,11 @@
             "member"
           ],
           "default": "all"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
         }
-      }
+      },
+      "url": "/orgs/:org/members"
     },
     "getOrgMembership": {
-      "url": "/orgs/:org/memberships/:username",
       "method": "GET",
       "params": {
         "org": {
@@ -4077,16 +4076,12 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/memberships/:username"
     },
     "getOutsideCollaborators": {
-      "url": "/orgs/:org/outside_collaborators",
       "method": "GET",
       "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
         "filter": {
           "type": "string",
           "enum": [
@@ -4095,6 +4090,10 @@
           ],
           "default": "all"
         },
+        "org": {
+          "type": "string",
+          "required": true
+        },
         "page": {
           "type": "number"
         },
@@ -4102,20 +4101,20 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/orgs/:org/outside_collaborators"
     },
     "getPendingOrgInvites": {
-      "url": "/orgs/:org/invitations",
       "method": "GET",
       "params": {
         "org": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/invitations"
     },
     "getPendingTeamInvites": {
-      "url": "/teams/:id/invitations",
       "method": "GET",
       "params": {
         "id": {
@@ -4129,41 +4128,48 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/teams/:id/invitations"
     },
     "getPublicMembers": {
-      "url": "/orgs/:org/public_members",
       "method": "GET",
       "params": {
         "org": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/public_members"
     },
     "getTeam": {
-      "url": "/teams/:id",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.hellcat-preview+json"
       },
+      "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/teams/:id"
     },
     "getTeamMembers": {
-      "url": "/teams/:id/members",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.hellcat-preview+json"
       },
+      "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
         },
         "role": {
           "type": "string",
@@ -4173,22 +4179,15 @@
             "all"
           ],
           "default": "all"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
         }
-      }
+      },
+      "url": "/teams/:id/members"
     },
     "getTeamMembership": {
-      "url": "/teams/:id/memberships/:username",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.hellcat-preview+json"
       },
+      "method": "GET",
       "params": {
         "id": {
           "type": "string",
@@ -4198,14 +4197,14 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/teams/:id/memberships/:username"
     },
     "getTeamRepos": {
-      "url": "/teams/:id/repos",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.hellcat-preview+json"
       },
+      "method": "GET",
       "params": {
         "id": {
           "type": "string",
@@ -4218,14 +4217,14 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/teams/:id/repos"
     },
     "getTeams": {
-      "url": "/orgs/:org/teams",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.hellcat-preview+json"
       },
+      "method": "GET",
       "params": {
         "org": {
           "type": "string",
@@ -4238,24 +4237,24 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/orgs/:org/teams"
     },
     "pingHook": {
-      "url": "/orgs/:org/hooks/:id/pings",
       "method": "POST",
       "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
         "id": {
           "type": "string",
           "required": true
+        },
+        "org": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/hooks/:id/pings"
     },
     "publicizeMembership": {
-      "url": "/orgs/:org/public_members/:username",
       "method": "PUT",
       "params": {
         "org": {
@@ -4266,10 +4265,10 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/public_members/:username"
     },
     "removeMember": {
-      "url": "/orgs/:org/members/:username",
       "method": "DELETE",
       "params": {
         "org": {
@@ -4280,10 +4279,10 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/members/:username"
     },
     "removeOrgMembership": {
-      "url": "/orgs/:org/memberships/:username",
       "method": "DELETE",
       "params": {
         "org": {
@@ -4294,10 +4293,10 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/memberships/:username"
     },
     "removeOutsideCollaborator": {
-      "url": "/orgs/:org/outside_collaborators/:username",
       "method": "DELETE",
       "params": {
         "org": {
@@ -4308,14 +4307,14 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/outside_collaborators/:username"
     },
     "removeTeamMembership": {
-      "url": "/teams/:id/memberships/:username",
-      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.hellcat-preview+json"
       },
+      "method": "DELETE",
       "params": {
         "id": {
           "type": "string",
@@ -4325,14 +4324,14 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/teams/:id/memberships/:username"
     },
     "unblockUser": {
-      "url": "/orgs/:org/blocks/:username",
-      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.giant-sentry-fist-preview+json"
       },
+      "method": "DELETE",
       "params": {
         "org": {
           "type": "string",
@@ -4342,32 +4341,16 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/blocks/:username"
     },
     "update": {
-      "url": "/orgs/:org",
       "method": "PATCH",
       "params": {
-        "org": {
-          "type": "string",
-          "required": true
-        },
         "billing_email": {
           "type": "string"
         },
         "company": {
-          "type": "string"
-        },
-        "email": {
-          "type": "string"
-        },
-        "location": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "description": {
           "type": "string"
         },
         "default_repository_permission": {
@@ -4380,44 +4363,66 @@
           ],
           "default": "read"
         },
+        "description": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
         "members_can_create_repositories": {
           "type": "boolean",
           "default": true
+        },
+        "name": {
+          "type": "string"
+        },
+        "org": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/orgs/:org"
     }
   },
   "projects": {
     "createOrgProject": {
-      "url": "/orgs/:org/projects",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "POST",
       "params": {
-        "org": {
-          "type": "string",
-          "required": true
+        "body": {
+          "type": "string"
         },
         "name": {
           "type": "string",
           "required": true
         },
-        "body": {
-          "type": "string"
+        "org": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/orgs/:org/projects"
     },
     "createProjectCard": {
-      "url": "/projects/columns/:id/cards",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "POST",
       "params": {
         "column_id": {
           "alias": "id",
           "deprecated": "`column_id` parameter has been renamed to `id`"
+        },
+        "content_id": {
+          "type": "string"
+        },
+        "content_type": {
+          "type": "string"
         },
         "id": {
           "type": "string",
@@ -4425,26 +4430,16 @@
         },
         "note": {
           "type": "string"
-        },
-        "content_id": {
-          "type": "string"
-        },
-        "content_type": {
-          "type": "string"
         }
-      }
+      },
+      "url": "/projects/columns/:id/cards"
     },
     "createProjectColumn": {
-      "url": "/projects/:id/columns",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "POST",
       "params": {
-        "project_id": {
-          "alias": "id",
-          "deprecated": "`project_id` parameter has been renamed to `id`"
-        },
         "id": {
           "type": "string",
           "required": true
@@ -4452,16 +4447,27 @@
         "name": {
           "type": "string",
           "required": true
+        },
+        "project_id": {
+          "alias": "id",
+          "deprecated": "`project_id` parameter has been renamed to `id`"
         }
-      }
+      },
+      "url": "/projects/:id/columns"
     },
     "createRepoProject": {
-      "url": "/repos/:owner/:repo/projects",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "POST",
       "params": {
+        "body": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -4469,61 +4475,54 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "name": {
-          "type": "string",
-          "required": true
-        },
-        "body": {
-          "type": "string"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/projects"
     },
     "deleteProject": {
-      "url": "/projects/:id",
-      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "DELETE",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/projects/:id"
     },
     "deleteProjectCard": {
-      "url": "/projects/columns/cards/:id",
-      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "DELETE",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/projects/columns/cards/:id"
     },
     "deleteProjectColumn": {
-      "url": "/projects/columns/:id",
-      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "DELETE",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/projects/columns/:id"
     },
     "getOrgProjects": {
-      "url": "/orgs/:org/projects",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "GET",
       "params": {
         "org": {
           "type": "string",
@@ -4538,40 +4537,40 @@
           ],
           "default": "open"
         }
-      }
+      },
+      "url": "/orgs/:org/projects"
     },
     "getProject": {
-      "url": "/projects/:id",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/projects/:id"
     },
     "getProjectCard": {
-      "url": "/projects/columns/cards/:id",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/projects/columns/cards/:id"
     },
     "getProjectCards": {
-      "url": "/projects/columns/:id/cards",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "GET",
       "params": {
         "column_id": {
           "alias": "id",
@@ -4581,44 +4580,44 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/projects/columns/:id/cards"
     },
     "getProjectColumn": {
-      "url": "/projects/columns/:id",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/projects/columns/:id"
     },
     "getProjectColumns": {
-      "url": "/projects/:id/columns",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "GET",
       "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
         "project_id": {
           "alias": "id",
           "deprecated": "`project_id` parameter has been renamed to `id`"
-        },
-        "id": {
-          "type": "string",
-          "required": true
         }
-      }
+      },
+      "url": "/projects/:id/columns"
     },
     "getRepoProjects": {
-      "url": "/repos/:owner/:repo/projects",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "GET",
       "params": {
         "owner": {
           "type": "string",
@@ -4637,15 +4636,18 @@
           ],
           "default": "open"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/projects"
     },
     "moveProjectCard": {
-      "url": "/projects/columns/cards/:id/moves",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "POST",
       "params": {
+        "column_id": {
+          "type": "string"
+        },
         "id": {
           "type": "string",
           "required": true
@@ -4654,18 +4656,15 @@
           "type": "string",
           "required": true,
           "validation": "^(top|bottom|after:\\d+)$"
-        },
-        "column_id": {
-          "type": "string"
         }
-      }
+      },
+      "url": "/projects/columns/cards/:id/moves"
     },
     "moveProjectColumn": {
-      "url": "/projects/columns/:id/moves",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "POST",
       "params": {
         "id": {
           "type": "string",
@@ -4676,15 +4675,18 @@
           "required": true,
           "validation": "^(first|last|after:\\d+)$"
         }
-      }
+      },
+      "url": "/projects/columns/:id/moves"
     },
     "updateProject": {
-      "url": "/projects/:id",
-      "method": "PATCH",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "PATCH",
       "params": {
+        "body": {
+          "type": "string"
+        },
         "id": {
           "type": "string",
           "required": true
@@ -4692,9 +4694,6 @@
         "name": {
           "type": "string",
           "required": true
-        },
-        "body": {
-          "type": "string"
         },
         "state": {
           "type": "string",
@@ -4705,14 +4704,14 @@
           ],
           "default": "open"
         }
-      }
+      },
+      "url": "/projects/:id"
     },
     "updateProjectCard": {
-      "url": "/projects/columns/cards/:id",
-      "method": "PATCH",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "PATCH",
       "params": {
         "id": {
           "type": "string",
@@ -4721,14 +4720,14 @@
         "note": {
           "type": "string"
         }
-      }
+      },
+      "url": "/projects/columns/cards/:id"
     },
     "updateProjectColumn": {
-      "url": "/projects/columns/:id",
-      "method": "PATCH",
       "headers": {
         "accept": "application/vnd.github.inertia-preview+json"
       },
+      "method": "PATCH",
       "params": {
         "id": {
           "type": "string",
@@ -4738,27 +4737,23 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/projects/columns/:id"
     }
   },
   "pullRequests": {
     "checkMerged": {
-      "url": "/repos/:owner/:repo/pulls/:number/merge",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.polaris-preview"
       },
+      "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "number": {
           "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
           "required": true
         },
         "page": {
@@ -4767,53 +4762,57 @@
         "per_page": {
           "type": "number",
           "default": "30"
-        }
-      }
-    },
-    "create": {
-      "url": "/repos/:owner/:repo/pulls",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
         },
         "repo": {
           "type": "string",
           "required": true
-        },
-        "head": {
-          "type": "string",
-          "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number/merge"
+    },
+    "create": {
+      "method": "POST",
+      "params": {
         "base": {
-          "type": "string",
-          "required": true
-        },
-        "title": {
           "type": "string",
           "required": true
         },
         "body": {
           "type": "string"
         },
+        "head": {
+          "type": "string",
+          "required": true
+        },
         "maintainer_can_modify": {
           "type": "boolean"
-        }
-      }
-    },
-    "createComment": {
-      "url": "/repos/:owner/:repo/pulls/:number/comments",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
         },
         "repo": {
+          "type": "string",
+          "required": true
+        },
+        "title": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/pulls"
+    },
+    "createComment": {
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "method": "POST",
+      "params": {
+        "body": {
+          "type": "string",
+          "required": true
+        },
+        "commit_id": {
           "type": "string",
           "required": true
         },
@@ -4821,11 +4820,7 @@
           "type": "number",
           "required": true
         },
-        "body": {
-          "type": "string",
-          "required": true
-        },
-        "commit_id": {
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -4836,28 +4831,20 @@
         "position": {
           "type": "number",
           "required": true
-        }
-      }
-    },
-    "createCommentReply": {
-      "url": "/repos/:owner/:repo/pulls/:number/comments",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
         },
         "repo": {
           "type": "string",
           "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number/comments"
+    },
+    "createCommentReply": {
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "method": "POST",
+      "params": {
         "body": {
           "type": "string",
           "required": true
@@ -4865,18 +4852,30 @@
         "in_reply_to": {
           "type": "number",
           "required": true
-        }
-      }
-    },
-    "createFromIssue": {
-      "url": "/repos/:owner/:repo/pulls",
-      "method": "POST",
-      "params": {
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
         },
         "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number/comments"
+    },
+    "createFromIssue": {
+      "method": "POST",
+      "params": {
+        "base": {
+          "type": "string",
+          "required": true
+        },
+        "head": {
           "type": "string",
           "required": true
         },
@@ -4884,20 +4883,6 @@
           "type": "number",
           "required": true
         },
-        "head": {
-          "type": "string",
-          "required": true
-        },
-        "base": {
-          "type": "string",
-          "required": true
-        }
-      }
-    },
-    "createReview": {
-      "url": "/repos/:owner/:repo/pulls/:number/reviews",
-      "method": "POST",
-      "params": {
         "owner": {
           "type": "string",
           "required": true
@@ -4905,15 +4890,20 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "commit_id": {
+        }
+      },
+      "url": "/repos/:owner/:repo/pulls"
+    },
+    "createReview": {
+      "method": "POST",
+      "params": {
+        "body": {
           "type": "string"
         },
-        "body": {
+        "comments": {
+          "type": "string[]"
+        },
+        "commit_id": {
           "type": "string"
         },
         "event": {
@@ -4926,18 +4916,31 @@
           ],
           "default": "PENDING"
         },
-        "comments": {
-          "type": "string[]"
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number/reviews"
     },
     "createReviewRequest": {
-      "url": "/repos/:owner/:repo/pulls/:number/requested_reviewers",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.thor-preview+json"
       },
+      "method": "POST",
       "params": {
+        "number": {
+          "type": "number",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -4946,48 +4949,40 @@
           "type": "string",
           "required": true
         },
-        "number": {
-          "type": "number",
-          "required": true
-        },
         "reviewers": {
           "type": "string[]"
         },
         "team_reviewers": {
           "type": "string[]"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number/requested_reviewers"
     },
     "deleteComment": {
-      "url": "/repos/:owner/:repo/pulls/comments/:id",
-      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.squirrel-girl-preview"
       },
+      "method": "DELETE",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "id": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "deletePendingReview": {
-      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id",
-      "method": "DELETE",
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
         },
         "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/pulls/comments/:id"
+    },
+    "deletePendingReview": {
+      "method": "DELETE",
+      "params": {
+        "id": {
           "type": "string",
           "required": true
         },
@@ -4995,29 +4990,33 @@
           "type": "number",
           "required": true
         },
-        "id": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id"
     },
     "deleteReviewRequest": {
-      "url": "/repos/:owner/:repo/pulls/:number/requested_reviewers",
-      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.thor-preview+json"
       },
+      "method": "DELETE",
       "params": {
+        "number": {
+          "type": "number",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
         },
         "repo": {
           "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
           "required": true
         },
         "reviewers": {
@@ -5026,24 +5025,12 @@
         "team_reviewers": {
           "type": "string[]"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number/requested_reviewers"
     },
     "dismissReview": {
-      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id/dismissals",
       "method": "PUT",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
         "id": {
           "type": "string",
           "required": true
@@ -5051,27 +5038,35 @@
         "message": {
           "type": "string"
         },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
         "page": {
           "type": "number"
         },
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id/dismissals"
     },
     "editComment": {
-      "url": "/repos/:owner/:repo/pulls/comments/:id",
-      "method": "PATCH",
       "headers": {
         "accept": "application/vnd.github.squirrel-girl-preview"
       },
+      "method": "PATCH",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
+        "body": {
           "type": "string",
           "required": true
         },
@@ -5079,16 +5074,6 @@
           "type": "string",
           "required": true
         },
-        "body": {
-          "type": "string",
-          "required": true
-        }
-      }
-    },
-    "get": {
-      "url": "/repos/:owner/:repo/pulls/:number",
-      "method": "GET",
-      "params": {
         "owner": {
           "type": "string",
           "required": true
@@ -5096,17 +5081,17 @@
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/pulls/comments/:id"
+    },
+    "get": {
+      "method": "GET",
+      "params": {
         "number": {
           "type": "number",
           "required": true
-        }
-      }
-    },
-    "getAll": {
-      "url": "/repos/:owner/:repo/pulls",
-      "method": "GET",
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -5114,21 +5099,41 @@
         "repo": {
           "type": "string",
           "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number"
+    },
+    "getAll": {
+      "method": "GET",
+      "params": {
+        "base": {
+          "type": "string"
         },
-        "state": {
+        "direction": {
           "type": "string",
           "enum": [
-            "open",
-            "closed",
-            "all"
+            "asc",
+            "desc"
           ],
-          "default": "open"
+          "default": "desc"
         },
         "head": {
           "type": "string"
         },
-        "base": {
-          "type": "string"
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         },
         "sort": {
           "type": "string",
@@ -5140,6 +5145,73 @@
           ],
           "default": "created"
         },
+        "state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "closed",
+            "all"
+          ],
+          "default": "open"
+        }
+      },
+      "url": "/repos/:owner/:repo/pulls"
+    },
+    "getComment": {
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "method": "GET",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/pulls/comments/:id"
+    },
+    "getComments": {
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "method": "GET",
+      "params": {
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number/comments"
+    },
+    "getCommentsForRepo": {
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "method": "GET",
+      "params": {
         "direction": {
           "type": "string",
           "enum": [
@@ -5148,53 +5220,8 @@
           ],
           "default": "desc"
         },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
-        }
-      }
-    },
-    "getComment": {
-      "url": "/repos/:owner/:repo/pulls/comments/:id",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
         "owner": {
           "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      }
-    },
-    "getComments": {
-      "url": "/repos/:owner/:repo/pulls/:number/comments",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
           "required": true
         },
         "page": {
@@ -5203,23 +5230,13 @@
         "per_page": {
           "type": "number",
           "default": "30"
-        }
-      }
-    },
-    "getCommentsForRepo": {
-      "url": "/repos/:owner/:repo/pulls/comments",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
         },
         "repo": {
           "type": "string",
           "required": true
+        },
+        "since": {
+          "type": "date"
         },
         "sort": {
           "type": "string",
@@ -5228,41 +5245,19 @@
             "updated"
           ],
           "default": "created"
-        },
-        "direction": {
-          "type": "string",
-          "enum": [
-            "asc",
-            "desc"
-          ],
-          "default": "desc"
-        },
-        "since": {
-          "type": "date"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/pulls/comments"
     },
     "getCommits": {
-      "url": "/repos/:owner/:repo/pulls/:number/commits",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "number": {
           "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
           "required": true
         },
         "page": {
@@ -5271,23 +5266,23 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number/commits"
     },
     "getFiles": {
-      "url": "/repos/:owner/:repo/pulls/:number/files",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "number": {
           "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
           "required": true
         },
         "page": {
@@ -5296,18 +5291,18 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number/files"
     },
     "getReview": {
-      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
+        "id": {
           "type": "string",
           "required": true
         },
@@ -5315,21 +5310,21 @@
           "type": "number",
           "required": true
         },
-        "id": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id"
     },
     "getReviewComments": {
-      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id/comments",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
+        "id": {
           "type": "string",
           "required": true
         },
@@ -5337,7 +5332,7 @@
           "type": "number",
           "required": true
         },
-        "id": {
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -5347,51 +5342,26 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id/comments"
     },
     "getReviewRequests": {
-      "url": "/repos/:owner/:repo/pulls/:number/requested_reviewers",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.thor-preview+json"
       },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
-        }
-      }
-    },
-    "getReviews": {
-      "url": "/repos/:owner/:repo/pulls/:number/reviews",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "number": {
           "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
           "required": true
         },
         "page": {
@@ -5400,35 +5370,49 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number/requested_reviewers"
+    },
+    "getReviews": {
+      "method": "GET",
+      "params": {
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number/reviews"
     },
     "merge": {
-      "url": "/repos/:owner/:repo/pulls/:number/merge",
-      "method": "PUT",
       "headers": {
         "accept": "application/vnd.github.polaris-preview"
       },
+      "method": "PUT",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "commit_title": {
-          "type": "string"
-        },
         "commit_message": {
           "type": "string"
         },
-        "sha": {
+        "commit_title": {
           "type": "string"
         },
         "merge_method": {
@@ -5439,13 +5423,11 @@
             "rebase"
           ],
           "default": "merge"
-        }
-      }
-    },
-    "submitReview": {
-      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id/events",
-      "method": "POST",
-      "params": {
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -5454,14 +5436,15 @@
           "type": "string",
           "required": true
         },
-        "number": {
-          "type": "number",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        },
+        "sha": {
+          "type": "string"
+        }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number/merge"
+    },
+    "submitReview": {
+      "method": "POST",
+      "params": {
         "body": {
           "type": "string"
         },
@@ -5474,18 +5457,8 @@
             "PENDING"
           ],
           "default": "PENDING"
-        }
-      }
-    },
-    "update": {
-      "url": "/repos/:owner/:repo/pulls/:number",
-      "method": "PATCH",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
         },
-        "repo": {
+        "id": {
           "type": "string",
           "required": true
         },
@@ -5493,11 +5466,41 @@
           "type": "number",
           "required": true
         },
-        "title": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number/reviews/:id/events"
+    },
+    "update": {
+      "method": "PATCH",
+      "params": {
+        "base": {
           "type": "string"
         },
         "body": {
           "type": "string"
+        },
+        "maintainer_can_modify": {
+          "type": "boolean",
+          "default": "true"
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         },
         "state": {
           "type": "string",
@@ -5506,36 +5509,20 @@
             "closed"
           ]
         },
-        "base": {
+        "title": {
           "type": "string"
-        },
-        "maintainer_can_modify": {
-          "type": "boolean",
-          "default": "true"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/pulls/:number"
     }
   },
   "reactions": {
     "createForCommitComment": {
-      "url": "/repos/:owner/:repo/comments/:id/reactions",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.squirrel-girl-preview"
       },
+      "method": "POST",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        },
         "content": {
           "type": "string",
           "required": true,
@@ -5547,28 +5534,28 @@
             "heart",
             "hooray"
           ]
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/comments/:id/reactions"
     },
     "createForIssue": {
-      "url": "/repos/:owner/:repo/issues/:number/reactions",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.squirrel-girl-preview"
       },
+      "method": "POST",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "number": {
-          "type": "number",
-          "required": true
-        },
         "content": {
           "type": "string",
           "required": true,
@@ -5580,28 +5567,28 @@
             "heart",
             "hooray"
           ]
+        },
+        "number": {
+          "type": "number",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/issues/:number/reactions"
     },
     "createForIssueComment": {
-      "url": "/repos/:owner/:repo/issues/comments/:id/reactions",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.squirrel-girl-preview"
       },
+      "method": "POST",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        },
         "content": {
           "type": "string",
           "required": true,
@@ -5613,28 +5600,28 @@
             "heart",
             "hooray"
           ]
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/issues/comments/:id/reactions"
     },
     "createForPullRequestReviewComment": {
-      "url": "/repos/:owner/:repo/pulls/comments/:id/reactions",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.squirrel-girl-preview"
       },
+      "method": "POST",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        },
         "content": {
           "type": "string",
           "required": true,
@@ -5646,29 +5633,11 @@
             "heart",
             "hooray"
           ]
-        }
-      }
-    },
-    "delete": {
-      "url": "/reactions/:id",
-      "method": "DELETE",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
+        },
         "id": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "getForCommitComment": {
-      "url": "/repos/:owner/:repo/comments/:id/reactions",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -5676,11 +5645,29 @@
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/pulls/comments/:id/reactions"
+    },
+    "delete": {
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "method": "DELETE",
+      "params": {
         "id": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/reactions/:id"
+    },
+    "getForCommitComment": {
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "method": "GET",
+      "params": {
         "content": {
           "type": "string",
           "enum": [
@@ -5691,16 +5678,11 @@
             "heart",
             "hooray"
           ]
-        }
-      }
-    },
-    "getForIssue": {
-      "url": "/repos/:owner/:repo/issues/:number/reactions",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.squirrel-girl-preview"
-      },
-      "params": {
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -5708,43 +5690,48 @@
         "repo": {
           "type": "string",
           "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/comments/:id/reactions"
+    },
+    "getForIssue": {
+      "headers": {
+        "accept": "application/vnd.github.squirrel-girl-preview"
+      },
+      "method": "GET",
+      "params": {
+        "content": {
+          "type": "string",
+          "enum": [
+            "+1",
+            "-1",
+            "laugh",
+            "confused",
+            "heart",
+            "hooray"
+          ]
         },
         "number": {
           "type": "number",
           "required": true
         },
-        "content": {
+        "owner": {
           "type": "string",
-          "enum": [
-            "+1",
-            "-1",
-            "laugh",
-            "confused",
-            "heart",
-            "hooray"
-          ]
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/issues/:number/reactions"
     },
     "getForIssueComment": {
-      "url": "/repos/:owner/:repo/issues/comments/:id/reactions",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.squirrel-girl-preview"
       },
+      "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        },
         "content": {
           "type": "string",
           "enum": [
@@ -5755,28 +5742,28 @@
             "heart",
             "hooray"
           ]
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/issues/comments/:id/reactions"
     },
     "getForPullRequestReviewComment": {
-      "url": "/repos/:owner/:repo/pulls/comments/:id/reactions",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.squirrel-girl-preview"
       },
+      "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
-        },
         "content": {
           "type": "string",
           "enum": [
@@ -5787,24 +5774,28 @@
             "heart",
             "hooray"
           ]
+        },
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/pulls/comments/:id/reactions"
     }
   },
   "repos": {
     "addCollaborator": {
-      "url": "/repos/:owner/:repo/collaborators/:username",
       "method": "PUT",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "username": {
           "type": "string",
           "required": true
         },
@@ -5816,16 +5807,31 @@
             "admin"
           ],
           "default": "push"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/collaborators/:username"
     },
     "addDeployKey": {
-      "url": "/repos/:owner/:repo/keys",
       "method": "POST",
       "params": {
+        "key": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
+        },
+        "read_only": {
+          "type": "boolean"
         },
         "repo": {
           "type": "string",
@@ -5834,29 +5840,18 @@
         "title": {
           "type": "string",
           "required": true
-        },
-        "key": {
-          "type": "string",
-          "required": true
-        },
-        "read_only": {
-          "type": "boolean"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/keys"
     },
     "addProtectedBranchAdminEnforcement": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins",
       "method": "POST",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "branch": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -5866,21 +5861,17 @@
         "per_page": {
           "type": "number",
           "default": "30"
-        }
-      }
-    },
-    "addProtectedBranchRequiredStatusChecksContexts": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
         },
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins"
+    },
+    "addProtectedBranchRequiredStatusChecksContexts": {
+      "method": "POST",
+      "params": {
         "branch": {
           "type": "string",
           "required": true
@@ -5889,13 +5880,7 @@
           "type": "string[]",
           "required": true,
           "mapTo": "input"
-        }
-      }
-    },
-    "addProtectedBranchTeamRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
-      "method": "POST",
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -5903,8 +5888,22 @@
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
+    },
+    "addProtectedBranchTeamRestrictions": {
+      "method": "POST",
+      "params": {
         "branch": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
           "type": "string",
           "required": true
         },
@@ -5913,12 +5912,16 @@
           "required": true,
           "mapTo": "input"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
     },
     "addProtectedBranchUserRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
       "method": "POST",
       "params": {
+        "branch": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -5927,19 +5930,15 @@
           "type": "string",
           "required": true
         },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
         "users": {
           "type": "string[]",
           "required": true,
           "mapTo": "input"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
     },
     "checkCollaborator": {
-      "url": "/repos/:owner/:repo/collaborators/:username",
       "method": "GET",
       "params": {
         "owner": {
@@ -5954,20 +5953,12 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/collaborators/:username"
     },
     "compareCommits": {
-      "url": "/repos/:owner/:repo/compare/:base...:head",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "base": {
           "type": "string",
           "required": true
@@ -5975,26 +5966,42 @@
         "head": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "create": {
-      "url": "/user/repos",
-      "method": "POST",
-      "params": {
-        "name": {
+        },
+        "owner": {
           "type": "string",
           "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/compare/:base...:head"
+    },
+    "create": {
+      "method": "POST",
+      "params": {
+        "allow_merge_commit": {
+          "type": "boolean",
+          "default": "true"
+        },
+        "allow_rebase_merge": {
+          "type": "boolean",
+          "default": "true"
+        },
+        "allow_squash_merge": {
+          "type": "boolean",
+          "default": "true"
+        },
+        "auto_init": {
+          "type": "boolean",
+          "default": "false"
         },
         "description": {
           "type": "string"
         },
-        "homepage": {
+        "gitignore_template": {
           "type": "string"
-        },
-        "private": {
-          "type": "boolean",
-          "default": "false"
         },
         "has_issues": {
           "type": "boolean",
@@ -6008,50 +6015,34 @@
           "type": "boolean",
           "default": "true"
         },
-        "team_id": {
-          "type": "number"
-        },
-        "auto_init": {
-          "type": "boolean",
-          "default": "false"
-        },
-        "gitignore_template": {
+        "homepage": {
           "type": "string"
         },
         "license_template": {
           "type": "string"
         },
-        "allow_squash_merge": {
-          "type": "boolean",
-          "default": "true"
+        "name": {
+          "type": "string",
+          "required": true
         },
-        "allow_merge_commit": {
+        "private": {
           "type": "boolean",
-          "default": "true"
+          "default": "false"
         },
-        "allow_rebase_merge": {
-          "type": "boolean",
-          "default": "true"
+        "team_id": {
+          "type": "number"
         }
-      }
+      },
+      "url": "/user/repos"
     },
     "createCommitComment": {
-      "url": "/repos/:owner/:repo/commits/:sha/comments",
       "method": "POST",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "sha": {
-          "type": "string",
-          "required": true
-        },
         "body": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -6060,40 +6051,29 @@
         },
         "position": {
           "type": "number"
-        }
-      }
-    },
-    "createDeployment": {
-      "url": "/repos/:owner/:repo/deployments",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.ant-man-preview+json"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
         },
         "repo": {
           "type": "string",
           "required": true
         },
-        "ref": {
+        "sha": {
           "type": "string",
           "required": true
-        },
-        "task": {
-          "type": "string",
-          "default": "deploy"
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/commits/:sha/comments"
+    },
+    "createDeployment": {
+      "headers": {
+        "accept": "application/vnd.github.ant-man-preview+json"
+      },
+      "method": "POST",
+      "params": {
         "auto_merge": {
           "type": "boolean",
           "default": "true"
         },
-        "required_contexts": {
-          "type": "string[]"
-        },
-        "payload": {
+        "description": {
           "type": "string",
           "default": "\"\""
         },
@@ -6101,27 +6081,18 @@
           "type": "string",
           "default": "none"
         },
-        "description": {
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "payload": {
           "type": "string",
           "default": "\"\""
         },
-        "transient_environment": {
-          "type": "boolean",
-          "default": false
-        },
         "production_environment": {
           "type": "boolean"
-        }
-      }
-    },
-    "createDeploymentStatus": {
-      "url": "/repos/:owner/:repo/deployments/:id/statuses",
-      "method": "POST",
-      "headers": {
-        "accept": "application/vnd.github.ant-man-preview+json"
-      },
-      "params": {
-        "owner": {
+        },
+        "ref": {
           "type": "string",
           "required": true
         },
@@ -6129,20 +6100,29 @@
           "type": "string",
           "required": true
         },
-        "id": {
-          "type": "string",
-          "required": true
+        "required_contexts": {
+          "type": "string[]"
         },
-        "state": {
-          "type": "string"
-        },
-        "target_url": {
+        "task": {
           "type": "string",
-          "default": "\"\""
+          "default": "deploy"
         },
-        "log_url": {
-          "type": "string",
-          "default": "\"\""
+        "transient_environment": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "url": "/repos/:owner/:repo/deployments"
+    },
+    "createDeploymentStatus": {
+      "headers": {
+        "accept": "application/vnd.github.ant-man-preview+json"
+      },
+      "method": "POST",
+      "params": {
+        "auto_inactive": {
+          "type": "boolean",
+          "default": true
         },
         "description": {
           "type": "string",
@@ -6152,16 +6132,14 @@
           "type": "string",
           "default": "\"\""
         },
-        "auto_inactive": {
-          "type": "boolean",
-          "default": true
-        }
-      }
-    },
-    "createFile": {
-      "url": "/repos/:owner/:repo/contents/:path",
-      "method": "PUT",
-      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
+        "log_url": {
+          "type": "string",
+          "default": "\"\""
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -6170,17 +6148,21 @@
           "type": "string",
           "required": true
         },
-        "path": {
-          "type": "string",
-          "required": true
+        "state": {
+          "type": "string"
         },
-        "message": {
+        "target_url": {
           "type": "string",
-          "required": true
-        },
-        "content": {
-          "type": "string",
-          "required": true
+          "default": "\"\""
+        }
+      },
+      "url": "/repos/:owner/:repo/deployments/:id/statuses"
+    },
+    "createFile": {
+      "method": "PUT",
+      "params": {
+        "author": {
+          "type": "json"
         },
         "branch": {
           "type": "string"
@@ -6188,32 +6170,53 @@
         "committer": {
           "type": "json"
         },
-        "author": {
-          "type": "json"
-        }
-      }
-    },
-    "createForOrg": {
-      "url": "/orgs/:org/repos",
-      "method": "POST",
-      "params": {
-        "org": {
+        "content": {
           "type": "string",
           "required": true
         },
-        "name": {
+        "message": {
           "type": "string",
           "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "path": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/contents/:path"
+    },
+    "createForOrg": {
+      "method": "POST",
+      "params": {
+        "allow_merge_commit": {
+          "type": "boolean",
+          "default": "true"
+        },
+        "allow_rebase_merge": {
+          "type": "boolean",
+          "default": "true"
+        },
+        "allow_squash_merge": {
+          "type": "boolean",
+          "default": "true"
+        },
+        "auto_init": {
+          "type": "boolean",
+          "default": "false"
         },
         "description": {
           "type": "string"
         },
-        "homepage": {
+        "gitignore_template": {
           "type": "string"
-        },
-        "private": {
-          "type": "boolean",
-          "default": "false"
         },
         "has_issues": {
           "type": "boolean",
@@ -6227,48 +6230,35 @@
           "type": "boolean",
           "default": "true"
         },
-        "team_id": {
-          "type": "number"
-        },
-        "auto_init": {
-          "type": "boolean",
-          "default": "false"
-        },
-        "gitignore_template": {
+        "homepage": {
           "type": "string"
         },
         "license_template": {
           "type": "string"
         },
-        "allow_squash_merge": {
-          "type": "boolean",
-          "default": "true"
-        },
-        "allow_merge_commit": {
-          "type": "boolean",
-          "default": "true"
-        },
-        "allow_rebase_merge": {
-          "type": "boolean",
-          "default": "true"
-        }
-      }
-    },
-    "createHook": {
-      "url": "/repos/:owner/:repo/hooks",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "name": {
           "type": "string",
           "required": true
+        },
+        "org": {
+          "type": "string",
+          "required": true
+        },
+        "private": {
+          "type": "boolean",
+          "default": "false"
+        },
+        "team_id": {
+          "type": "number"
+        }
+      },
+      "url": "/orgs/:org/repos"
+    },
+    "createHook": {
+      "method": "POST",
+      "params": {
+        "active": {
+          "type": "boolean"
         },
         "config": {
           "type": "json",
@@ -6278,18 +6268,41 @@
           "type": "string[]",
           "default": "[\"push\"]"
         },
-        "active": {
-          "type": "boolean"
-        }
-      }
-    },
-    "createRelease": {
-      "url": "/repos/:owner/:repo/releases",
-      "method": "POST",
-      "params": {
+        "name": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/hooks"
+    },
+    "createRelease": {
+      "method": "POST",
+      "params": {
+        "body": {
+          "type": "string"
+        },
+        "draft": {
+          "type": "boolean",
+          "default": "false"
+        },
+        "name": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "prerelease": {
+          "type": "boolean",
+          "default": "false"
         },
         "repo": {
           "type": "string",
@@ -6301,27 +6314,19 @@
         },
         "target_commitish": {
           "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        },
-        "draft": {
-          "type": "boolean",
-          "default": "false"
-        },
-        "prerelease": {
-          "type": "boolean",
-          "default": "false"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/releases"
     },
     "createStatus": {
-      "url": "/repos/:owner/:repo/statuses/:sha",
       "method": "POST",
       "params": {
+        "context": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -6346,21 +6351,15 @@
         },
         "target_url": {
           "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "context": {
-          "type": "string"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/statuses/:sha"
     },
     "delete": {
-      "url": "/repos/:owner/:repo",
-      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.drax-preview+json"
       },
+      "method": "DELETE",
       "params": {
         "owner": {
           "type": "string",
@@ -6370,12 +6369,16 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo"
     },
     "deleteAsset": {
-      "url": "/repos/:owner/:repo/releases/assets/:id",
       "method": "DELETE",
       "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -6383,17 +6386,17 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/releases/assets/:id"
     },
     "deleteCommitComment": {
-      "url": "/repos/:owner/:repo/comments/:id",
       "method": "DELETE",
       "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -6401,17 +6404,17 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/comments/:id"
     },
     "deleteDeployKey": {
-      "url": "/repos/:owner/:repo/keys/:id",
       "method": "DELETE",
       "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -6419,35 +6422,17 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/keys/:id"
     },
     "deleteDownload": {
-      "url": "/repos/:owner/:repo/downloads/:id",
       "method": "DELETE",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "id": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "deleteFile": {
-      "url": "/repos/:owner/:repo/contents/:path",
-      "method": "DELETE",
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -6455,18 +6440,15 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "path": {
-          "type": "string",
-          "required": true
-        },
-        "message": {
-          "type": "string",
-          "required": true
-        },
-        "sha": {
-          "type": "string",
-          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/downloads/:id"
+    },
+    "deleteFile": {
+      "method": "DELETE",
+      "params": {
+        "author": {
+          "type": "json"
         },
         "branch": {
           "type": "string"
@@ -6474,16 +6456,15 @@
         "committer": {
           "type": "json"
         },
-        "author": {
-          "type": "json"
-        }
-      }
-    },
-    "deleteHook": {
-      "url": "/repos/:owner/:repo/hooks/:id",
-      "method": "DELETE",
-      "params": {
+        "message": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
+          "type": "string",
+          "required": true
+        },
+        "path": {
           "type": "string",
           "required": true
         },
@@ -6491,16 +6472,20 @@
           "type": "string",
           "required": true
         },
+        "sha": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/contents/:path"
+    },
+    "deleteHook": {
+      "method": "DELETE",
+      "params": {
         "id": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "deleteInvite": {
-      "url": "/repos/:owner/:repo/invitations/:invitation_id",
-      "method": "DELETE",
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -6508,17 +6493,17 @@
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/hooks/:id"
+    },
+    "deleteInvite": {
+      "method": "DELETE",
+      "params": {
         "invitation_id": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "deleteRelease": {
-      "url": "/repos/:owner/:repo/releases/:id",
-      "method": "DELETE",
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -6526,20 +6511,17 @@
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/invitations/:invitation_id"
+    },
+    "deleteRelease": {
+      "method": "DELETE",
+      "params": {
         "id": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "edit": {
-      "url": "/repos/:owner/:repo",
-      "method": "PATCH",
-      "headers": {
-        "accept": "application/vnd.github.drax-preview+json"
-      },
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -6547,20 +6529,33 @@
         "repo": {
           "type": "string",
           "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/releases/:id"
+    },
+    "edit": {
+      "headers": {
+        "accept": "application/vnd.github.drax-preview+json"
+      },
+      "method": "PATCH",
+      "params": {
+        "allow_merge_commit": {
+          "type": "boolean",
+          "default": "true"
         },
-        "name": {
-          "type": "string",
-          "required": true
+        "allow_rebase_merge": {
+          "type": "boolean",
+          "default": "true"
+        },
+        "allow_squash_merge": {
+          "type": "boolean",
+          "default": "true"
+        },
+        "default_branch": {
+          "type": "string"
         },
         "description": {
           "type": "string"
-        },
-        "homepage": {
-          "type": "string"
-        },
-        "private": {
-          "type": "boolean",
-          "default": "false"
         },
         "has_issues": {
           "type": "boolean",
@@ -6574,52 +6569,42 @@
           "type": "boolean",
           "default": "true"
         },
-        "default_branch": {
+        "homepage": {
           "type": "string"
         },
-        "allow_squash_merge": {
-          "type": "boolean",
-          "default": "true"
+        "name": {
+          "type": "string",
+          "required": true
         },
-        "allow_merge_commit": {
-          "type": "boolean",
-          "default": "true"
-        },
-        "allow_rebase_merge": {
-          "type": "boolean",
-          "default": "true"
-        }
-      }
-    },
-    "editAsset": {
-      "url": "/repos/:owner/:repo/releases/assets/:id",
-      "method": "PATCH",
-      "params": {
         "owner": {
           "type": "string",
           "required": true
         },
+        "private": {
+          "type": "boolean",
+          "default": "false"
+        },
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo"
+    },
+    "editAsset": {
+      "method": "PATCH",
+      "params": {
         "id": {
-          "type": "string",
-          "required": true
-        },
-        "name": {
           "type": "string",
           "required": true
         },
         "label": {
           "type": "string"
-        }
-      }
-    },
-    "editHook": {
-      "url": "/repos/:owner/:repo/hooks/:id",
-      "method": "PATCH",
-      "params": {
+        },
+        "name": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -6627,14 +6612,18 @@
         "repo": {
           "type": "string",
           "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/releases/assets/:id"
+    },
+    "editHook": {
+      "method": "PATCH",
+      "params": {
+        "active": {
+          "type": "boolean"
         },
-        "id": {
-          "type": "string",
-          "required": true
-        },
-        "name": {
-          "type": "string",
-          "required": true
+        "add_events": {
+          "type": "string[]"
         },
         "config": {
           "type": "json",
@@ -6644,30 +6633,54 @@
           "type": "string[]",
           "default": "[\"push\"]"
         },
-        "add_events": {
-          "type": "string[]"
+        "id": {
+          "type": "string",
+          "required": true
         },
-        "remove_events": {
-          "type": "string[]"
+        "name": {
+          "type": "string",
+          "required": true
         },
-        "active": {
-          "type": "boolean"
-        }
-      }
-    },
-    "editRelease": {
-      "url": "/repos/:owner/:repo/releases/:id",
-      "method": "PATCH",
-      "params": {
         "owner": {
           "type": "string",
           "required": true
         },
+        "remove_events": {
+          "type": "string[]"
+        },
         "repo": {
           "type": "string",
           "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/hooks/:id"
+    },
+    "editRelease": {
+      "method": "PATCH",
+      "params": {
+        "body": {
+          "type": "string"
+        },
+        "draft": {
+          "type": "boolean",
+          "default": "false"
         },
         "id": {
+          "type": "string",
+          "required": true
+        },
+        "name": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "prerelease": {
+          "type": "boolean",
+          "default": "false"
+        },
+        "repo": {
           "type": "string",
           "required": true
         },
@@ -6677,27 +6690,16 @@
         },
         "target_commitish": {
           "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        },
-        "draft": {
-          "type": "boolean",
-          "default": "false"
-        },
-        "prerelease": {
-          "type": "boolean",
-          "default": "false"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/releases/:id"
     },
     "fork": {
-      "url": "/repos/:owner/:repo/forks",
       "method": "POST",
       "params": {
+        "organization": {
+          "type": "string"
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -6705,18 +6707,15 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "organization": {
-          "type": "string"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/forks"
     },
     "get": {
-      "url": "/repos/:owner/:repo",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.drax-preview+json"
       },
+      "method": "GET",
       "params": {
         "owner": {
           "type": "string",
@@ -6726,45 +6725,15 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo"
     },
     "getAll": {
-      "url": "/user/repos",
       "method": "GET",
       "params": {
-        "visibility": {
-          "type": "string",
-          "enum": [
-            "all",
-            "public",
-            "private"
-          ],
-          "default": "all"
-        },
         "affiliation": {
           "type": "string",
           "default": "owner,collaborator,organization_member"
-        },
-        "type": {
-          "type": "string",
-          "enum": [
-            "all",
-            "owner",
-            "public",
-            "private",
-            "member"
-          ],
-          "default": "all"
-        },
-        "sort": {
-          "type": "string",
-          "enum": [
-            "created",
-            "updated",
-            "pushed",
-            "full_name"
-          ],
-          "default": "full_name"
         },
         "direction": {
           "type": "string",
@@ -6780,18 +6749,44 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "sort": {
+          "type": "string",
+          "enum": [
+            "created",
+            "updated",
+            "pushed",
+            "full_name"
+          ],
+          "default": "full_name"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "all",
+            "owner",
+            "public",
+            "private",
+            "member"
+          ],
+          "default": "all"
+        },
+        "visibility": {
+          "type": "string",
+          "enum": [
+            "all",
+            "public",
+            "private"
+          ],
+          "default": "all"
         }
-      }
+      },
+      "url": "/user/repos"
     },
     "getAllCommitComments": {
-      "url": "/repos/:owner/:repo/comments",
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -6801,21 +6796,17 @@
         "per_page": {
           "type": "number",
           "default": "30"
-        }
-      }
-    },
-    "getArchiveLink": {
-      "url": "/repos/:owner/:repo/:archive_format/:ref",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
         },
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/comments"
+    },
+    "getArchiveLink": {
+      "method": "GET",
+      "params": {
         "archive_format": {
           "type": "string",
           "required": true,
@@ -6825,15 +6816,27 @@
           ],
           "default": "tarball"
         },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
         "ref": {
           "type": "string"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/:archive_format/:ref"
     },
     "getAsset": {
-      "url": "/repos/:owner/:repo/releases/assets/:id",
       "method": "GET",
       "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -6841,44 +6844,36 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/releases/assets/:id"
     },
     "getAssets": {
-      "url": "/repos/:owner/:repo/releases/:id/assets",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "id": {
           "type": "string",
           "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/releases/:id/assets"
     },
     "getBranch": {
-      "url": "/repos/:owner/:repo/branches/:branch",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "branch": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -6888,22 +6883,22 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch"
     },
     "getBranchProtection": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "branch": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -6913,52 +6908,52 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection"
     },
     "getBranches": {
-      "url": "/repos/:owner/:repo/branches",
       "method": "GET",
       "params": {
         "owner": {
           "type": "string",
           "required": true
         },
-        "repo": {
-          "type": "string",
-          "required": true
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
         },
         "protected": {
           "type": "boolean"
         },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches"
     },
     "getById": {
-      "url": "/repositories/:id",
       "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repositories/:id"
     },
     "getClones": {
-      "url": "/repos/:owner/:repo/traffic/clones",
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -6968,21 +6963,17 @@
         "per_page": {
           "type": "number",
           "default": "30"
-        }
-      }
-    },
-    "getCollaborators": {
-      "url": "/repos/:owner/:repo/collaborators",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
         },
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/traffic/clones"
+    },
+    "getCollaborators": {
+      "method": "GET",
+      "params": {
         "affiliation": {
           "type": "string",
           "enum": [
@@ -6992,46 +6983,54 @@
           ],
           "default": "all"
         },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
         "page": {
           "type": "number"
         },
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/collaborators"
     },
     "getCombinedStatusForRef": {
-      "url": "/repos/:owner/:repo/commits/:ref/status",
       "method": "GET",
       "params": {
         "owner": {
           "type": "string",
           "required": true
         },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "ref": {
-          "type": "string",
-          "required": true
-        },
         "page": {
           "type": "number"
         },
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "ref": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/commits/:ref/status"
     },
     "getCommit": {
-      "url": "/repos/:owner/:repo/commits/:sha",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.cryptographer-preview"
       },
+      "method": "GET",
       "params": {
         "owner": {
           "type": "string",
@@ -7045,30 +7044,16 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/commits/:sha"
     },
     "getCommitComment": {
-      "url": "/repos/:owner/:repo/comments/:id",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "id": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "getCommitComments": {
-      "url": "/repos/:owner/:repo/commits/:ref/comments",
-      "method": "GET",
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -7076,8 +7061,14 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "ref": {
+        }
+      },
+      "url": "/repos/:owner/:repo/comments/:id"
+    },
+    "getCommitComments": {
+      "method": "GET",
+      "params": {
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -7087,28 +7078,43 @@
         "per_page": {
           "type": "number",
           "default": "30"
-        }
-      }
-    },
-    "getCommits": {
-      "url": "/repos/:owner/:repo/commits",
-      "method": "GET",
-      "params": {
-        "owner": {
+        },
+        "ref": {
           "type": "string",
           "required": true
         },
         "repo": {
           "type": "string",
           "required": true
-        },
-        "sha": {
+        }
+      },
+      "url": "/repos/:owner/:repo/commits/:ref/comments"
+    },
+    "getCommits": {
+      "method": "GET",
+      "params": {
+        "author": {
           "type": "string"
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "page": {
+          "type": "number"
         },
         "path": {
           "type": "string"
         },
-        "author": {
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
+        },
+        "sha": {
           "type": "string"
         },
         "since": {
@@ -7116,42 +7122,31 @@
         },
         "until": {
           "type": "date"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/commits"
     },
     "getCommunityProfileMetrics": {
-      "url": "/repos/:owner/:name/community/profile",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.black-panther-preview+json"
       },
+      "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
         "name": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "getContent": {
-      "url": "/repos/:owner/:repo/contents/:path",
-      "method": "GET",
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
-        },
-        "repo": {
+        }
+      },
+      "url": "/repos/:owner/:name/community/profile"
+    },
+    "getContent": {
+      "method": "GET",
+      "params": {
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -7162,60 +7157,60 @@
         },
         "ref": {
           "type": "string"
-        }
-      }
-    },
-    "getContributors": {
-      "url": "/repos/:owner/:repo/contributors",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
         },
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/contents/:path"
+    },
+    "getContributors": {
+      "method": "GET",
+      "params": {
         "anon": {
           "type": "boolean"
         },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
         "page": {
           "type": "number"
         },
         "per_page": {
           "type": "number",
           "default": "30"
-        }
-      }
-    },
-    "getDeployKey": {
-      "url": "/repos/:owner/:repo/keys/:id",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
         },
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/contributors"
+    },
+    "getDeployKey": {
+      "method": "GET",
+      "params": {
         "id": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "getDeployKeys": {
-      "url": "/repos/:owner/:repo/keys",
-      "method": "GET",
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
         },
         "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/keys/:id"
+    },
+    "getDeployKeys": {
+      "method": "GET",
+      "params": {
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -7225,21 +7220,17 @@
         "per_page": {
           "type": "number",
           "default": "30"
-        }
-      }
-    },
-    "getDeployment": {
-      "url": "/repos/:owner/:repo/deployments/:id",
-      "method": "GET",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
         },
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/keys"
+    },
+    "getDeployment": {
+      "method": "GET",
+      "params": {
         "deployment_id": {
           "alias": "id",
           "deprecated": "`deployment_id` parameter has been renamed to `id`"
@@ -7247,13 +7238,7 @@
         "id": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "getDeploymentStatus": {
-      "url": "/repos/:owner/:repo/deployments/:id/statuses/:status_id",
-      "method": "GET",
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -7261,8 +7246,22 @@
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/deployments/:id"
+    },
+    "getDeploymentStatus": {
+      "method": "GET",
+      "params": {
         "id": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
           "type": "string",
           "required": true
         },
@@ -7270,15 +7269,19 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/deployments/:id/statuses/:status_id"
     },
     "getDeploymentStatuses": {
-      "url": "/repos/:owner/:repo/deployments/:id/statuses",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.ant-man-preview+json"
       },
+      "method": "GET",
       "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -7286,23 +7289,34 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/deployments/:id/statuses"
     },
     "getDeployments": {
-      "url": "/repos/:owner/:repo/deployments",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.ant-man-preview+json"
       },
+      "method": "GET",
       "params": {
+        "environment": {
+          "type": "string",
+          "default": "none"
+        },
         "owner": {
           "type": "string",
           "required": true
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
+        "ref": {
+          "type": "string",
+          "default": "none"
         },
         "repo": {
           "type": "string",
@@ -7312,54 +7326,35 @@
           "type": "string",
           "default": "none"
         },
-        "ref": {
-          "type": "string",
-          "default": "none"
-        },
         "task": {
           "type": "string",
           "default": "none"
-        },
-        "environment": {
-          "type": "string",
-          "default": "none"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/deployments"
     },
     "getDownload": {
-      "url": "/repos/:owner/:repo/downloads/:id",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "id": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "getDownloads": {
-      "url": "/repos/:owner/:repo/downloads",
-      "method": "GET",
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
         },
         "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/downloads/:id"
+    },
+    "getDownloads": {
+      "method": "GET",
+      "params": {
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -7369,16 +7364,27 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/downloads"
     },
     "getForOrg": {
-      "url": "/orgs/:org/repos",
       "method": "GET",
       "params": {
         "org": {
           "type": "string",
           "required": true
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
         },
         "type": {
           "type": "string",
@@ -7391,43 +7397,13 @@
             "member"
           ],
           "default": "all"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
         }
-      }
+      },
+      "url": "/orgs/:org/repos"
     },
     "getForUser": {
-      "url": "/users/:username/repos",
       "method": "GET",
       "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        },
-        "type": {
-          "type": "string",
-          "enum": [
-            "all",
-            "owner",
-            "member"
-          ],
-          "default": "owner"
-        },
-        "sort": {
-          "type": "string",
-          "enum": [
-            "created",
-            "updated",
-            "pushed",
-            "full_name"
-          ],
-          "default": "full_name"
-        },
         "direction": {
           "type": "string",
           "enum": [
@@ -7442,16 +7418,46 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "sort": {
+          "type": "string",
+          "enum": [
+            "created",
+            "updated",
+            "pushed",
+            "full_name"
+          ],
+          "default": "full_name"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "all",
+            "owner",
+            "member"
+          ],
+          "default": "owner"
+        },
+        "username": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/users/:username/repos"
     },
     "getForks": {
-      "url": "/repos/:owner/:repo/forks",
       "method": "GET",
       "params": {
         "owner": {
           "type": "string",
           "required": true
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
         },
         "repo": {
           "type": "string",
@@ -7465,20 +7471,17 @@
             "stargazers"
           ],
           "default": "newest"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/forks"
     },
     "getHook": {
-      "url": "/repos/:owner/:repo/hooks/:id",
       "method": "GET",
       "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -7486,22 +7489,14 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/hooks/:id"
     },
     "getHooks": {
-      "url": "/repos/:owner/:repo/hooks",
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -7511,11 +7506,15 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/hooks"
     },
     "getInvites": {
-      "url": "/repos/:owner/:repo/invitations",
       "method": "GET",
       "params": {
         "owner": {
@@ -7526,17 +7525,13 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/invitations"
     },
     "getLanguages": {
-      "url": "/repos/:owner/:repo/languages",
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -7546,15 +7541,19 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/languages"
     },
     "getLatestPagesBuild": {
-      "url": "/repos/:owner/:repo/pages/builds/latest",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.mister-fantastic-preview+json"
       },
+      "method": "GET",
       "params": {
         "owner": {
           "type": "string",
@@ -7564,10 +7563,10 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/pages/builds/latest"
     },
     "getLatestRelease": {
-      "url": "/repos/:owner/:repo/releases/latest",
       "method": "GET",
       "params": {
         "owner": {
@@ -7578,20 +7577,16 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/releases/latest"
     },
     "getPages": {
-      "url": "/repos/:owner/:repo/pages",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.mister-fantastic-preview+json"
       },
+      "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -7601,42 +7596,42 @@
         "per_page": {
           "type": "number",
           "default": "30"
-        }
-      }
-    },
-    "getPagesBuild": {
-      "url": "/repos/:owner/:repo/pages/builds/:id",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.mister-fantastic-preview+json"
-      },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
         },
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/pages"
+    },
+    "getPagesBuild": {
+      "headers": {
+        "accept": "application/vnd.github.mister-fantastic-preview+json"
+      },
+      "method": "GET",
+      "params": {
         "id": {
           "type": "string",
           "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/pages/builds/:id"
     },
     "getPagesBuilds": {
-      "url": "/repos/:owner/:repo/pages/builds",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.mister-fantastic-preview+json"
       },
+      "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -7646,18 +7641,18 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/pages/builds"
     },
     "getPaths": {
-      "url": "/repos/:owner/:repo/traffic/popular/paths",
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -7667,22 +7662,22 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/traffic/popular/paths"
     },
     "getProtectedBranchAdminEnforcement": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "branch": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -7692,22 +7687,22 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins"
     },
     "getProtectedBranchPullRequestReviewEnforcement": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "branch": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -7717,22 +7712,22 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews"
     },
     "getProtectedBranchRequiredStatusChecks": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "branch": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -7742,22 +7737,22 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks"
     },
     "getProtectedBranchRequiredStatusChecksContexts": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "branch": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -7767,22 +7762,22 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
     },
     "getProtectedBranchRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "branch": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -7792,22 +7787,22 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions"
     },
     "getProtectedBranchTeamRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "branch": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -7817,76 +7812,76 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
     },
     "getProtectedBranchUserRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
       "method": "GET",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "branch": {
           "type": "string",
           "required": true
         },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
-        }
-      }
-    },
-    "getPublic": {
-      "url": "/repositories",
-      "method": "GET",
-      "params": {
-        "since": {
-          "type": "string"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
-        }
-      }
-    },
-    "getReadme": {
-      "url": "/repos/:owner/:repo/readme",
-      "method": "GET",
-      "params": {
         "owner": {
           "type": "string",
           "required": true
         },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
         "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
+    },
+    "getPublic": {
+      "method": "GET",
+      "params": {
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
+        "since": {
+          "type": "string"
+        }
+      },
+      "url": "/repositories"
+    },
+    "getReadme": {
+      "method": "GET",
+      "params": {
+        "owner": {
           "type": "string",
           "required": true
         },
         "ref": {
           "type": "string"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/readme"
     },
     "getReferrers": {
-      "url": "/repos/:owner/:repo/traffic/popular/referrers",
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -7896,13 +7891,21 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/traffic/popular/referrers"
     },
     "getRelease": {
-      "url": "/repos/:owner/:repo/releases/:id",
       "method": "GET",
       "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -7910,15 +7913,11 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "id": {
-          "type": "string",
-          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/releases/:id"
     },
     "getReleaseByTag": {
-      "url": "/repos/:owner/:repo/releases/tags/:tag",
       "method": "GET",
       "params": {
         "owner": {
@@ -7933,17 +7932,13 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/releases/tags/:tag"
     },
     "getReleases": {
-      "url": "/repos/:owner/:repo/releases",
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -7953,18 +7948,18 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/releases"
     },
     "getShaOfCommitRef": {
-      "url": "/repos/:owner/:repo/commits/:ref",
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -7972,11 +7967,15 @@
           "type": "string",
           "required": true,
           "allow-empty": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/commits/:ref"
     },
     "getStatsCodeFrequency": {
-      "url": "/repos/:owner/:repo/stats/code_frequency",
       "method": "GET",
       "params": {
         "owner": {
@@ -7987,10 +7986,10 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/stats/code_frequency"
     },
     "getStatsCommitActivity": {
-      "url": "/repos/:owner/:repo/stats/commit_activity",
       "method": "GET",
       "params": {
         "owner": {
@@ -8001,10 +8000,10 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/stats/commit_activity"
     },
     "getStatsContributors": {
-      "url": "/repos/:owner/:repo/stats/contributors",
       "method": "GET",
       "params": {
         "owner": {
@@ -8015,10 +8014,10 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/stats/contributors"
     },
     "getStatsParticipation": {
-      "url": "/repos/:owner/:repo/stats/participation",
       "method": "GET",
       "params": {
         "owner": {
@@ -8029,10 +8028,10 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/stats/participation"
     },
     "getStatsPunchCard": {
-      "url": "/repos/:owner/:repo/stats/punch_card",
       "method": "GET",
       "params": {
         "owner": {
@@ -8043,42 +8042,38 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/stats/punch_card"
     },
     "getStatuses": {
-      "url": "/repos/:owner/:repo/commits/:ref/statuses",
       "method": "GET",
       "params": {
         "owner": {
           "type": "string",
           "required": true
         },
-        "repo": {
-          "type": "string",
-          "required": true
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
         },
         "ref": {
           "type": "string",
           "required": true
         },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/commits/:ref/statuses"
     },
     "getTags": {
-      "url": "/repos/:owner/:repo/tags",
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -8088,18 +8083,18 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/tags"
     },
     "getTeams": {
-      "url": "/repos/:owner/:repo/teams",
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
           "type": "string",
           "required": true
         },
@@ -8109,42 +8104,42 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/teams"
     },
     "getTopics": {
-      "url": "/repos/:owner/:repo/topics",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.mercy-preview+json"
       },
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
-        }
-      }
-    },
-    "getViews": {
-      "url": "/repos/:owner/:repo/traffic/views",
       "method": "GET",
       "params": {
         "owner": {
           "type": "string",
           "required": true
         },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
         "repo": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/topics"
+    },
+    "getViews": {
+      "method": "GET",
+      "params": {
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -8154,38 +8149,28 @@
         "per_page": {
           "type": "number",
           "default": "30"
-        }
-      }
-    },
-    "merge": {
-      "url": "/repos/:owner/:repo/merges",
-      "method": "POST",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
         },
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/traffic/views"
+    },
+    "merge": {
+      "method": "POST",
+      "params": {
         "base": {
-          "type": "string",
-          "required": true
-        },
-        "head": {
           "type": "string",
           "required": true
         },
         "commit_message": {
           "type": "string"
-        }
-      }
-    },
-    "pingHook": {
-      "url": "/repos/:owner/:repo/hooks/:id/pings",
-      "method": "POST",
-      "params": {
+        },
+        "head": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -8193,17 +8178,17 @@
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/merges"
+    },
+    "pingHook": {
+      "method": "POST",
+      "params": {
         "id": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "removeBranchProtection": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection",
-      "method": "DELETE",
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -8211,15 +8196,29 @@
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/hooks/:id/pings"
+    },
+    "removeBranchProtection": {
+      "method": "DELETE",
+      "params": {
         "branch": {
           "type": "string",
           "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection"
     },
     "removeCollaborator": {
-      "url": "/repos/:owner/:repo/collaborators/:username",
       "method": "DELETE",
       "params": {
         "owner": {
@@ -8234,12 +8233,16 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/collaborators/:username"
     },
     "removeProtectedBranchAdminEnforcement": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins",
       "method": "DELETE",
       "params": {
+        "branch": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -8247,17 +8250,17 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins"
     },
     "removeProtectedBranchPullRequestReviewEnforcement": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews",
       "method": "DELETE",
       "params": {
+        "branch": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -8265,17 +8268,17 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews"
     },
     "removeProtectedBranchRequiredStatusChecks": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks",
       "method": "DELETE",
       "params": {
+        "branch": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -8283,25 +8286,13 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "branch": {
-          "type": "string",
-          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks"
     },
     "removeProtectedBranchRequiredStatusChecksContexts": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
       "method": "DELETE",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "branch": {
           "type": "string",
           "required": true
@@ -8310,40 +8301,48 @@
           "type": "string[]",
           "required": true,
           "mapTo": "input"
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
     },
     "removeProtectedBranchRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions",
       "method": "DELETE",
       "params": {
+        "branch": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
         },
         "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions"
     },
     "removeProtectedBranchTeamRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
       "method": "DELETE",
       "params": {
+        "branch": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
         },
         "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
           "type": "string",
           "required": true
         },
@@ -8352,21 +8351,21 @@
           "required": true,
           "mapTo": "input"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
     },
     "removeProtectedBranchUserRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
       "method": "DELETE",
       "params": {
+        "branch": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
         },
         "repo": {
-          "type": "string",
-          "required": true
-        },
-        "branch": {
           "type": "string",
           "required": true
         },
@@ -8375,20 +8374,12 @@
           "required": true,
           "mapTo": "input"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
     },
     "replaceProtectedBranchRequiredStatusChecksContexts": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
       "method": "PUT",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "branch": {
           "type": "string",
           "required": true
@@ -8397,13 +8388,7 @@
           "type": "string[]",
           "required": true,
           "mapTo": "input"
-        }
-      }
-    },
-    "replaceProtectedBranchTeamRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
-      "method": "PUT",
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -8411,8 +8396,22 @@
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
+    },
+    "replaceProtectedBranchTeamRestrictions": {
+      "method": "PUT",
+      "params": {
         "branch": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
           "type": "string",
           "required": true
         },
@@ -8421,12 +8420,16 @@
           "required": true,
           "mapTo": "input"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
     },
     "replaceProtectedBranchUserRestrictions": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
       "method": "PUT",
       "params": {
+        "branch": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -8435,44 +8438,40 @@
           "type": "string",
           "required": true
         },
-        "branch": {
-          "type": "string",
-          "required": true
-        },
         "users": {
           "type": "string[]",
           "required": true,
           "mapTo": "input"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
     },
     "replaceTopics": {
-      "url": "/repos/:owner/:repo/topics",
-      "method": "PUT",
       "headers": {
         "accept": "application/vnd.github.mercy-preview+json"
       },
+      "method": "PUT",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "names": {
           "type": "string[]",
           "required": true
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/topics"
     },
     "requestPageBuild": {
-      "url": "/repos/:owner/:repo/pages/builds",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.mister-fantastic-preview+json"
       },
+      "method": "POST",
       "params": {
         "owner": {
           "type": "string",
@@ -8482,10 +8481,10 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/pages/builds"
     },
     "reviewUserPermissionLevel": {
-      "url": "/repos/:owner/:repo/collaborators/:username/permission",
       "method": "GET",
       "params": {
         "owner": {
@@ -8500,30 +8499,16 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/collaborators/:username/permission"
     },
     "testHook": {
-      "url": "/repos/:owner/:repo/hooks/:id/tests",
       "method": "POST",
       "params": {
-        "owner": {
-          "type": "string",
-          "required": true
-        },
-        "repo": {
-          "type": "string",
-          "required": true
-        },
         "id": {
           "type": "string",
           "required": true
-        }
-      }
-    },
-    "updateBranchProtection": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection",
-      "method": "PUT",
-      "params": {
+        },
         "owner": {
           "type": "string",
           "required": true
@@ -8531,28 +8516,19 @@
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/hooks/:id/tests"
+    },
+    "updateBranchProtection": {
+      "method": "PUT",
+      "params": {
         "branch": {
           "type": "string",
           "required": true
         },
-        "required_status_checks": {
-          "type": "json",
-          "required": true,
-          "allow-null": true
-        },
-        "required_pull_request_reviews": {
-          "type": "json",
-          "required": true,
-          "allow-null": true
-        },
         "dismissal_restrictions": {
           "type": "json",
-          "allow-null": true
-        },
-        "restrictions": {
-          "type": "json",
-          "required": true,
           "allow-null": true
         },
         "enforce_admins": {
@@ -8560,24 +8536,43 @@
           "required": true,
           "allow-null": false
         },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
         "page": {
           "type": "number"
         },
         "per_page": {
           "type": "number",
           "default": "30"
-        }
-      }
-    },
-    "updateCommitComment": {
-      "url": "/repos/:owner/:repo/comments/:id",
-      "method": "PATCH",
-      "params": {
-        "owner": {
+        },
+        "repo": {
           "type": "string",
           "required": true
         },
-        "repo": {
+        "required_pull_request_reviews": {
+          "type": "json",
+          "required": true,
+          "allow-null": true
+        },
+        "required_status_checks": {
+          "type": "json",
+          "required": true,
+          "allow-null": true
+        },
+        "restrictions": {
+          "type": "json",
+          "required": true,
+          "allow-null": true
+        }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection"
+    },
+    "updateCommitComment": {
+      "method": "PATCH",
+      "params": {
+        "body": {
           "type": "string",
           "required": true
         },
@@ -8585,16 +8580,6 @@
           "type": "string",
           "required": true
         },
-        "body": {
-          "type": "string",
-          "required": true
-        }
-      }
-    },
-    "updateFile": {
-      "url": "/repos/:owner/:repo/contents/:path",
-      "method": "PUT",
-      "params": {
         "owner": {
           "type": "string",
           "required": true
@@ -8602,22 +8587,15 @@
         "repo": {
           "type": "string",
           "required": true
-        },
-        "path": {
-          "type": "string",
-          "required": true
-        },
-        "message": {
-          "type": "string",
-          "required": true
-        },
-        "content": {
-          "type": "string",
-          "required": true
-        },
-        "sha": {
-          "type": "string",
-          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/comments/:id"
+    },
+    "updateFile": {
+      "method": "PUT",
+      "params": {
+        "author": {
+          "type": "json"
         },
         "branch": {
           "type": "string"
@@ -8625,16 +8603,19 @@
         "committer": {
           "type": "json"
         },
-        "author": {
-          "type": "json"
-        }
-      }
-    },
-    "updateInvite": {
-      "url": "/repos/:owner/:repo/invitations/:invitation_id",
-      "method": "PATCH",
-      "params": {
+        "content": {
+          "type": "string",
+          "required": true
+        },
+        "message": {
+          "type": "string",
+          "required": true
+        },
         "owner": {
+          "type": "string",
+          "required": true
+        },
+        "path": {
           "type": "string",
           "required": true
         },
@@ -8642,7 +8623,21 @@
           "type": "string",
           "required": true
         },
+        "sha": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/repos/:owner/:repo/contents/:path"
+    },
+    "updateInvite": {
+      "method": "PATCH",
+      "params": {
         "invitation_id": {
+          "type": "string",
+          "required": true
+        },
+        "owner": {
           "type": "string",
           "required": true
         },
@@ -8653,41 +8648,28 @@
             "write",
             "admin"
           ]
-        }
-      }
-    },
-    "updateProtectedBranchPullRequestReviewEnforcement": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews",
-      "method": "PATCH",
-      "params": {
-        "owner": {
-          "type": "string",
-          "required": true
         },
         "repo": {
           "type": "string",
           "required": true
-        },
+        }
+      },
+      "url": "/repos/:owner/:repo/invitations/:invitation_id"
+    },
+    "updateProtectedBranchPullRequestReviewEnforcement": {
+      "method": "PATCH",
+      "params": {
         "branch": {
           "type": "string",
           "required": true
+        },
+        "dismiss_stale_reviews": {
+          "type": "boolean"
         },
         "dismissal_restrictions": {
           "type": "json",
           "allow-null": true
         },
-        "dismiss_stale_reviews": {
-          "type": "boolean"
-        },
-        "require_code_owner_reviews": {
-          "type": "boolean"
-        }
-      }
-    },
-    "updateProtectedBranchRequiredStatusChecks": {
-      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks",
-      "method": "PATCH",
-      "params": {
         "owner": {
           "type": "string",
           "required": true
@@ -8696,66 +8678,73 @@
           "type": "string",
           "required": true
         },
+        "require_code_owner_reviews": {
+          "type": "boolean"
+        }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews"
+    },
+    "updateProtectedBranchRequiredStatusChecks": {
+      "method": "PATCH",
+      "params": {
         "branch": {
+          "type": "string",
+          "required": true
+        },
+        "contexts": {
+          "type": "string[]"
+        },
+        "owner": {
+          "type": "string",
+          "required": true
+        },
+        "repo": {
           "type": "string",
           "required": true
         },
         "strict": {
           "type": "boolean"
-        },
-        "contexts": {
-          "type": "string[]"
         }
-      }
+      },
+      "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks"
     },
     "uploadAsset": {
       "method": "POST",
-      "url": ":url",
       "params": {
-        "url": {
-          "type": "string",
-          "required": true
-        },
-        "file": {
-          "type": "string | object",
+        "contentLength": {
+          "type": "number",
           "required": true,
-          "mapTo": "input"
+          "mapTo": "headers.content-length"
         },
         "contentType": {
           "type": "string",
           "required": true,
           "mapTo": "headers.content-type"
         },
-        "contentLength": {
-          "type": "number",
+        "file": {
+          "type": "string | object",
           "required": true,
-          "mapTo": "headers.content-length"
+          "mapTo": "input"
+        },
+        "label": {
+          "type": "string"
         },
         "name": {
           "type": "string",
           "required": true
         },
-        "label": {
-          "type": "string"
+        "url": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": ":url"
     }
   },
   "search": {
     "code": {
-      "url": "/search/code",
       "method": "GET",
       "params": {
-        "q": {
-          "type": "string",
-          "required": true
-        },
-        "sort": {
-          "type": "string",
-          "enum": [
-            "indexed"
-          ]
-        },
         "order": {
           "type": "string",
           "enum": [
@@ -8770,16 +8759,41 @@
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "q": {
+          "type": "string",
+          "required": true
+        },
+        "sort": {
+          "type": "string",
+          "enum": [
+            "indexed"
+          ]
         }
-      }
+      },
+      "url": "/search/code"
     },
     "commits": {
-      "url": "/search/commits",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.cloak-preview+json"
       },
+      "method": "GET",
       "params": {
+        "order": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "default": "desc"
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
         "q": {
           "type": "string",
           "required": true
@@ -8790,7 +8804,13 @@
             "author-date",
             "committer-date"
           ]
-        },
+        }
+      },
+      "url": "/search/commits"
+    },
+    "issues": {
+      "method": "GET",
+      "params": {
         "order": {
           "type": "string",
           "enum": [
@@ -8805,13 +8825,7 @@
         "per_page": {
           "type": "number",
           "default": "30"
-        }
-      }
-    },
-    "issues": {
-      "url": "/search/issues",
-      "method": "GET",
-      "params": {
+        },
         "q": {
           "type": "string",
           "required": true
@@ -8823,7 +8837,16 @@
             "created",
             "updated"
           ]
-        },
+        }
+      },
+      "url": "/search/issues"
+    },
+    "repos": {
+      "headers": {
+        "accept": "application/vnd.github.mercy-preview+json"
+      },
+      "method": "GET",
+      "params": {
         "order": {
           "type": "string",
           "enum": [
@@ -8838,16 +8861,7 @@
         "per_page": {
           "type": "number",
           "default": "30"
-        }
-      }
-    },
-    "repos": {
-      "url": "/search/repositories",
-      "method": "GET",
-      "headers": {
-        "accept": "application/vnd.github.mercy-preview+json"
-      },
-      "params": {
+        },
         "q": {
           "type": "string",
           "required": true
@@ -8859,7 +8873,13 @@
             "forks",
             "updated"
           ]
-        },
+        }
+      },
+      "url": "/search/repositories"
+    },
+    "users": {
+      "method": "GET",
+      "params": {
         "order": {
           "type": "string",
           "enum": [
@@ -8874,13 +8894,7 @@
         "per_page": {
           "type": "number",
           "default": "30"
-        }
-      }
-    },
-    "users": {
-      "url": "/search/users",
-      "method": "GET",
-      "params": {
+        },
         "q": {
           "type": "string",
           "required": true
@@ -8892,38 +8906,23 @@
             "repositories",
             "joined"
           ]
-        },
-        "order": {
-          "type": "string",
-          "enum": [
-            "asc",
-            "desc"
-          ],
-          "default": "desc"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
         }
-      }
+      },
+      "url": "/search/users"
     }
   },
   "users": {
     "acceptRepoInvite": {
-      "url": "/user/repository_invitations/:invitation_id",
       "method": "PATCH",
       "params": {
         "invitation_id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/repository_invitations/:invitation_id"
     },
     "addEmails": {
-      "url": "/user/emails",
       "method": "POST",
       "params": {
         "emails": {
@@ -8931,14 +8930,14 @@
           "required": true,
           "mapTo": "input"
         }
-      }
+      },
+      "url": "/user/emails"
     },
     "addRepoToInstallation": {
-      "url": "/user/installations/:installation_id/repositories/:repository_id",
-      "method": "PUT",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
+      "method": "PUT",
       "params": {
         "installation_id": {
           "type": "string",
@@ -8948,97 +8947,97 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/installations/:installation_id/repositories/:repository_id"
     },
     "blockUser": {
-      "url": "/user/blocks/:username",
-      "method": "PUT",
       "headers": {
         "accept": "application/vnd.github.giant-sentry-fist-preview+json"
       },
+      "method": "PUT",
       "params": {
         "username": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/blocks/:username"
     },
     "checkBlockedUser": {
-      "url": "/user/blocks/:username",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.giant-sentry-fist-preview+json"
       },
+      "method": "GET",
       "params": {
         "username": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/blocks/:username"
     },
     "checkFollowing": {
-      "url": "/user/following/:username",
       "method": "GET",
       "params": {
         "username": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/following/:username"
     },
     "checkIfOneFollowersOther": {
-      "url": "/users/:username/following/:target_user",
       "method": "GET",
       "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        },
         "target_user": {
           "type": "string",
           "required": true
+        },
+        "username": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/users/:username/following/:target_user"
     },
     "createGpgKey": {
-      "url": "/user/gpg_keys",
-      "method": "POST",
       "headers": {
         "accept": "application/vnd.github.cryptographer-preview"
       },
+      "method": "POST",
       "params": {
         "armored_public_key": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/gpg_keys"
     },
     "createKey": {
-      "url": "/user/keys",
       "method": "POST",
       "params": {
-        "title": {
-          "type": "string",
-          "required": true
-        },
         "key": {
           "type": "string",
           "required": true
+        },
+        "title": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/user/keys"
     },
     "declineRepoInvite": {
-      "url": "/user/repository_invitations/:invitation_id",
       "method": "DELETE",
       "params": {
         "invitation_id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/repository_invitations/:invitation_id"
     },
     "deleteEmails": {
-      "url": "/user/emails",
       "method": "DELETE",
       "params": {
         "emails": {
@@ -9046,43 +9045,43 @@
           "required": true,
           "mapTo": "input"
         }
-      }
+      },
+      "url": "/user/emails"
     },
     "deleteGpgKey": {
-      "url": "/user/gpg_keys/:id",
-      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.cryptographer-preview"
       },
-      "params": {
-        "id": {
-          "type": "string",
-          "required": true
-        }
-      }
-    },
-    "deleteKey": {
-      "url": "/user/keys/:id",
       "method": "DELETE",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/gpg_keys/:id"
+    },
+    "deleteKey": {
+      "method": "DELETE",
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "url": "/user/keys/:id"
     },
     "demote": {
-      "url": "/users/:username/site_admin",
       "method": "DELETE",
       "params": {
         "username": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/users/:username/site_admin"
     },
     "editOrgMembership": {
-      "url": "/user/memberships/orgs/:org",
       "method": "PATCH",
       "params": {
         "org": {
@@ -9096,52 +9095,52 @@
             "active"
           ]
         }
-      }
+      },
+      "url": "/user/memberships/orgs/:org"
     },
     "followUser": {
-      "url": "/user/following/:username",
       "method": "PUT",
       "params": {
         "username": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/following/:username"
     },
     "get": {
-      "url": "/user",
       "method": "GET",
-      "params": {}
+      "params": {},
+      "url": "/user"
     },
     "getAll": {
-      "url": "/users",
       "method": "GET",
       "params": {
         "since": {
           "type": "number"
         }
-      }
+      },
+      "url": "/users"
     },
     "getBlockedUsers": {
-      "url": "/user/blocks",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.giant-sentry-fist-preview+json"
       },
-      "params": {}
+      "method": "GET",
+      "params": {},
+      "url": "/user/blocks"
     },
     "getById": {
-      "url": "/user/:id",
       "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/:id"
     },
     "getEmails": {
-      "url": "/user/emails",
       "method": "GET",
       "params": {
         "page": {
@@ -9151,10 +9150,10 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/user/emails"
     },
     "getFollowers": {
-      "url": "/user/followers",
       "method": "GET",
       "params": {
         "page": {
@@ -9164,27 +9163,27 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/user/followers"
     },
     "getFollowersForUser": {
-      "url": "/users/:username/followers",
       "method": "GET",
       "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        },
         "page": {
           "type": "number"
         },
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "username": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/users/:username/followers"
     },
     "getFollowing": {
-      "url": "/user/following",
       "method": "GET",
       "params": {
         "page": {
@@ -9194,54 +9193,54 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/user/following"
     },
     "getFollowingForUser": {
-      "url": "/users/:username/following",
       "method": "GET",
       "params": {
-        "username": {
-          "type": "string",
-          "required": true
-        },
         "page": {
           "type": "number"
         },
         "per_page": {
           "type": "number",
           "default": "30"
+        },
+        "username": {
+          "type": "string",
+          "required": true
         }
-      }
+      },
+      "url": "/users/:username/following"
     },
     "getForUser": {
-      "url": "/users/:username",
       "method": "GET",
       "params": {
         "username": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/users/:username"
     },
     "getGpgKey": {
-      "url": "/user/gpg_keys/:id",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.cryptographer-preview"
       },
+      "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/gpg_keys/:id"
     },
     "getGpgKeys": {
-      "url": "/user/gpg_keys",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.cryptographer-preview"
       },
+      "method": "GET",
       "params": {
         "page": {
           "type": "number"
@@ -9250,30 +9249,30 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/user/gpg_keys"
     },
     "getGpgKeysForUser": {
-      "url": "/users/:username/gpg_keys",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.cryptographer-preview"
       },
+      "method": "GET",
       "params": {
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
         "username": {
           "type": "string",
           "required": true
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
         }
-      }
+      },
+      "url": "/users/:username/gpg_keys"
     },
     "getInstallationRepos": {
-      "url": "/user/installations/:installation_id/repositories",
       "method": "GET",
       "params": {
         "installation_id": {
@@ -9287,14 +9286,14 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/user/installations/:installation_id/repositories"
     },
     "getInstallations": {
-      "url": "/user/installations",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
+      "method": "GET",
       "params": {
         "page": {
           "type": "number"
@@ -9303,20 +9302,20 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/user/installations"
     },
     "getKey": {
-      "url": "/user/keys/:id",
       "method": "GET",
       "params": {
         "id": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/keys/:id"
     },
     "getKeys": {
-      "url": "/user/keys",
       "method": "GET",
       "params": {
         "page": {
@@ -9326,31 +9325,31 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/user/keys"
     },
     "getKeysForUser": {
-      "url": "/users/:username/keys",
       "method": "GET",
       "params": {
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number",
+          "default": "30"
+        },
         "username": {
           "type": "string",
           "required": true
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number",
-          "default": "30"
         }
-      }
+      },
+      "url": "/users/:username/keys"
     },
     "getMarketplacePurchases": {
-      "url": "/user/marketplace_purchases",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.valkyrie-preview+json"
       },
+      "method": "GET",
       "params": {
         "page": {
           "type": "number"
@@ -9359,14 +9358,14 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/user/marketplace_purchases"
     },
     "getMarketplaceStubbedPurchases": {
-      "url": "/user/marketplace_purchases/stubbed",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.valkyrie-preview+json"
       },
+      "method": "GET",
       "params": {
         "page": {
           "type": "number"
@@ -9375,20 +9374,20 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/user/marketplace_purchases/stubbed"
     },
     "getOrgMembership": {
-      "url": "/user/memberships/orgs/:org",
       "method": "GET",
       "params": {
         "org": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/memberships/orgs/:org"
     },
     "getOrgMemberships": {
-      "url": "/user/memberships/orgs",
       "method": "GET",
       "params": {
         "state": {
@@ -9398,10 +9397,10 @@
             "pending"
           ]
         }
-      }
+      },
+      "url": "/user/memberships/orgs"
     },
     "getOrgs": {
-      "url": "/user/orgs",
       "method": "GET",
       "params": {
         "page": {
@@ -9411,10 +9410,10 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/user/orgs"
     },
     "getPublicEmails": {
-      "url": "/user/public_emails",
       "method": "GET",
       "params": {
         "page": {
@@ -9424,19 +9423,19 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/user/public_emails"
     },
     "getRepoInvites": {
-      "url": "/user/repository_invitations",
       "method": "GET",
-      "params": {}
+      "params": {},
+      "url": "/user/repository_invitations"
     },
     "getTeams": {
-      "url": "/user/teams",
-      "method": "GET",
       "headers": {
         "accept": "application/vnd.github.hellcat-preview+json"
       },
+      "method": "GET",
       "params": {
         "page": {
           "type": "number"
@@ -9445,24 +9444,24 @@
           "type": "number",
           "default": "30"
         }
-      }
+      },
+      "url": "/user/teams"
     },
     "promote": {
-      "url": "/users/:username/site_admin",
       "method": "PUT",
       "params": {
         "username": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/users/:username/site_admin"
     },
     "removeRepoFromInstallation": {
-      "url": "/user/installations/:installation_id/repositories/:repository_id",
-      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.machine-man-preview"
       },
+      "method": "DELETE",
       "params": {
         "installation_id": {
           "type": "string",
@@ -9472,64 +9471,61 @@
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/installations/:installation_id/repositories/:repository_id"
     },
     "suspend": {
-      "url": "/users/:username/suspended",
       "method": "PUT",
       "params": {
         "username": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/users/:username/suspended"
     },
     "togglePrimaryEmailVisibility": {
-      "url": "/user/email/visibility",
       "method": "PATCH",
-      "params": {}
+      "params": {},
+      "url": "/user/email/visibility"
     },
     "unblockUser": {
-      "url": "/user/blocks/:username",
-      "method": "DELETE",
       "headers": {
         "accept": "application/vnd.github.giant-sentry-fist-preview+json"
       },
+      "method": "DELETE",
       "params": {
         "username": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/blocks/:username"
     },
     "unfollowUser": {
-      "url": "/user/following/:username",
       "method": "DELETE",
       "params": {
         "username": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/user/following/:username"
     },
     "unsuspend": {
-      "url": "/users/:username/suspended",
       "method": "DELETE",
       "params": {
         "username": {
           "type": "string",
           "required": true
         }
-      }
+      },
+      "url": "/users/:username/suspended"
     },
     "update": {
-      "url": "/user",
       "method": "PATCH",
       "params": {
-        "name": {
-          "type": "string"
-        },
-        "email": {
+        "bio": {
           "type": "string"
         },
         "blog": {
@@ -9538,16 +9534,20 @@
         "company": {
           "type": "string"
         },
-        "location": {
+        "email": {
           "type": "string"
         },
         "hireable": {
           "type": "boolean"
         },
-        "bio": {
+        "location": {
+          "type": "string"
+        },
+        "name": {
           "type": "string"
         }
-      }
+      },
+      "url": "/user"
     }
   }
 }

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -8293,10 +8293,6 @@
           "required": true,
           "type": "string"
         },
-        "dismissal_restrictions": {
-          "allow-null": true,
-          "type": "object"
-        },
         "enforce_admins": {
           "allow-null": false,
           "required": true,
@@ -8314,6 +8310,24 @@
           "allow-null": true,
           "required": true,
           "type": "object"
+        },
+        "required_pull_request_reviews.dismiss_stale_reviews": {
+          "type": "boolean"
+        },
+        "required_pull_request_reviews.dismissal_restrictions": {
+          "type": "object"
+        },
+        "required_pull_request_reviews.dismissal_restrictions.teams": {
+          "type": "string[]"
+        },
+        "required_pull_request_reviews.dismissal_restrictions.users": {
+          "type": "string[]"
+        },
+        "required_pull_request_reviews.require_code_owner_reviews": {
+          "type": "boolean"
+        },
+        "required_pull_request_reviews.required_approving_review_count": {
+          "type": "integer"
         },
         "required_status_checks": {
           "allow-null": true,

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -993,7 +993,7 @@
         },
         "environment": {
           "required": true,
-          "type": "json"
+          "type": "object"
         },
         "name": {
           "required": true,
@@ -1005,7 +1005,7 @@
         },
         "script_repository": {
           "required": true,
-          "type": "json"
+          "type": "object"
         }
       },
       "url": "/admin/pre-receive-hooks"
@@ -1054,7 +1054,7 @@
         "hook": {
           "mapTo": "input",
           "required": true,
-          "type": "json"
+          "type": "object"
         },
         "id": {
           "required": true,
@@ -1237,7 +1237,7 @@
         },
         "files": {
           "required": true,
-          "type": "json"
+          "type": "object"
         },
         "public": {
           "required": true,
@@ -1298,7 +1298,7 @@
         },
         "files": {
           "required": true,
-          "type": "json"
+          "type": "object"
         },
         "id": {
           "required": true,
@@ -1509,10 +1509,10 @@
       "method": "POST",
       "params": {
         "author": {
-          "type": "json"
+          "type": "object"
         },
         "committer": {
-          "type": "json"
+          "type": "object"
         },
         "message": {
           "required": true,
@@ -1584,7 +1584,7 @@
         },
         "tagger": {
           "required": true,
-          "type": "json"
+          "type": "object"
         },
         "type": {
           "required": true,
@@ -1609,7 +1609,7 @@
         },
         "tree": {
           "required": true,
-          "type": "json"
+          "type": "object"
         }
       },
       "url": "/repos/:owner/:repo/git/trees"
@@ -3626,7 +3626,7 @@
         },
         "config": {
           "required": true,
-          "type": "json"
+          "type": "object"
         },
         "events": {
           "type": "string[]"
@@ -3734,7 +3734,7 @@
         },
         "config": {
           "required": true,
-          "type": "json"
+          "type": "object"
         },
         "events": {
           "type": "string[]"
@@ -5953,13 +5953,13 @@
       "method": "PUT",
       "params": {
         "author": {
-          "type": "json"
+          "type": "object"
         },
         "branch": {
           "type": "string"
         },
         "committer": {
-          "type": "json"
+          "type": "object"
         },
         "content": {
           "required": true,
@@ -6045,7 +6045,7 @@
         },
         "config": {
           "required": true,
-          "type": "json"
+          "type": "object"
         },
         "events": {
           "type": "string[]"
@@ -6228,13 +6228,13 @@
       "method": "DELETE",
       "params": {
         "author": {
-          "type": "json"
+          "type": "object"
         },
         "branch": {
           "type": "string"
         },
         "committer": {
-          "type": "json"
+          "type": "object"
         },
         "message": {
           "required": true,
@@ -6400,7 +6400,7 @@
         },
         "config": {
           "required": true,
-          "type": "json"
+          "type": "object"
         },
         "events": {
           "type": "string[]"
@@ -8150,7 +8150,7 @@
         },
         "dismissal_restrictions": {
           "allow-null": true,
-          "type": "json"
+          "type": "object"
         },
         "enforce_admins": {
           "allow-null": false,
@@ -8168,17 +8168,17 @@
         "required_pull_request_reviews": {
           "allow-null": true,
           "required": true,
-          "type": "json"
+          "type": "object"
         },
         "required_status_checks": {
           "allow-null": true,
           "required": true,
-          "type": "json"
+          "type": "object"
         },
         "restrictions": {
           "allow-null": true,
           "required": true,
-          "type": "json"
+          "type": "object"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection"
@@ -8209,13 +8209,13 @@
       "method": "PUT",
       "params": {
         "author": {
-          "type": "json"
+          "type": "object"
         },
         "branch": {
           "type": "string"
         },
         "committer": {
-          "type": "json"
+          "type": "object"
         },
         "content": {
           "required": true,
@@ -8282,7 +8282,7 @@
         },
         "dismissal_restrictions": {
           "allow-null": true,
-          "type": "json"
+          "type": "object"
         },
         "owner": {
           "required": true,

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -2561,7 +2561,7 @@
       "method": "GET",
       "params": {
         "issue_number": {
-          "alias": "integer",
+          "alias": "number",
           "deprecated": "`issue_number` parameter has been renamed to `number`"
         },
         "number": {
@@ -2612,7 +2612,7 @@
       "method": "GET",
       "params": {
         "issue_number": {
-          "alias": "integer",
+          "alias": "number",
           "deprecated": "`issue_number` parameter has been renamed to `number`"
         },
         "number": {
@@ -4490,7 +4490,7 @@
       "params": {
         "column_id": {
           "required": true,
-          "type": "integer"
+          "type": "string"
         },
         "content_id": {
           "type": "integer"
@@ -4638,15 +4638,15 @@
         "id": {
           "alias": "project_id"
         },
-        "project_id": {
-          "required": true,
-          "type": "string"
-        },
         "page": {
           "type": "integer"
         },
         "per_page": {
           "type": "integer"
+        },
+        "project_id": {
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/projects/:project_id"
@@ -4675,7 +4675,7 @@
       "params": {
         "column_id": {
           "required": true,
-          "type": "integer"
+          "type": "string"
         },
         "page": {
           "type": "integer"
@@ -4813,7 +4813,6 @@
           "alias": "project_id"
         },
         "name": {
-          "required": true,
           "type": "string"
         },
         "organization_permission": {
@@ -8825,10 +8824,10 @@
           "type": "string"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "indexed"
-          ]
+          ],
+          "type": "string"
         }
       },
       "url": "/search/code"

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -1712,10 +1712,10 @@
           "required": true,
           "type": "object[]"
         },
-        "tree.content": {
+        "tree[].content": {
           "type": "string"
         },
-        "tree.mode": {
+        "tree[].mode": {
           "enum": [
             "100644",
             "100755",
@@ -1725,13 +1725,13 @@
           ],
           "type": "string"
         },
-        "tree.path": {
+        "tree[].path": {
           "type": "string"
         },
-        "tree.sha": {
+        "tree[].sha": {
           "type": "string"
         },
-        "tree.type": {
+        "tree[].type": {
           "enum": [
             "blob",
             "tree",
@@ -5058,13 +5058,13 @@
         "comments": {
           "type": "object[]"
         },
-        "comments.body": {
+        "comments[].body": {
           "type": "string"
         },
-        "comments.path": {
+        "comments[].path": {
           "type": "string"
         },
-        "comments.position": {
+        "comments[].position": {
           "type": "integer"
         },
         "commit_id": {

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -675,6 +675,13 @@
       },
       "method": "GET",
       "params": {
+        "direction": {
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "type": "string"
+        },
         "id": {
           "required": true,
           "type": "string"
@@ -684,6 +691,13 @@
         },
         "per_page": {
           "type": "integer"
+        },
+        "sort": {
+          "enum": [
+            "created",
+            "updated"
+          ],
+          "type": "string"
         }
       },
       "url": "/marketplace_listing/plans/:id/accounts"
@@ -709,6 +723,13 @@
       },
       "method": "GET",
       "params": {
+        "direction": {
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "type": "string"
+        },
         "id": {
           "required": true,
           "type": "string"
@@ -718,6 +739,13 @@
         },
         "per_page": {
           "type": "integer"
+        },
+        "sort": {
+          "enum": [
+            "created",
+            "updated"
+          ],
+          "type": "string"
         }
       },
       "url": "/marketplace_listing/stubbed/plans/:id/accounts"
@@ -764,6 +792,7 @@
           "type": "string"
         },
         "client_id": {
+          "required": true,
           "type": "string"
         }
       },
@@ -782,6 +811,7 @@
           "type": "string"
         },
         "note": {
+          "required": true,
           "type": "string"
         },
         "note_url": {
@@ -861,6 +891,7 @@
       "method": "PUT",
       "params": {
         "client_id": {
+          "required": true,
           "type": "string"
         },
         "client_secret": {
@@ -886,6 +917,7 @@
       "method": "PUT",
       "params": {
         "client_id": {
+          "required": true,
           "type": "string"
         },
         "client_secret": {
@@ -893,6 +925,7 @@
           "type": "string"
         },
         "fingerprint": {
+          "required": true,
           "type": "string"
         },
         "note": {
@@ -915,6 +948,7 @@
           "type": "string"
         },
         "client_id": {
+          "required": true,
           "type": "string"
         }
       },
@@ -928,6 +962,7 @@
           "type": "string"
         },
         "client_id": {
+          "required": true,
           "type": "string"
         }
       },
@@ -941,6 +976,7 @@
           "type": "string"
         },
         "client_id": {
+          "required": true,
           "type": "string"
         }
       },
@@ -1271,7 +1307,6 @@
           "type": "object"
         },
         "public": {
-          "required": true,
           "type": "boolean"
         }
       },
@@ -1328,7 +1363,6 @@
           "type": "string"
         },
         "files": {
-          "required": true,
           "type": "object"
         },
         "id": {
@@ -1637,10 +1671,23 @@
           "type": "string"
         },
         "tagger": {
-          "required": true,
           "type": "object"
         },
+        "tagger.date": {
+          "type": "string"
+        },
+        "tagger.email": {
+          "type": "string"
+        },
+        "tagger.name": {
+          "type": "string"
+        },
         "type": {
+          "enum": [
+            "commit",
+            "tree",
+            "blob"
+          ],
           "required": true,
           "type": "string"
         }
@@ -1663,7 +1710,34 @@
         },
         "tree": {
           "required": true,
-          "type": "object"
+          "type": "object[]"
+        },
+        "tree.content": {
+          "type": "string"
+        },
+        "tree.mode": {
+          "enum": [
+            "100644",
+            "100755",
+            "040000",
+            "160000",
+            "120000"
+          ],
+          "type": "string"
+        },
+        "tree.path": {
+          "type": "string"
+        },
+        "tree.sha": {
+          "type": "string"
+        },
+        "tree.type": {
+          "enum": [
+            "blob",
+            "tree",
+            "commit"
+          ],
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/git/trees"
@@ -1755,15 +1829,7 @@
     "getReference": {
       "method": "GET",
       "params": {
-        "owner": {
-          "required": true,
-          "type": "string"
-        },
         "ref": {
-          "required": true,
-          "type": "string"
-        },
-        "repo": {
           "required": true,
           "type": "string"
         }
@@ -1860,9 +1926,6 @@
         "owner": {
           "required": true,
           "type": "string"
-        },
-        "recursive": {
-          "type": "boolean"
         },
         "repo": {
           "required": true,
@@ -1987,7 +2050,6 @@
       "method": "POST",
       "params": {
         "assignees": {
-          "required": true,
           "type": "string[]"
         },
         "number": {
@@ -2114,6 +2176,9 @@
           "required": true,
           "type": "string"
         },
+        "description": {
+          "type": "string"
+        },
         "name": {
           "required": true,
           "type": "string"
@@ -2149,8 +2214,7 @@
         "state": {
           "enum": [
             "open",
-            "closed",
-            "all"
+            "closed"
           ],
           "type": "string"
         },
@@ -2326,11 +2390,11 @@
         },
         "filter": {
           "enum": [
-            "all",
             "assigned",
             "created",
             "mentioned",
-            "subscribed"
+            "subscribed",
+            "all"
           ],
           "type": "string"
         },
@@ -2399,6 +2463,12 @@
           "required": true,
           "type": "string"
         },
+        "page": {
+          "type": "integer"
+        },
+        "per_page": {
+          "type": "integer"
+        },
         "repo": {
           "required": true,
           "type": "string"
@@ -2452,12 +2522,6 @@
         "owner": {
           "required": true,
           "type": "string"
-        },
-        "page": {
-          "type": "integer"
-        },
-        "per_page": {
-          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -2588,11 +2652,11 @@
         },
         "filter": {
           "enum": [
-            "all",
             "assigned",
             "created",
             "mentioned",
-            "subscribed"
+            "subscribed",
+            "all"
           ],
           "type": "string"
         },
@@ -2711,11 +2775,11 @@
         },
         "filter": {
           "enum": [
-            "all",
             "assigned",
             "created",
             "mentioned",
-            "subscribed"
+            "subscribed",
+            "all"
           ],
           "type": "string"
         },
@@ -2899,6 +2963,15 @@
     "lock": {
       "method": "PUT",
       "params": {
+        "lock_reason": {
+          "enum": [
+            "off-topic",
+            "too heated",
+            "resolved",
+            "spam"
+          ],
+          "type": "string"
+        },
         "number": {
           "required": true,
           "type": "integer"
@@ -2936,7 +3009,6 @@
       "method": "DELETE",
       "params": {
         "assignees": {
-          "required": true,
           "type": "string[]"
         },
         "number": {
@@ -3023,6 +3095,9 @@
         "color": {
           "type": "string"
         },
+        "description": {
+          "type": "string"
+        },
         "name": {
           "type": "string"
         },
@@ -3065,8 +3140,7 @@
         "state": {
           "enum": [
             "open",
-            "closed",
-            "all"
+            "closed"
           ],
           "type": "string"
         },
@@ -3269,6 +3343,10 @@
           "type": "string"
         },
         "use_lfs": {
+          "enum": [
+            "opt_in",
+            "opt_out"
+          ],
           "required": true,
           "type": "string"
         }
@@ -3537,7 +3615,6 @@
             "admin",
             "member"
           ],
-          "required": true,
           "type": "string"
         },
         "username": {
@@ -3725,6 +3802,19 @@
           "required": true,
           "type": "object"
         },
+        "config.content_type": {
+          "type": "string"
+        },
+        "config.insecure_ssl": {
+          "type": "string"
+        },
+        "config.secret": {
+          "type": "string"
+        },
+        "config.url": {
+          "required": true,
+          "type": "string"
+        },
         "events": {
           "type": "string[]"
         },
@@ -3761,6 +3851,14 @@
         },
         "parent_team_id": {
           "type": "integer"
+        },
+        "permission": {
+          "enum": [
+            "pull",
+            "push",
+            "admin"
+          ],
+          "type": "string"
         },
         "privacy": {
           "enum": [
@@ -3830,8 +3928,20 @@
           "type": "boolean"
         },
         "config": {
-          "required": true,
           "type": "object"
+        },
+        "config.content_type": {
+          "type": "string"
+        },
+        "config.insecure_ssl": {
+          "type": "string"
+        },
+        "config.secret": {
+          "type": "string"
+        },
+        "config.url": {
+          "required": true,
+          "type": "string"
         },
         "events": {
           "type": "string[]"
@@ -3867,11 +3977,15 @@
         "parent_team_id": {
           "type": "integer"
         },
-        "privacy": {
+        "permission": {
           "enum": [
-            "secret",
-            "closed"
+            "pull",
+            "push",
+            "admin"
           ],
+          "type": "string"
+        },
+        "privacy": {
           "type": "string"
         }
       },
@@ -3883,12 +3997,6 @@
         "org": {
           "required": true,
           "type": "string"
-        },
-        "page": {
-          "type": "integer"
-        },
-        "per_page": {
-          "type": "integer"
         }
       },
       "url": "/orgs/:org"
@@ -3917,12 +4025,6 @@
         "org": {
           "required": true,
           "type": "string"
-        },
-        "page": {
-          "type": "integer"
-        },
-        "per_page": {
-          "type": "integer"
         }
       },
       "url": "/orgs/:org/blocks"
@@ -3997,8 +4099,8 @@
       "params": {
         "filter": {
           "enum": [
-            "all",
-            "2fa_disabled"
+            "2fa_disabled",
+            "all"
           ],
           "type": "string"
         },
@@ -4042,8 +4144,8 @@
       "params": {
         "filter": {
           "enum": [
-            "all",
-            "2fa_disabled"
+            "2fa_disabled",
+            "all"
           ],
           "type": "string"
         },
@@ -4331,6 +4433,12 @@
         "email": {
           "type": "string"
         },
+        "has_organization_projects": {
+          "type": "boolean"
+        },
+        "has_repository_projects": {
+          "type": "boolean"
+        },
         "location": {
           "type": "string"
         },
@@ -4365,6 +4473,12 @@
         "org": {
           "required": true,
           "type": "string"
+        },
+        "page": {
+          "type": "integer"
+        },
+        "per_page": {
+          "type": "integer"
         }
       },
       "url": "/orgs/:org/projects"
@@ -4376,24 +4490,20 @@
       "method": "POST",
       "params": {
         "column_id": {
-          "alias": "id",
-          "deprecated": "`column_id` parameter has been renamed to `id`"
+          "required": true,
+          "type": "integer"
         },
         "content_id": {
-          "type": "string"
+          "type": "integer"
         },
         "content_type": {
-          "type": "string"
-        },
-        "id": {
-          "required": true,
           "type": "string"
         },
         "note": {
           "type": "string"
         }
       },
-      "url": "/projects/columns/:id/cards"
+      "url": "/projects/columns/:column_id/cards"
     },
     "createProjectColumn": {
       "headers": {
@@ -4431,6 +4541,12 @@
         "owner": {
           "required": true,
           "type": "string"
+        },
+        "page": {
+          "type": "integer"
+        },
+        "per_page": {
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -4526,6 +4642,12 @@
         "project_id": {
           "required": true,
           "type": "string"
+        },
+        "page": {
+          "type": "integer"
+        },
+        "per_page": {
+          "type": "integer"
         }
       },
       "url": "/projects/:project_id"
@@ -4553,12 +4675,8 @@
       "method": "GET",
       "params": {
         "column_id": {
-          "alias": "id",
-          "deprecated": "`column_id` parameter has been renamed to `id`"
-        },
-        "id": {
           "required": true,
-          "type": "string"
+          "type": "integer"
         },
         "page": {
           "type": "integer"
@@ -4567,7 +4685,7 @@
           "type": "integer"
         }
       },
-      "url": "/projects/columns/:id/cards"
+      "url": "/projects/columns/:column_id/cards"
     },
     "getProjectColumn": {
       "headers": {
@@ -4649,7 +4767,7 @@
           "type": "string"
         },
         "column_id": {
-          "type": "string"
+          "type": "integer"
         },
         "id": {
           "alias": "card_id"
@@ -4718,8 +4836,7 @@
         "state": {
           "enum": [
             "open",
-            "closed",
-            "all"
+            "closed"
           ],
           "type": "string"
         }
@@ -4893,19 +5010,25 @@
           "required": true,
           "type": "string"
         },
+        "body": {
+          "type": "string"
+        },
         "head": {
           "required": true,
           "type": "string"
         },
-        "issue": {
-          "required": true,
-          "type": "integer"
+        "maintainer_can_modify": {
+          "type": "boolean"
         },
         "owner": {
           "required": true,
           "type": "string"
         },
         "repo": {
+          "required": true,
+          "type": "string"
+        },
+        "title": {
           "required": true,
           "type": "string"
         }
@@ -4919,7 +5042,16 @@
           "type": "string"
         },
         "comments": {
-          "type": "string[]"
+          "type": "object[]"
+        },
+        "comments.body": {
+          "type": "string"
+        },
+        "comments.path": {
+          "type": "string"
+        },
+        "comments.position": {
+          "type": "integer"
         },
         "commit_id": {
           "type": "string"
@@ -4928,8 +5060,7 @@
           "enum": [
             "APPROVE",
             "REQUEST_CHANGES",
-            "COMMENT",
-            "PENDING"
+            "COMMENT"
           ],
           "type": "string"
         },
@@ -5190,6 +5321,13 @@
       },
       "method": "GET",
       "params": {
+        "direction": {
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "type": "string"
+        },
         "number": {
           "required": true,
           "type": "integer"
@@ -5206,6 +5344,16 @@
         },
         "repo": {
           "required": true,
+          "type": "string"
+        },
+        "since": {
+          "type": "string"
+        },
+        "sort": {
+          "enum": [
+            "created",
+            "updated"
+          ],
           "type": "string"
         }
       },
@@ -5448,8 +5596,7 @@
           "enum": [
             "APPROVE",
             "REQUEST_CHANGES",
-            "COMMENT",
-            "PENDING"
+            "COMMENT"
           ],
           "type": "string"
         },
@@ -5855,7 +6002,6 @@
           "type": "string"
         },
         "title": {
-          "required": true,
           "type": "string"
         }
       },
@@ -6044,6 +6190,9 @@
           "required": true,
           "type": "string"
         },
+        "line": {
+          "type": "integer"
+        },
         "owner": {
           "required": true,
           "type": "string"
@@ -6141,6 +6290,14 @@
           "type": "string"
         },
         "state": {
+          "enum": [
+            "error",
+            "failure",
+            "inactive",
+            "pending",
+            "success"
+          ],
+          "required": true,
           "type": "string"
         },
         "target_url": {
@@ -6247,6 +6404,19 @@
           "required": true,
           "type": "object"
         },
+        "config.content_type": {
+          "type": "string"
+        },
+        "config.insecure_ssl": {
+          "type": "string"
+        },
+        "config.secret": {
+          "type": "string"
+        },
+        "config.url": {
+          "required": true,
+          "type": "string"
+        },
         "events": {
           "type": "string[]"
         },
@@ -6321,10 +6491,10 @@
         },
         "state": {
           "enum": [
-            "pending",
-            "success",
             "error",
-            "failure"
+            "failure",
+            "pending",
+            "success"
           ],
           "required": true,
           "type": "string"
@@ -6528,6 +6698,9 @@
         "allow_squash_merge": {
           "type": "boolean"
         },
+        "archived": {
+          "type": "boolean"
+        },
         "default_branch": {
           "type": "string"
         },
@@ -6575,7 +6748,6 @@
           "type": "string"
         },
         "name": {
-          "required": true,
           "type": "string"
         },
         "owner": {
@@ -6599,17 +6771,25 @@
           "type": "string[]"
         },
         "config": {
-          "required": true,
           "type": "object"
+        },
+        "config.content_type": {
+          "type": "string"
+        },
+        "config.insecure_ssl": {
+          "type": "string"
+        },
+        "config.secret": {
+          "type": "string"
+        },
+        "config.url": {
+          "required": true,
+          "type": "string"
         },
         "events": {
           "type": "string[]"
         },
         "id": {
-          "required": true,
-          "type": "string"
-        },
-        "name": {
           "required": true,
           "type": "string"
         },
@@ -6655,7 +6835,6 @@
           "type": "string"
         },
         "tag_name": {
-          "required": true,
           "type": "string"
         },
         "target_commitish": {
@@ -6702,6 +6881,11 @@
       "method": "GET",
       "params": {
         "affiliation": {
+          "enum": [
+            "owner",
+            "collaborator",
+            "organization_member"
+          ],
           "type": "string"
         },
         "direction": {
@@ -6783,6 +6967,7 @@
           "type": "string"
         },
         "ref": {
+          "required": true,
           "type": "string"
         },
         "repo": {
@@ -6910,11 +7095,12 @@
           "required": true,
           "type": "string"
         },
-        "page": {
-          "type": "integer"
-        },
-        "per_page": {
-          "type": "integer"
+        "per": {
+          "enum": [
+            "day",
+            "week"
+          ],
+          "type": "string"
         },
         "repo": {
           "required": true,
@@ -6929,8 +7115,8 @@
         "affiliation": {
           "enum": [
             "outside",
-            "all",
-            "direct"
+            "direct",
+            "all"
           ],
           "type": "string"
         },
@@ -7109,7 +7295,7 @@
       "method": "GET",
       "params": {
         "anon": {
-          "type": "boolean"
+          "type": "string"
         },
         "owner": {
           "required": true,
@@ -7193,7 +7379,7 @@
       "params": {
         "id": {
           "required": true,
-          "type": "string"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -7205,7 +7391,7 @@
         },
         "status_id": {
           "required": true,
-          "type": "string"
+          "type": "integer"
         }
       },
       "url": "/repos/:owner/:repo/deployments/:id/statuses/:status_id"
@@ -7218,7 +7404,7 @@
       "params": {
         "id": {
           "required": true,
-          "type": "string"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -7987,6 +8173,13 @@
           "required": true,
           "type": "string"
         },
+        "per": {
+          "enum": [
+            "day",
+            "week"
+          ],
+          "type": "string"
+        },
         "repo": {
           "required": true,
           "type": "string"
@@ -8365,7 +8558,7 @@
           "type": "string"
         },
         "enforce_admins": {
-          "allowNull": false,
+          "allowNull": true,
           "required": true,
           "type": "boolean"
         },
@@ -8405,10 +8598,24 @@
           "required": true,
           "type": "object"
         },
+        "required_status_checks.contexts": {
+          "required": true,
+          "type": "string[]"
+        },
+        "required_status_checks.strict": {
+          "required": true,
+          "type": "boolean"
+        },
         "restrictions": {
           "allowNull": true,
           "required": true,
           "type": "object"
+        },
+        "restrictions.teams": {
+          "type": "string[]"
+        },
+        "restrictions.users": {
+          "type": "string[]"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection"
@@ -8511,8 +8718,13 @@
           "type": "boolean"
         },
         "dismissal_restrictions": {
-          "allowNull": true,
           "type": "object"
+        },
+        "dismissal_restrictions.teams": {
+          "type": "string[]"
+        },
+        "dismissal_restrictions.users": {
+          "type": "string[]"
         },
         "owner": {
           "required": true,
@@ -8524,6 +8736,9 @@
         },
         "require_code_owner_reviews": {
           "type": "boolean"
+        },
+        "required_approving_review_count": {
+          "type": "integer"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews"
@@ -8607,10 +8822,10 @@
           "type": "string"
         },
         "sort": {
+          "type": "string",
           "enum": [
             "indexed"
-          ],
-          "type": "string"
+          ]
         }
       },
       "url": "/search/code"
@@ -8839,26 +9054,12 @@
         "accept": "application/vnd.github.cryptographer-preview"
       },
       "method": "POST",
-      "params": {
-        "armored_public_key": {
-          "required": true,
-          "type": "string"
-        }
-      },
+      "params": {},
       "url": "/user/gpg_keys"
     },
     "createKey": {
       "method": "POST",
-      "params": {
-        "key": {
-          "required": true,
-          "type": "string"
-        },
-        "title": {
-          "required": true,
-          "type": "string"
-        }
-      },
+      "params": {},
       "url": "/user/keys"
     },
     "declineRepoInvite": {
@@ -8957,7 +9158,7 @@
           "type": "integer"
         },
         "since": {
-          "type": "integer"
+          "type": "string"
         }
       },
       "url": "/users"
@@ -9323,7 +9524,16 @@
     },
     "togglePrimaryEmailVisibility": {
       "method": "PATCH",
-      "params": {},
+      "params": {
+        "email": {
+          "required": true,
+          "type": "string"
+        },
+        "visibility": {
+          "required": true,
+          "type": "string"
+        }
+      },
       "url": "/user/email/visibility"
     },
     "unblockUser": {

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -38,10 +38,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/events"
@@ -54,10 +54,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/orgs/:org/events"
@@ -70,10 +70,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -90,10 +90,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -110,10 +110,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -126,10 +126,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "username": {
           "required": true,
@@ -146,10 +146,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "username": {
           "required": true,
@@ -162,10 +162,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "username": {
           "required": true,
@@ -178,10 +178,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "username": {
           "required": true,
@@ -194,10 +194,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "username": {
           "required": true,
@@ -231,13 +231,13 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "participating": {
           "type": "boolean"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "since": {
           "type": "string"
@@ -259,13 +259,13 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "participating": {
           "type": "boolean"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -302,10 +302,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -328,10 +328,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "sort": {
           "enum": [
@@ -357,10 +357,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "sort": {
           "enum": [
@@ -380,10 +380,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/user/subscriptions"
@@ -392,10 +392,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "username": {
           "required": true,
@@ -412,10 +412,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -568,10 +568,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/marketplace_listing/accounts/:id"
@@ -587,10 +587,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/marketplace_listing/stubbed/accounts/:id"
@@ -646,10 +646,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/installation/repositories"
@@ -661,10 +661,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/app/installations"
@@ -680,10 +680,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/marketplace_listing/plans/:id/accounts"
@@ -695,10 +695,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/marketplace_listing/plans"
@@ -714,10 +714,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/marketplace_listing/stubbed/plans/:id/accounts"
@@ -729,10 +729,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/marketplace_listing/stubbed/plans"
@@ -827,10 +827,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/authorizations"
@@ -849,10 +849,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/applications/grants"
@@ -1192,7 +1192,7 @@
       "params": {
         "team_id": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/admin/ldap/teams/:team_id/sync"
@@ -1229,7 +1229,7 @@
         },
         "team_id": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/admin/ldap/teams/:team_id/mapping"
@@ -1380,10 +1380,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "since": {
           "type": "string"
@@ -1413,10 +1413,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/gists/:gist_id/comments"
@@ -1429,10 +1429,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/gists/:id/commits"
@@ -1441,10 +1441,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "since": {
           "type": "string"
@@ -1464,10 +1464,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/gists/:id/forks"
@@ -1476,10 +1476,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "since": {
           "type": "string"
@@ -1505,10 +1505,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "since": {
           "type": "string"
@@ -1766,10 +1766,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -1822,10 +1822,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -1931,10 +1931,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/app/installations"
@@ -1968,7 +1968,7 @@
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -1991,7 +1991,7 @@
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -2041,7 +2041,7 @@
           "type": "string[]"
         },
         "milestone": {
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -2070,7 +2070,7 @@
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -2181,7 +2181,7 @@
       "params": {
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -2214,11 +2214,11 @@
         },
         "milestone": {
           "allow-null": true,
-          "type": "number"
+          "type": "integer"
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -2274,7 +2274,7 @@
       "params": {
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -2314,10 +2314,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "since": {
           "type": "string"
@@ -2349,10 +2349,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -2390,17 +2390,17 @@
       "params": {
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -2430,10 +2430,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -2474,22 +2474,22 @@
       "method": "GET",
       "params": {
         "issue_number": {
-          "alias": "number",
+          "alias": "integer",
           "deprecated": "`issue_number` parameter has been renamed to `number`"
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -2506,10 +2506,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -2525,22 +2525,22 @@
       "method": "GET",
       "params": {
         "issue_number": {
-          "alias": "number",
+          "alias": "integer",
           "deprecated": "`issue_number` parameter has been renamed to `number`"
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -2580,10 +2580,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "since": {
           "type": "string"
@@ -2641,10 +2641,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -2699,10 +2699,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "since": {
           "type": "string"
@@ -2731,17 +2731,17 @@
       "params": {
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -2776,10 +2776,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -2793,7 +2793,7 @@
       "params": {
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -2811,17 +2811,17 @@
       "params": {
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -2845,10 +2845,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -2877,7 +2877,7 @@
       "params": {
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -2895,7 +2895,7 @@
       "params": {
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -2917,7 +2917,7 @@
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -2939,7 +2939,7 @@
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -2962,7 +2962,7 @@
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -2980,7 +2980,7 @@
       "params": {
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -3028,7 +3028,7 @@
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -3191,10 +3191,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/orgs/:org/migrations"
@@ -3732,7 +3732,7 @@
           "type": "string"
         },
         "parent_team_id": {
-          "type": "number"
+          "type": "integer"
         },
         "privacy": {
           "enum": [
@@ -3837,7 +3837,7 @@
           "type": "string"
         },
         "parent_team_id": {
-          "type": "number"
+          "type": "integer"
         },
         "privacy": {
           "enum": [
@@ -3857,10 +3857,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/orgs/:org"
@@ -3869,10 +3869,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "since": {
           "type": "string"
@@ -3891,10 +3891,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/orgs/:org/blocks"
@@ -3910,10 +3910,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/teams/:id/teams"
@@ -3922,10 +3922,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "username": {
           "required": true,
@@ -3956,10 +3956,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/orgs/:org/hooks"
@@ -3979,10 +3979,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "role": {
           "enum": [
@@ -4024,10 +4024,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/orgs/:org/outside_collaborators"
@@ -4040,10 +4040,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/orgs/:org/invitations"
@@ -4056,10 +4056,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/teams/:id/invitations"
@@ -4072,10 +4072,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/orgs/:org/public_members"
@@ -4104,10 +4104,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "role": {
           "enum": [
@@ -4148,10 +4148,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/teams/:id/repos"
@@ -4167,10 +4167,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/orgs/:org/teams"
@@ -4470,10 +4470,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "state": {
           "enum": [
@@ -4533,10 +4533,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/projects/columns/:id/cards"
@@ -4567,10 +4567,10 @@
           "alias": "project_id"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "project_id": {
           "required": true,
@@ -4590,10 +4590,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -4747,7 +4747,7 @@
       "params": {
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -4808,7 +4808,7 @@
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -4820,7 +4820,7 @@
         },
         "position": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -4841,11 +4841,11 @@
         },
         "in_reply_to": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -4871,7 +4871,7 @@
         },
         "issue": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -4907,7 +4907,7 @@
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -4928,7 +4928,7 @@
       "params": {
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -4977,7 +4977,7 @@
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -4998,7 +4998,7 @@
       "params": {
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -5029,7 +5029,7 @@
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -5072,7 +5072,7 @@
       "params": {
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -5106,10 +5106,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -5164,17 +5164,17 @@
       "params": {
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -5201,10 +5201,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -5228,17 +5228,17 @@
       "params": {
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -5252,17 +5252,17 @@
       "params": {
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -5280,7 +5280,7 @@
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -5302,17 +5302,17 @@
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -5329,17 +5329,17 @@
       "params": {
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -5353,17 +5353,17 @@
       "params": {
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -5394,7 +5394,7 @@
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -5431,7 +5431,7 @@
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -5458,7 +5458,7 @@
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -5536,7 +5536,7 @@
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -5654,10 +5654,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -5685,17 +5685,17 @@
         },
         "number": {
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "owner": {
           "required": true,
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -5730,10 +5730,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -5768,10 +5768,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -6004,7 +6004,7 @@
           "type": "boolean"
         },
         "team_id": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/user/repos"
@@ -6024,7 +6024,7 @@
           "type": "string"
         },
         "position": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -6204,7 +6204,7 @@
           "type": "boolean"
         },
         "team_id": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/orgs/:org/repos"
@@ -6684,10 +6684,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "sort": {
           "enum": [
@@ -6727,10 +6727,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -6794,10 +6794,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -6850,10 +6850,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "protected": {
           "type": "boolean"
@@ -6883,10 +6883,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -6911,10 +6911,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -6988,10 +6988,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "ref": {
           "required": true,
@@ -7015,13 +7015,13 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "path": {
           "type": "string"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -7088,10 +7088,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -7126,10 +7126,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -7197,10 +7197,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -7223,10 +7223,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "ref": {
           "type": "string"
@@ -7270,10 +7270,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -7290,10 +7290,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "type": {
           "enum": [
@@ -7320,10 +7320,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "sort": {
           "enum": [
@@ -7357,10 +7357,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -7403,10 +7403,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -7423,10 +7423,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -7529,10 +7529,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -7685,10 +7685,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "since": {
           "type": "string"
@@ -7771,10 +7771,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -7879,10 +7879,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "ref": {
           "required": true,
@@ -7903,10 +7903,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -7923,10 +7923,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "repo": {
           "required": true,
@@ -8530,7 +8530,7 @@
         "contentLength": {
           "mapTo": "headers.content-length",
           "required": true,
-          "type": "number"
+          "type": "integer"
         },
         "contentType": {
           "mapTo": "headers.content-type",
@@ -8569,10 +8569,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "q": {
           "required": true,
@@ -8601,10 +8601,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "q": {
           "required": true,
@@ -8631,10 +8631,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "q": {
           "required": true,
@@ -8665,10 +8665,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "q": {
           "required": true,
@@ -8696,10 +8696,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "q": {
           "required": true,
@@ -8923,13 +8923,13 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "since": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/users"
@@ -8956,10 +8956,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/user/emails"
@@ -8968,10 +8968,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/user/followers"
@@ -8980,10 +8980,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "username": {
           "required": true,
@@ -8996,10 +8996,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/user/following"
@@ -9008,10 +9008,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "username": {
           "required": true,
@@ -9050,10 +9050,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/user/gpg_keys"
@@ -9065,10 +9065,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "username": {
           "required": true,
@@ -9085,10 +9085,10 @@
           "type": "string"
         },
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/user/installations/:installation_id/repositories"
@@ -9100,10 +9100,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/user/installations"
@@ -9122,10 +9122,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/user/keys"
@@ -9134,10 +9134,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "username": {
           "required": true,
@@ -9153,10 +9153,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/user/marketplace_purchases"
@@ -9168,10 +9168,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/user/marketplace_purchases/stubbed"
@@ -9190,10 +9190,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         },
         "state": {
           "enum": [
@@ -9209,10 +9209,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/user/orgs"
@@ -9221,10 +9221,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/user/public_emails"
@@ -9233,10 +9233,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/user/repository_invitations"
@@ -9248,10 +9248,10 @@
       "method": "GET",
       "params": {
         "page": {
-          "type": "number"
+          "type": "integer"
         },
         "per_page": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "url": "/user/teams"

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -2213,7 +2213,7 @@
           "type": "string[]"
         },
         "milestone": {
-          "allow-null": true,
+          "allowNull": true,
           "type": "integer"
         },
         "number": {
@@ -8337,7 +8337,7 @@
           "type": "string"
         },
         "enforce_admins": {
-          "allow-null": false,
+          "allowNull": false,
           "required": true,
           "type": "boolean"
         },
@@ -8350,7 +8350,7 @@
           "type": "string"
         },
         "required_pull_request_reviews": {
-          "allow-null": true,
+          "allowNull": true,
           "required": true,
           "type": "object"
         },
@@ -8373,12 +8373,12 @@
           "type": "integer"
         },
         "required_status_checks": {
-          "allow-null": true,
+          "allowNull": true,
           "required": true,
           "type": "object"
         },
         "restrictions": {
-          "allow-null": true,
+          "allowNull": true,
           "required": true,
           "type": "object"
         }
@@ -8483,7 +8483,7 @@
           "type": "boolean"
         },
         "dismissal_restrictions": {
-          "allow-null": true,
+          "allowNull": true,
           "type": "object"
         },
         "owner": {

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -1487,7 +1487,6 @@
       "method": "POST",
       "params": {
         "content": {
-          "allow-empty": true,
           "required": true,
           "type": "string"
         },
@@ -1622,7 +1621,6 @@
           "type": "string"
         },
         "ref": {
-          "allow-empty": true,
           "required": true,
           "type": "string"
         },
@@ -1695,7 +1693,6 @@
           "type": "string"
         },
         "ref": {
-          "allow-empty": true,
           "required": true,
           "type": "string"
         },
@@ -1814,7 +1811,6 @@
           "type": "string"
         },
         "ref": {
-          "allow-empty": true,
           "required": true,
           "type": "string"
         },
@@ -6886,7 +6882,6 @@
           "type": "string"
         },
         "path": {
-          "allow-empty": true,
           "required": true,
           "type": "string"
         },
@@ -7602,7 +7597,6 @@
           "type": "string"
         },
         "ref": {
-          "allow-empty": true,
           "required": true,
           "type": "string"
         },

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -83,24 +83,9 @@
       "url": "/repos/:owner/:repo/events"
     },
     "getEventsForRepoIssues": {
-      "method": "GET",
-      "params": {
-        "owner": {
-          "required": true,
-          "type": "string"
-        },
-        "page": {
-          "type": "integer"
-        },
-        "per_page": {
-          "type": "integer"
-        },
-        "repo": {
-          "required": true,
-          "type": "string"
-        }
-      },
-      "url": "/repos/:owner/:repo/issues/events"
+      "alias": "issues.getEventsForRepo",
+      "deprecated": "`activity.getEventsForRepoIssues()` is deprecated, use `issues.getEventsForRepo`",
+      "params": {}
     },
     "getEventsForRepoNetwork": {
       "method": "GET",

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -4,8 +4,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/notifications/threads/:id/subscription"
@@ -14,19 +14,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/starred/:owner/:repo"
@@ -35,8 +34,8 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/notifications/threads/:id/subscription"
@@ -48,8 +47,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/events"
@@ -58,15 +56,14 @@
       "method": "GET",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/orgs/:org/events"
@@ -75,19 +72,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/events"
@@ -96,19 +92,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/events"
@@ -117,19 +112,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/networks/:owner/:repo/events"
@@ -141,12 +135,11 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/events"
@@ -155,19 +148,18 @@
       "method": "GET",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/events/orgs/:org"
@@ -179,12 +171,11 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/events/public"
@@ -196,12 +187,11 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/received_events"
@@ -213,12 +203,11 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/received_events/public"
@@ -232,8 +221,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/notifications/threads/:id"
@@ -242,15 +231,13 @@
       "method": "GET",
       "params": {
         "all": {
-          "type": "boolean",
-          "default": "false"
+          "type": "boolean"
         },
         "before": {
           "type": "string"
         },
         "participating": {
-          "type": "boolean",
-          "default": "false"
+          "type": "boolean"
         },
         "since": {
           "type": "date"
@@ -262,23 +249,21 @@
       "method": "GET",
       "params": {
         "all": {
-          "type": "boolean",
-          "default": "false"
+          "type": "boolean"
         },
         "before": {
           "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "participating": {
-          "type": "boolean",
-          "default": "false"
+          "type": "boolean"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "since": {
           "type": "date"
@@ -290,19 +275,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/subscription"
@@ -314,19 +298,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/stargazers"
@@ -338,27 +321,24 @@
       "method": "GET",
       "params": {
         "direction": {
-          "type": "string",
           "enum": [
             "asc",
             "desc"
           ],
-          "default": "desc"
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "created",
             "updated"
           ],
-          "default": "created"
+          "type": "string"
         }
       },
       "url": "/user/starred"
@@ -370,31 +350,28 @@
       "method": "GET",
       "params": {
         "direction": {
-          "type": "string",
           "enum": [
             "asc",
             "desc"
           ],
-          "default": "desc"
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "created",
             "updated"
           ],
-          "default": "created"
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/starred"
@@ -406,8 +383,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/user/subscriptions"
@@ -419,12 +395,11 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/subscriptions"
@@ -433,19 +408,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/subscribers"
@@ -454,8 +428,8 @@
       "method": "PATCH",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/notifications/threads/:id"
@@ -464,8 +438,7 @@
       "method": "PUT",
       "params": {
         "last_read_at": {
-          "type": "string",
-          "default": "Time.now"
+          "type": "string"
         }
       },
       "url": "/notifications"
@@ -474,16 +447,15 @@
       "method": "PUT",
       "params": {
         "last_read_at": {
-          "type": "string",
-          "default": "Time.now"
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/notifications"
@@ -492,8 +464,8 @@
       "method": "PUT",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "ignored": {
           "type": "boolean"
@@ -511,12 +483,12 @@
           "type": "boolean"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "subscribed": {
           "type": "boolean"
@@ -528,12 +500,12 @@
       "method": "PUT",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/starred/:owner/:repo"
@@ -542,12 +514,12 @@
       "method": "DELETE",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/starred/:owner/:repo"
@@ -556,12 +528,12 @@
       "method": "DELETE",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/subscription"
@@ -575,12 +547,12 @@
       "method": "PUT",
       "params": {
         "installation_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repository_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/installations/:installation_id/repositories/:repository_id"
@@ -592,8 +564,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/marketplace_listing/accounts/:id"
@@ -605,8 +577,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/marketplace_listing/stubbed/accounts/:id"
@@ -618,8 +590,8 @@
       "method": "POST",
       "params": {
         "installation_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "user_id": {
           "type": "string"
@@ -639,8 +611,8 @@
       "method": "GET",
       "params": {
         "app_slug": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/apps/:app_slug"
@@ -652,8 +624,8 @@
       "method": "GET",
       "params": {
         "installation_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/app/installations/:installation_id"
@@ -680,8 +652,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/app/installations"
@@ -693,15 +664,14 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/marketplace_listing/plans/:id/accounts"
@@ -716,8 +686,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/marketplace_listing/plans"
@@ -729,15 +698,14 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/marketplace_listing/stubbed/plans/:id/accounts"
@@ -752,8 +720,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/marketplace_listing/stubbed/plans"
@@ -765,12 +732,12 @@
       "method": "DELETE",
       "params": {
         "installation_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repository_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/installations/:installation_id/repositories/:repository_id"
@@ -781,8 +748,8 @@
       "method": "GET",
       "params": {
         "access_token": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "client_id": {
           "type": "string"
@@ -818,8 +785,8 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/authorizations/:id"
@@ -828,8 +795,8 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/applications/grants/:id"
@@ -838,8 +805,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/authorizations/:id"
@@ -851,8 +818,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/authorizations"
@@ -861,15 +827,14 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/applications/grants/:id"
@@ -881,8 +846,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/applications/grants"
@@ -894,8 +858,8 @@
           "type": "string"
         },
         "client_secret": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "fingerprint": {
           "type": "string"
@@ -919,8 +883,8 @@
           "type": "string"
         },
         "client_secret": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "fingerprint": {
           "type": "string"
@@ -941,8 +905,8 @@
       "method": "POST",
       "params": {
         "access_token": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "client_id": {
           "type": "string"
@@ -954,8 +918,8 @@
       "method": "DELETE",
       "params": {
         "access_token": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "client_id": {
           "type": "string"
@@ -967,8 +931,8 @@
       "method": "DELETE",
       "params": {
         "access_token": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "client_id": {
           "type": "string"
@@ -986,8 +950,8 @@
           "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "note": {
           "type": "string"
@@ -1010,12 +974,12 @@
       "method": "POST",
       "params": {
         "admin": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "login": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "profile_name": {
           "type": "string"
@@ -1030,12 +994,12 @@
       "method": "POST",
       "params": {
         "image_url": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/admin/pre-receive-environments"
@@ -1047,28 +1011,26 @@
       "method": "POST",
       "params": {
         "allow_downstream_configuration": {
-          "type": "boolean",
-          "default": "false"
+          "type": "boolean"
         },
         "enforcement": {
-          "type": "string",
-          "default": "disabled"
+          "type": "string"
         },
         "environment": {
-          "type": "json",
-          "required": true
+          "required": true,
+          "type": "json"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "script": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "script_repository": {
-          "type": "json",
-          "required": true
+          "required": true,
+          "type": "json"
         }
       },
       "url": "/admin/pre-receive-hooks"
@@ -1077,8 +1039,8 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/admin/pre-receive-environments/:id"
@@ -1087,8 +1049,8 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/admin/pre_receive_hooks/:id"
@@ -1097,16 +1059,16 @@
       "method": "PATCH",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "image_url": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/admin/pre-receive-environments/:id"
@@ -1115,13 +1077,13 @@
       "method": "PATCH",
       "params": {
         "hook": {
-          "type": "json",
+          "mapTo": "input",
           "required": true,
-          "mapTo": "input"
+          "type": "json"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/admin/pre_receive_hooks/:id"
@@ -1138,8 +1100,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/admin/pre-receive-environments/:id"
@@ -1151,8 +1113,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/admin/pre-receive-environments/:id/downloads/latest"
@@ -1172,8 +1134,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/admin/pre-receive-hooks/:id"
@@ -1190,8 +1152,8 @@
       "method": "POST",
       "params": {
         "target": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/staff/indexing_jobs"
@@ -1200,8 +1162,6 @@
       "method": "GET",
       "params": {
         "type": {
-          "type": "string",
-          "required": true,
           "enum": [
             "issues",
             "hooks",
@@ -1214,7 +1174,9 @@
             "pulls",
             "repos",
             "all"
-          ]
+          ],
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/enterprise/stats/:type"
@@ -1223,8 +1185,8 @@
       "method": "POST",
       "params": {
         "team_id": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         }
       },
       "url": "/admin/ldap/teams/:team_id/sync"
@@ -1233,8 +1195,8 @@
       "method": "POST",
       "params": {
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/admin/ldap/users/:username/sync"
@@ -1246,8 +1208,8 @@
       "method": "POST",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/admin/pre-receive-environments/:id/downloads"
@@ -1256,12 +1218,12 @@
       "method": "PATCH",
       "params": {
         "ldap_dn": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "team_id": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         }
       },
       "url": "/admin/ldap/teams/:team_id/mapping"
@@ -1270,12 +1232,12 @@
       "method": "PATCH",
       "params": {
         "ldap_dn": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/admin/ldap/users/:username/mapping"
@@ -1286,8 +1248,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/gists/:id/star"
@@ -1299,12 +1261,12 @@
           "type": "string"
         },
         "files": {
-          "type": "json",
-          "required": true
+          "required": true,
+          "type": "json"
         },
         "public": {
-          "type": "boolean",
-          "required": true
+          "required": true,
+          "type": "boolean"
         }
       },
       "url": "/gists"
@@ -1313,12 +1275,12 @@
       "method": "POST",
       "params": {
         "body": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "gist_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/gists/:gist_id/comments"
@@ -1327,8 +1289,8 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/gists/:id"
@@ -1337,12 +1299,12 @@
       "method": "DELETE",
       "params": {
         "gist_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/gists/:gist_id/comments/:id"
@@ -1360,12 +1322,12 @@
           "type": "string"
         },
         "files": {
-          "type": "json",
-          "required": true
+          "required": true,
+          "type": "json"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/gists/:id"
@@ -1374,16 +1336,16 @@
       "method": "PATCH",
       "params": {
         "body": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "gist_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/gists/:gist_id/comments/:id"
@@ -1392,8 +1354,8 @@
       "method": "POST",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/gists/:id/forks"
@@ -1402,8 +1364,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/gists/:id"
@@ -1415,8 +1377,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "since": {
           "type": "date"
@@ -1428,12 +1389,12 @@
       "method": "GET",
       "params": {
         "gist_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/gists/:gist_id/comments/:id"
@@ -1442,8 +1403,8 @@
       "method": "GET",
       "params": {
         "gist_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/gists/:gist_id/comments"
@@ -1452,8 +1413,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/gists/:id/commits"
@@ -1465,15 +1426,14 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "since": {
           "type": "date"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/gists"
@@ -1482,15 +1442,14 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/gists/:id/forks"
@@ -1508,12 +1467,12 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sha": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/gists/:id/:sha"
@@ -1531,8 +1490,8 @@
       "method": "PUT",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/gists/:id/star"
@@ -1541,8 +1500,8 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/gists/:id/star"
@@ -1553,21 +1512,21 @@
       "method": "POST",
       "params": {
         "content": {
-          "type": "string",
+          "allow-empty": true,
           "required": true,
-          "allow-empty": true
+          "type": "string"
         },
         "encoding": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/git/blobs"
@@ -1582,24 +1541,24 @@
           "type": "json"
         },
         "message": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "parents": {
-          "type": "string[]",
-          "required": true
+          "required": true,
+          "type": "string[]"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "tree": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/git/commits"
@@ -1608,20 +1567,20 @@
       "method": "POST",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "ref": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sha": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/git/refs"
@@ -1630,32 +1589,32 @@
       "method": "POST",
       "params": {
         "message": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "object": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "tag": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "tagger": {
-          "type": "json",
-          "required": true
+          "required": true,
+          "type": "json"
         },
         "type": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/git/tags"
@@ -1667,16 +1626,16 @@
           "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "tree": {
-          "type": "json",
-          "required": true
+          "required": true,
+          "type": "json"
         }
       },
       "url": "/repos/:owner/:repo/git/trees"
@@ -1685,17 +1644,17 @@
       "method": "DELETE",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "ref": {
-          "type": "string",
+          "allow-empty": true,
           "required": true,
-          "allow-empty": true
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/git/refs/:ref"
@@ -1704,23 +1663,22 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sha": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/git/blobs/:sha"
@@ -1729,16 +1687,16 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sha": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/git/commits/:sha"
@@ -1747,16 +1705,16 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sha": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/git/commits/:sha"
@@ -1765,17 +1723,17 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "ref": {
-          "type": "string",
+          "allow-empty": true,
           "required": true,
-          "allow-empty": true
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/git/refs/:ref"
@@ -1784,19 +1742,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/git/refs"
@@ -1805,16 +1762,16 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sha": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/git/tags/:sha"
@@ -1823,16 +1780,16 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sha": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/git/tags/:sha"
@@ -1841,19 +1798,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/git/refs/tags"
@@ -1862,19 +1818,19 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "recursive": {
           "type": "boolean"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sha": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/git/trees/:sha"
@@ -1883,25 +1839,24 @@
       "method": "PATCH",
       "params": {
         "force": {
-          "type": "boolean",
-          "default": "false"
+          "type": "boolean"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "ref": {
-          "type": "string",
+          "allow-empty": true,
           "required": true,
-          "allow-empty": true
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sha": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/git/refs/:ref"
@@ -1916,12 +1871,12 @@
       "method": "PUT",
       "params": {
         "installation_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repository_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/installations/:installation_id/repositories/:repository_id"
@@ -1934,8 +1889,8 @@
       "method": "POST",
       "params": {
         "installation_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "user_id": {
           "type": "string"
@@ -1967,8 +1922,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/app/installations"
@@ -1981,12 +1935,12 @@
       "method": "DELETE",
       "params": {
         "installation_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repository_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/installations/:installation_id/repositories/:repository_id"
@@ -1997,20 +1951,20 @@
       "method": "POST",
       "params": {
         "assignees": {
-          "type": "string[]",
-          "required": true
+          "required": true,
+          "type": "string[]"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/:number/assignees"
@@ -2019,21 +1973,21 @@
       "method": "POST",
       "params": {
         "labels": {
-          "type": "string[]",
+          "mapTo": "input",
           "required": true,
-          "mapTo": "input"
+          "type": "string[]"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/:number/labels"
@@ -2042,16 +1996,16 @@
       "method": "GET",
       "params": {
         "assignee": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/assignees/:assignee"
@@ -2078,16 +2032,16 @@
           "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "title": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues"
@@ -2099,20 +2053,20 @@
       "method": "POST",
       "params": {
         "body": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/:number/comments"
@@ -2121,20 +2075,20 @@
       "method": "POST",
       "params": {
         "color": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/labels"
@@ -2149,25 +2103,24 @@
           "type": "date"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "state": {
-          "type": "string",
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "default": "open"
+          "type": "string"
         },
         "title": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/milestones"
@@ -2179,16 +2132,16 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/comments/:id"
@@ -2197,16 +2150,16 @@
       "method": "DELETE",
       "params": {
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/labels/:name"
@@ -2215,16 +2168,16 @@
       "method": "DELETE",
       "params": {
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/milestones/:number"
@@ -2248,28 +2201,27 @@
           "type": "string[]"
         },
         "milestone": {
-          "type": "number",
-          "allow-null": true
+          "allow-null": true,
+          "type": "number"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "state": {
-          "type": "string",
           "enum": [
             "open",
             "closed"
           ],
-          "default": "open"
+          "type": "string"
         },
         "title": {
           "type": "string"
@@ -2284,20 +2236,20 @@
       "method": "PATCH",
       "params": {
         "body": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/comments/:id"
@@ -2309,16 +2261,16 @@
       "method": "GET",
       "params": {
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/:number"
@@ -2330,15 +2282,13 @@
       "method": "GET",
       "params": {
         "direction": {
-          "type": "string",
           "enum": [
             "asc",
             "desc"
           ],
-          "default": "desc"
+          "type": "string"
         },
         "filter": {
-          "type": "string",
           "enum": [
             "all",
             "assigned",
@@ -2346,7 +2296,7 @@
             "mentioned",
             "subscribed"
           ],
-          "default": "assigned"
+          "type": "string"
         },
         "labels": {
           "type": "string"
@@ -2355,29 +2305,26 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "since": {
           "type": "date"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "created",
             "updated",
             "comments"
           ],
-          "default": "created"
+          "type": "string"
         },
         "state": {
-          "type": "string",
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "default": "open"
+          "type": "string"
         }
       },
       "url": "/issues"
@@ -2386,12 +2333,12 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/assignees"
@@ -2403,16 +2350,16 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/comments/:id"
@@ -2424,23 +2371,22 @@
       "method": "GET",
       "params": {
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "since": {
           "type": "date"
@@ -2455,38 +2401,35 @@
       "method": "GET",
       "params": {
         "direction": {
-          "type": "string",
           "enum": [
             "asc",
             "desc"
           ],
-          "default": "desc"
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "since": {
           "type": "date"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "created",
             "updated"
           ],
-          "default": "created"
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/comments"
@@ -2495,16 +2438,16 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/events/:id"
@@ -2517,23 +2460,22 @@
           "deprecated": "`issue_number` parameter has been renamed to `number`"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/:number/events"
@@ -2542,19 +2484,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/events"
@@ -2570,23 +2511,22 @@
           "deprecated": "`issue_number` parameter has been renamed to `number`"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/:number/timeline"
@@ -2598,57 +2538,53 @@
       "method": "GET",
       "params": {
         "direction": {
-          "type": "string",
           "enum": [
             "asc",
             "desc"
           ],
-          "default": "desc"
+          "type": "string"
         },
         "filter": {
-          "type": "string",
           "enum": [
             "all",
             "assigned",
             "created",
             "mentioned",
             "subscribed"
-          ]
+          ],
+          "type": "string"
         },
         "labels": {
           "type": "string"
         },
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "since": {
           "type": "date"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "created",
             "updated",
             "comments"
           ],
-          "default": "created"
+          "type": "string"
         },
         "state": {
-          "type": "string",
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "default": "open"
+          "type": "string"
         }
       },
       "url": "/orgs/:org/issues"
@@ -2666,12 +2602,11 @@
           "type": "string"
         },
         "direction": {
-          "type": "string",
           "enum": [
             "asc",
             "desc"
           ],
-          "default": "desc"
+          "type": "string"
         },
         "labels": {
           "type": "string"
@@ -2684,40 +2619,37 @@
           "validation": "^([0-9]+|none|\\*)$"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "since": {
           "type": "date"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "created",
             "updated",
             "comments"
           ],
-          "default": "created"
+          "type": "string"
         },
         "state": {
-          "type": "string",
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "default": "open"
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues"
@@ -2729,22 +2661,21 @@
       "method": "GET",
       "params": {
         "direction": {
-          "type": "string",
           "enum": [
             "asc",
             "desc"
           ],
-          "default": "desc"
+          "type": "string"
         },
         "filter": {
-          "type": "string",
           "enum": [
             "all",
             "assigned",
             "created",
             "mentioned",
             "subscribed"
-          ]
+          ],
+          "type": "string"
         },
         "labels": {
           "type": "string"
@@ -2753,29 +2684,26 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "since": {
           "type": "date"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "created",
             "updated",
             "comments"
           ],
-          "default": "created"
+          "type": "string"
         },
         "state": {
-          "type": "string",
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "default": "open"
+          "type": "string"
         }
       },
       "url": "/user/issues"
@@ -2784,16 +2712,16 @@
       "method": "GET",
       "params": {
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/:number/labels"
@@ -2802,16 +2730,16 @@
       "method": "GET",
       "params": {
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/labels/:name"
@@ -2820,19 +2748,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/labels"
@@ -2841,16 +2768,16 @@
       "method": "GET",
       "params": {
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/milestones/:number"
@@ -2859,16 +2786,16 @@
       "method": "GET",
       "params": {
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/milestones/:number/labels"
@@ -2877,44 +2804,40 @@
       "method": "GET",
       "params": {
         "direction": {
-          "type": "string",
           "enum": [
             "asc",
             "desc"
           ],
-          "default": "asc"
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "due_on",
             "completeness"
           ],
-          "default": "due_on"
+          "type": "string"
         },
         "state": {
-          "type": "string",
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "default": "open"
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/milestones"
@@ -2923,16 +2846,16 @@
       "method": "PUT",
       "params": {
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/:number/lock"
@@ -2941,16 +2864,16 @@
       "method": "DELETE",
       "params": {
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/:number/labels"
@@ -2959,20 +2882,20 @@
       "method": "DELETE",
       "params": {
         "body": {
-          "type": "json",
-          "required": true
+          "required": true,
+          "type": "json"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/:number/assignees"
@@ -2981,20 +2904,20 @@
       "method": "DELETE",
       "params": {
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/:number/labels/:name"
@@ -3003,21 +2926,21 @@
       "method": "PUT",
       "params": {
         "labels": {
-          "type": "string[]",
+          "mapTo": "input",
           "required": true,
-          "mapTo": "input"
+          "type": "string[]"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/:number/labels"
@@ -3026,16 +2949,16 @@
       "method": "DELETE",
       "params": {
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/:number/lock"
@@ -3044,24 +2967,24 @@
       "method": "PATCH",
       "params": {
         "color": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "oldname": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/labels/:oldname"
@@ -3076,29 +2999,28 @@
           "type": "date"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "state": {
-          "type": "string",
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "default": "open"
+          "type": "string"
         },
         "title": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/milestones/:number"
@@ -3112,12 +3034,12 @@
       "method": "DELETE",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/import"
@@ -3129,12 +3051,12 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/migrations/:id/archive"
@@ -3146,12 +3068,12 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "since": {
           "type": "string"
@@ -3166,12 +3088,12 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/import"
@@ -3187,12 +3109,12 @@
           "deprecated": "`name` parameter has been renamed to `repo`"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/import/large_files"
@@ -3204,12 +3126,12 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/migrations/:id/archive"
@@ -3221,12 +3143,12 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/migrations/:id"
@@ -3238,15 +3160,14 @@
       "method": "GET",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/orgs/:org/migrations"
@@ -3258,8 +3179,8 @@
       "method": "PATCH",
       "params": {
         "author_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "email": {
           "type": "string"
@@ -3268,12 +3189,12 @@
           "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/import/authors/:author_id"
@@ -3289,16 +3210,16 @@
           "deprecated": "`name` parameter has been renamed to `repo`"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "use_lfs": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/import/lfs"
@@ -3310,31 +3231,31 @@
       "method": "PUT",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "tfvc_project": {
           "type": "string"
         },
         "vcs": {
-          "type": "string",
           "enum": [
             "subversion",
             "git",
             "mercurial",
             "tfvc"
-          ]
+          ],
+          "type": "string"
         },
         "vcs_password": {
           "type": "string"
         },
         "vcs_url": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "vcs_username": {
           "type": "string"
@@ -3349,20 +3270,18 @@
       "method": "POST",
       "params": {
         "exclude_attachments": {
-          "type": "boolean",
-          "default": "false"
+          "type": "boolean"
         },
         "lock_repositories": {
-          "type": "boolean",
-          "default": "false"
+          "type": "boolean"
         },
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repositories": {
-          "type": "string[]",
-          "required": true
+          "required": true,
+          "type": "string[]"
         }
       },
       "url": "/orgs/:org/migrations"
@@ -3374,16 +3293,16 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo_name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/migrations/:id/repos/:repo_name/lock"
@@ -3395,12 +3314,12 @@
       "method": "PATCH",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "vcs_password": {
           "type": "string"
@@ -3420,8 +3339,8 @@
       "method": "GET",
       "params": {
         "key": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/codes_of_conduct/:key"
@@ -3443,8 +3362,8 @@
       "method": "GET",
       "params": {
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/gitignore/templates/:name"
@@ -3461,8 +3380,8 @@
       "method": "GET",
       "params": {
         "license": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/licenses/:license"
@@ -3492,12 +3411,12 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/community/code_of_conduct"
@@ -3509,12 +3428,12 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/license"
@@ -3526,16 +3445,15 @@
           "type": "string"
         },
         "mode": {
-          "type": "string",
           "enum": [
             "markdown",
             "gfm"
           ],
-          "default": "markdown"
+          "type": "string"
         },
         "text": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/markdown"
@@ -3547,9 +3465,9 @@
       "method": "POST",
       "params": {
         "data": {
-          "type": "string",
+          "mapTo": "input",
           "required": true,
-          "mapTo": "input"
+          "type": "string"
         }
       },
       "url": "/markdown/raw"
@@ -3560,21 +3478,20 @@
       "method": "PUT",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "role": {
-          "type": "string",
-          "required": true,
           "enum": [
             "admin",
             "member"
           ],
-          "default": "member"
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/memberships/:username"
@@ -3586,20 +3503,19 @@
       "method": "PUT",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "role": {
-          "type": "string",
           "enum": [
             "member",
             "maintainer"
           ],
-          "default": "member"
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/teams/:id/memberships/:username"
@@ -3611,24 +3527,24 @@
       "method": "PUT",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "permission": {
-          "type": "string",
           "enum": [
             "pull",
             "push",
             "admin"
-          ]
+          ],
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/teams/:id/repos/:org/:repo"
@@ -3640,12 +3556,12 @@
       "method": "PUT",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/blocks/:username"
@@ -3657,12 +3573,12 @@
       "method": "GET",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/blocks/:username"
@@ -3671,12 +3587,12 @@
       "method": "GET",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/members/:username"
@@ -3685,12 +3601,12 @@
       "method": "GET",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/public_members/:username"
@@ -3702,16 +3618,16 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/teams/:id/repos/:owner/:repo"
@@ -3720,12 +3636,12 @@
       "method": "DELETE",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/public_members/:username"
@@ -3734,12 +3650,12 @@
       "method": "PUT",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/outside_collaborators/:username"
@@ -3751,20 +3667,19 @@
           "type": "boolean"
         },
         "config": {
-          "type": "json",
-          "required": true
+          "required": true,
+          "type": "json"
         },
         "events": {
-          "type": "string[]",
-          "default": "[\"push\"]"
+          "type": "string[]"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/hooks"
@@ -3782,23 +3697,22 @@
           "type": "string[]"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "parent_team_id": {
           "type": "number"
         },
         "privacy": {
-          "type": "string",
           "enum": [
             "secret",
             "closed"
           ],
-          "default": "secret"
+          "type": "string"
         },
         "repo_names": {
           "type": "string[]"
@@ -3810,12 +3724,12 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/hooks/:id"
@@ -3827,8 +3741,8 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/teams/:id"
@@ -3840,16 +3754,16 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/teams/:id/repos/:owner/:repo"
@@ -3861,20 +3775,19 @@
           "type": "boolean"
         },
         "config": {
-          "type": "json",
-          "required": true
+          "required": true,
+          "type": "json"
         },
         "events": {
-          "type": "string[]",
-          "default": "[\"push\"]"
+          "type": "string[]"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/hooks/:id"
@@ -3889,23 +3802,22 @@
           "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "parent_team_id": {
           "type": "number"
         },
         "privacy": {
-          "type": "string",
           "enum": [
             "secret",
             "closed"
           ],
-          "default": "secret"
+          "type": "string"
         }
       },
       "url": "/teams/:id"
@@ -3914,15 +3826,14 @@
       "method": "GET",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/orgs/:org"
@@ -3934,8 +3845,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "since": {
           "type": "string"
@@ -3950,15 +3860,14 @@
       "method": "GET",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/orgs/:org/blocks"
@@ -3970,15 +3879,14 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/teams/:id/teams"
@@ -3990,12 +3898,11 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/orgs"
@@ -4004,12 +3911,12 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/hooks/:id"
@@ -4018,15 +3925,14 @@
       "method": "GET",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/orgs/:org/hooks"
@@ -4035,32 +3941,29 @@
       "method": "GET",
       "params": {
         "filter": {
-          "type": "string",
           "enum": [
             "all",
             "2fa_disabled"
           ],
-          "default": "all"
+          "type": "string"
         },
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "role": {
-          "type": "string",
           "enum": [
             "all",
             "admin",
             "member"
           ],
-          "default": "all"
+          "type": "string"
         }
       },
       "url": "/orgs/:org/members"
@@ -4069,12 +3972,12 @@
       "method": "GET",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/memberships/:username"
@@ -4083,23 +3986,21 @@
       "method": "GET",
       "params": {
         "filter": {
-          "type": "string",
           "enum": [
             "all",
             "2fa_disabled"
           ],
-          "default": "all"
+          "type": "string"
         },
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/orgs/:org/outside_collaborators"
@@ -4108,8 +4009,8 @@
       "method": "GET",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/invitations"
@@ -4118,15 +4019,14 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/teams/:id/invitations"
@@ -4135,8 +4035,8 @@
       "method": "GET",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/public_members"
@@ -4148,8 +4048,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/teams/:id"
@@ -4161,24 +4061,22 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "role": {
-          "type": "string",
           "enum": [
             "member",
             "maintainer",
             "all"
           ],
-          "default": "all"
+          "type": "string"
         }
       },
       "url": "/teams/:id/members"
@@ -4190,12 +4088,12 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/teams/:id/memberships/:username"
@@ -4207,15 +4105,14 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/teams/:id/repos"
@@ -4227,15 +4124,14 @@
       "method": "GET",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/orgs/:org/teams"
@@ -4244,12 +4140,12 @@
       "method": "POST",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/hooks/:id/pings"
@@ -4258,12 +4154,12 @@
       "method": "PUT",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/public_members/:username"
@@ -4272,12 +4168,12 @@
       "method": "DELETE",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/members/:username"
@@ -4286,12 +4182,12 @@
       "method": "DELETE",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/memberships/:username"
@@ -4300,12 +4196,12 @@
       "method": "DELETE",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/outside_collaborators/:username"
@@ -4317,12 +4213,12 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/teams/:id/memberships/:username"
@@ -4334,12 +4230,12 @@
       "method": "DELETE",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/blocks/:username"
@@ -4354,14 +4250,13 @@
           "type": "string"
         },
         "default_repository_permission": {
-          "type": "string",
           "enum": [
             "read",
             "write",
             "admin",
             "none"
           ],
-          "default": "read"
+          "type": "string"
         },
         "description": {
           "type": "string"
@@ -4373,15 +4268,14 @@
           "type": "string"
         },
         "members_can_create_repositories": {
-          "type": "boolean",
-          "default": true
+          "type": "boolean"
         },
         "name": {
           "type": "string"
         },
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org"
@@ -4398,12 +4292,12 @@
           "type": "string"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/orgs/:org/projects"
@@ -4425,8 +4319,8 @@
           "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "note": {
           "type": "string"
@@ -4441,12 +4335,12 @@
       "method": "POST",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "project_id": {
           "alias": "id",
@@ -4465,16 +4359,16 @@
           "type": "string"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/projects"
@@ -4486,8 +4380,8 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/projects/:id"
@@ -4499,8 +4393,8 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/projects/columns/cards/:id"
@@ -4512,8 +4406,8 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/projects/columns/:id"
@@ -4525,17 +4419,16 @@
       "method": "GET",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "state": {
-          "type": "string",
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "default": "open"
+          "type": "string"
         }
       },
       "url": "/orgs/:org/projects"
@@ -4547,8 +4440,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/projects/:id"
@@ -4560,8 +4453,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/projects/columns/cards/:id"
@@ -4577,8 +4470,8 @@
           "deprecated": "`column_id` parameter has been renamed to `id`"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/projects/columns/:id/cards"
@@ -4590,8 +4483,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/projects/columns/:id"
@@ -4603,8 +4496,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "project_id": {
           "alias": "id",
@@ -4620,21 +4513,20 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "state": {
-          "type": "string",
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "default": "open"
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/projects"
@@ -4649,12 +4541,12 @@
           "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "position": {
-          "type": "string",
           "required": true,
+          "type": "string",
           "validation": "^(top|bottom|after:\\d+)$"
         }
       },
@@ -4667,12 +4559,12 @@
       "method": "POST",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "position": {
-          "type": "string",
           "required": true,
+          "type": "string",
           "validation": "^(first|last|after:\\d+)$"
         }
       },
@@ -4688,21 +4580,20 @@
           "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "state": {
-          "type": "string",
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "default": "open"
+          "type": "string"
         }
       },
       "url": "/projects/:id"
@@ -4714,8 +4605,8 @@
       "method": "PATCH",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "note": {
           "type": "string"
@@ -4730,12 +4621,12 @@
       "method": "PATCH",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/projects/columns/:id"
@@ -4749,23 +4640,22 @@
       "method": "GET",
       "params": {
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/:number/merge"
@@ -4774,30 +4664,30 @@
       "method": "POST",
       "params": {
         "base": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "body": {
           "type": "string"
         },
         "head": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "maintainer_can_modify": {
           "type": "boolean"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "title": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls"
@@ -4809,32 +4699,32 @@
       "method": "POST",
       "params": {
         "body": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "commit_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "path": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "position": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/:number/comments"
@@ -4846,24 +4736,24 @@
       "method": "POST",
       "params": {
         "body": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "in_reply_to": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/:number/comments"
@@ -4872,24 +4762,24 @@
       "method": "POST",
       "params": {
         "base": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "head": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "issue": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls"
@@ -4907,26 +4797,25 @@
           "type": "string"
         },
         "event": {
-          "type": "string",
           "enum": [
             "APPROVE",
             "REQUEST_CHANGES",
             "COMMENT",
             "PENDING"
           ],
-          "default": "PENDING"
+          "type": "string"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/:number/reviews"
@@ -4938,16 +4827,16 @@
       "method": "POST",
       "params": {
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "reviewers": {
           "type": "string[]"
@@ -4965,16 +4854,16 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/comments/:id"
@@ -4983,20 +4872,20 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/:number/reviews/:id"
@@ -5008,16 +4897,16 @@
       "method": "DELETE",
       "params": {
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "reviewers": {
           "type": "string[]"
@@ -5032,30 +4921,29 @@
       "method": "PUT",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "message": {
           "type": "string"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/:number/reviews/:id/dismissals"
@@ -5067,20 +4955,20 @@
       "method": "PATCH",
       "params": {
         "body": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/comments/:id"
@@ -5089,16 +4977,16 @@
       "method": "GET",
       "params": {
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/:number"
@@ -5110,49 +4998,45 @@
           "type": "string"
         },
         "direction": {
-          "type": "string",
           "enum": [
             "asc",
             "desc"
           ],
-          "default": "desc"
+          "type": "string"
         },
         "head": {
           "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "created",
             "updated",
             "popularity",
             "long-running"
           ],
-          "default": "created"
+          "type": "string"
         },
         "state": {
-          "type": "string",
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "default": "open"
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls"
@@ -5164,16 +5048,16 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/comments/:id"
@@ -5185,23 +5069,22 @@
       "method": "GET",
       "params": {
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/:number/comments"
@@ -5213,38 +5096,35 @@
       "method": "GET",
       "params": {
         "direction": {
-          "type": "string",
           "enum": [
             "asc",
             "desc"
           ],
-          "default": "desc"
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "since": {
           "type": "date"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "created",
             "updated"
           ],
-          "default": "created"
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/comments"
@@ -5253,23 +5133,22 @@
       "method": "GET",
       "params": {
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/:number/commits"
@@ -5278,23 +5157,22 @@
       "method": "GET",
       "params": {
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/:number/files"
@@ -5303,20 +5181,20 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/:number/reviews/:id"
@@ -5325,27 +5203,26 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/:number/reviews/:id/comments"
@@ -5357,23 +5234,22 @@
       "method": "GET",
       "params": {
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/:number/requested_reviewers"
@@ -5382,23 +5258,22 @@
       "method": "GET",
       "params": {
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/:number/reviews"
@@ -5416,25 +5291,24 @@
           "type": "string"
         },
         "merge_method": {
-          "type": "string",
           "enum": [
             "merge",
             "squash",
             "rebase"
           ],
-          "default": "merge"
+          "type": "string"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sha": {
           "type": "string"
@@ -5449,30 +5323,29 @@
           "type": "string"
         },
         "event": {
-          "type": "string",
           "enum": [
             "APPROVE",
             "REQUEST_CHANGES",
             "COMMENT",
             "PENDING"
           ],
-          "default": "PENDING"
+          "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/:number/reviews/:id/events"
@@ -5487,27 +5360,26 @@
           "type": "string"
         },
         "maintainer_can_modify": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "state": {
-          "type": "string",
           "enum": [
             "open",
             "closed"
-          ]
+          ],
+          "type": "string"
         },
         "title": {
           "type": "string"
@@ -5524,8 +5396,6 @@
       "method": "POST",
       "params": {
         "content": {
-          "type": "string",
-          "required": true,
           "enum": [
             "+1",
             "-1",
@@ -5533,19 +5403,21 @@
             "confused",
             "heart",
             "hooray"
-          ]
+          ],
+          "required": true,
+          "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/comments/:id/reactions"
@@ -5557,8 +5429,6 @@
       "method": "POST",
       "params": {
         "content": {
-          "type": "string",
-          "required": true,
           "enum": [
             "+1",
             "-1",
@@ -5566,19 +5436,21 @@
             "confused",
             "heart",
             "hooray"
-          ]
+          ],
+          "required": true,
+          "type": "string"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/:number/reactions"
@@ -5590,8 +5462,6 @@
       "method": "POST",
       "params": {
         "content": {
-          "type": "string",
-          "required": true,
           "enum": [
             "+1",
             "-1",
@@ -5599,19 +5469,21 @@
             "confused",
             "heart",
             "hooray"
-          ]
+          ],
+          "required": true,
+          "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/comments/:id/reactions"
@@ -5623,8 +5495,6 @@
       "method": "POST",
       "params": {
         "content": {
-          "type": "string",
-          "required": true,
           "enum": [
             "+1",
             "-1",
@@ -5632,19 +5502,21 @@
             "confused",
             "heart",
             "hooray"
-          ]
+          ],
+          "required": true,
+          "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/comments/:id/reactions"
@@ -5656,8 +5528,8 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/reactions/:id"
@@ -5669,7 +5541,6 @@
       "method": "GET",
       "params": {
         "content": {
-          "type": "string",
           "enum": [
             "+1",
             "-1",
@@ -5677,19 +5548,20 @@
             "confused",
             "heart",
             "hooray"
-          ]
+          ],
+          "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/comments/:id/reactions"
@@ -5701,7 +5573,6 @@
       "method": "GET",
       "params": {
         "content": {
-          "type": "string",
           "enum": [
             "+1",
             "-1",
@@ -5709,19 +5580,20 @@
             "confused",
             "heart",
             "hooray"
-          ]
+          ],
+          "type": "string"
         },
         "number": {
-          "type": "number",
-          "required": true
+          "required": true,
+          "type": "number"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/:number/reactions"
@@ -5733,7 +5605,6 @@
       "method": "GET",
       "params": {
         "content": {
-          "type": "string",
           "enum": [
             "+1",
             "-1",
@@ -5741,19 +5612,20 @@
             "confused",
             "heart",
             "hooray"
-          ]
+          ],
+          "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/issues/comments/:id/reactions"
@@ -5765,7 +5637,6 @@
       "method": "GET",
       "params": {
         "content": {
-          "type": "string",
           "enum": [
             "+1",
             "-1",
@@ -5773,19 +5644,20 @@
             "confused",
             "heart",
             "hooray"
-          ]
+          ],
+          "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pulls/comments/:id/reactions"
@@ -5796,25 +5668,24 @@
       "method": "PUT",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "permission": {
-          "type": "string",
           "enum": [
             "pull",
             "push",
             "admin"
           ],
-          "default": "push"
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/collaborators/:username"
@@ -5823,23 +5694,23 @@
       "method": "POST",
       "params": {
         "key": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "read_only": {
           "type": "boolean"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "title": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/keys"
@@ -5848,23 +5719,22 @@
       "method": "POST",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins"
@@ -5873,21 +5743,21 @@
       "method": "POST",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "contexts": {
-          "type": "string[]",
+          "mapTo": "input",
           "required": true,
-          "mapTo": "input"
+          "type": "string[]"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
@@ -5896,21 +5766,21 @@
       "method": "POST",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "teams": {
-          "type": "string[]",
+          "mapTo": "input",
           "required": true,
-          "mapTo": "input"
+          "type": "string[]"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
@@ -5919,21 +5789,21 @@
       "method": "POST",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "users": {
-          "type": "string[]",
+          "mapTo": "input",
           "required": true,
-          "mapTo": "input"
+          "type": "string[]"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
@@ -5942,16 +5812,16 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/collaborators/:username"
@@ -5960,20 +5830,20 @@
       "method": "GET",
       "params": {
         "base": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "head": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/compare/:base...:head"
@@ -5982,20 +5852,16 @@
       "method": "POST",
       "params": {
         "allow_merge_commit": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "allow_rebase_merge": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "allow_squash_merge": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "auto_init": {
-          "type": "boolean",
-          "default": "false"
+          "type": "boolean"
         },
         "description": {
           "type": "string"
@@ -6004,16 +5870,13 @@
           "type": "string"
         },
         "has_issues": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "has_projects": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "has_wiki": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "homepage": {
           "type": "string"
@@ -6022,12 +5885,11 @@
           "type": "string"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "private": {
-          "type": "boolean",
-          "default": "false"
+          "type": "boolean"
         },
         "team_id": {
           "type": "number"
@@ -6039,12 +5901,12 @@
       "method": "POST",
       "params": {
         "body": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "path": {
           "type": "string"
@@ -6053,12 +5915,12 @@
           "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sha": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/commits/:sha/comments"
@@ -6070,46 +5932,40 @@
       "method": "POST",
       "params": {
         "auto_merge": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "description": {
-          "type": "string",
-          "default": "\"\""
+          "type": "string"
         },
         "environment": {
-          "type": "string",
-          "default": "none"
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "payload": {
-          "type": "string",
-          "default": "\"\""
+          "type": "string"
         },
         "production_environment": {
           "type": "boolean"
         },
         "ref": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "required_contexts": {
           "type": "string[]"
         },
         "task": {
-          "type": "string",
-          "default": "deploy"
+          "type": "string"
         },
         "transient_environment": {
-          "type": "boolean",
-          "default": false
+          "type": "boolean"
         }
       },
       "url": "/repos/:owner/:repo/deployments"
@@ -6121,39 +5977,34 @@
       "method": "POST",
       "params": {
         "auto_inactive": {
-          "type": "boolean",
-          "default": true
+          "type": "boolean"
         },
         "description": {
-          "type": "string",
-          "default": "\"\""
+          "type": "string"
         },
         "environment_url": {
-          "type": "string",
-          "default": "\"\""
+          "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "log_url": {
-          "type": "string",
-          "default": "\"\""
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "state": {
           "type": "string"
         },
         "target_url": {
-          "type": "string",
-          "default": "\"\""
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/deployments/:id/statuses"
@@ -6171,24 +6022,24 @@
           "type": "json"
         },
         "content": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "message": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "path": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/contents/:path"
@@ -6197,20 +6048,16 @@
       "method": "POST",
       "params": {
         "allow_merge_commit": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "allow_rebase_merge": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "allow_squash_merge": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "auto_init": {
-          "type": "boolean",
-          "default": "false"
+          "type": "boolean"
         },
         "description": {
           "type": "string"
@@ -6219,16 +6066,13 @@
           "type": "string"
         },
         "has_issues": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "has_projects": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "has_wiki": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "homepage": {
           "type": "string"
@@ -6237,16 +6081,15 @@
           "type": "string"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "private": {
-          "type": "boolean",
-          "default": "false"
+          "type": "boolean"
         },
         "team_id": {
           "type": "number"
@@ -6261,24 +6104,23 @@
           "type": "boolean"
         },
         "config": {
-          "type": "json",
-          "required": true
+          "required": true,
+          "type": "json"
         },
         "events": {
-          "type": "string[]",
-          "default": "[\"push\"]"
+          "type": "string[]"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/hooks"
@@ -6290,27 +6132,25 @@
           "type": "string"
         },
         "draft": {
-          "type": "boolean",
-          "default": "false"
+          "type": "boolean"
         },
         "name": {
           "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "prerelease": {
-          "type": "boolean",
-          "default": "false"
+          "type": "boolean"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "tag_name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "target_commitish": {
           "type": "string"
@@ -6328,26 +6168,26 @@
           "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sha": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "state": {
-          "type": "string",
-          "required": true,
           "enum": [
             "pending",
             "success",
             "error",
             "failure"
-          ]
+          ],
+          "required": true,
+          "type": "string"
         },
         "target_url": {
           "type": "string"
@@ -6362,12 +6202,12 @@
       "method": "DELETE",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo"
@@ -6376,16 +6216,16 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/releases/assets/:id"
@@ -6394,16 +6234,16 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/comments/:id"
@@ -6412,16 +6252,16 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/keys/:id"
@@ -6430,16 +6270,16 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/downloads/:id"
@@ -6457,24 +6297,24 @@
           "type": "json"
         },
         "message": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "path": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sha": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/contents/:path"
@@ -6483,16 +6323,16 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/hooks/:id"
@@ -6501,16 +6341,16 @@
       "method": "DELETE",
       "params": {
         "invitation_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/invitations/:invitation_id"
@@ -6519,16 +6359,16 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/releases/:id"
@@ -6540,16 +6380,13 @@
       "method": "PATCH",
       "params": {
         "allow_merge_commit": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "allow_rebase_merge": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "allow_squash_merge": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "default_branch": {
           "type": "string"
@@ -6558,35 +6395,31 @@
           "type": "string"
         },
         "has_issues": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "has_projects": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "has_wiki": {
-          "type": "boolean",
-          "default": "true"
+          "type": "boolean"
         },
         "homepage": {
           "type": "string"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "private": {
-          "type": "boolean",
-          "default": "false"
+          "type": "boolean"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo"
@@ -6595,23 +6428,23 @@
       "method": "PATCH",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "label": {
           "type": "string"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/releases/assets/:id"
@@ -6626,31 +6459,30 @@
           "type": "string[]"
         },
         "config": {
-          "type": "json",
-          "required": true
+          "required": true,
+          "type": "json"
         },
         "events": {
-          "type": "string[]",
-          "default": "[\"push\"]"
+          "type": "string[]"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "remove_events": {
           "type": "string[]"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/hooks/:id"
@@ -6662,31 +6494,29 @@
           "type": "string"
         },
         "draft": {
-          "type": "boolean",
-          "default": "false"
+          "type": "boolean"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "name": {
           "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "prerelease": {
-          "type": "boolean",
-          "default": "false"
+          "type": "boolean"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "tag_name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "target_commitish": {
           "type": "string"
@@ -6701,12 +6531,12 @@
           "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/forks"
@@ -6718,12 +6548,12 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo"
@@ -6732,36 +6562,31 @@
       "method": "GET",
       "params": {
         "affiliation": {
-          "type": "string",
-          "default": "owner,collaborator,organization_member"
+          "type": "string"
         },
         "direction": {
-          "type": "string",
           "enum": [
             "asc",
             "desc"
           ],
-          "default": "desc"
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "created",
             "updated",
             "pushed",
             "full_name"
           ],
-          "default": "full_name"
+          "type": "string"
         },
         "type": {
-          "type": "string",
           "enum": [
             "all",
             "owner",
@@ -6769,16 +6594,15 @@
             "private",
             "member"
           ],
-          "default": "all"
+          "type": "string"
         },
         "visibility": {
-          "type": "string",
           "enum": [
             "all",
             "public",
             "private"
           ],
-          "default": "all"
+          "type": "string"
         }
       },
       "url": "/user/repos"
@@ -6787,19 +6611,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/comments"
@@ -6808,24 +6631,23 @@
       "method": "GET",
       "params": {
         "archive_format": {
-          "type": "string",
-          "required": true,
           "enum": [
             "tarball",
             "zipball"
           ],
-          "default": "tarball"
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "ref": {
           "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/:archive_format/:ref"
@@ -6834,16 +6656,16 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/releases/assets/:id"
@@ -6852,16 +6674,16 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/releases/:id/assets"
@@ -6870,23 +6692,22 @@
       "method": "GET",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch"
@@ -6895,23 +6716,22 @@
       "method": "GET",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection"
@@ -6920,22 +6740,21 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "protected": {
           "type": "boolean"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches"
@@ -6944,8 +6763,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repositories/:id"
@@ -6954,19 +6773,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/traffic/clones"
@@ -6975,28 +6793,26 @@
       "method": "GET",
       "params": {
         "affiliation": {
-          "type": "string",
           "enum": [
             "outside",
             "all",
             "direct"
           ],
-          "default": "all"
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/collaborators"
@@ -7005,23 +6821,22 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "ref": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/commits/:ref/status"
@@ -7033,16 +6848,16 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sha": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/commits/:sha"
@@ -7051,16 +6866,16 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/comments/:id"
@@ -7069,23 +6884,22 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "ref": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/commits/:ref/comments"
@@ -7097,8 +6911,8 @@
           "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
@@ -7107,12 +6921,11 @@
           "type": "string"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sha": {
           "type": "string"
@@ -7133,12 +6946,12 @@
       "method": "GET",
       "params": {
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:name/community/profile"
@@ -7147,20 +6960,20 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "path": {
-          "type": "string",
+          "allow-empty": true,
           "required": true,
-          "allow-empty": true
+          "type": "string"
         },
         "ref": {
           "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/contents/:path"
@@ -7172,19 +6985,18 @@
           "type": "boolean"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/contributors"
@@ -7193,16 +7005,16 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/keys/:id"
@@ -7211,19 +7023,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/keys"
@@ -7236,16 +7047,16 @@
           "deprecated": "`deployment_id` parameter has been renamed to `id`"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/deployments/:id"
@@ -7254,20 +7065,20 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "status_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/deployments/:id/statuses/:status_id"
@@ -7279,16 +7090,16 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/deployments/:id/statuses"
@@ -7300,35 +7111,30 @@
       "method": "GET",
       "params": {
         "environment": {
-          "type": "string",
-          "default": "none"
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "ref": {
-          "type": "string",
-          "default": "none"
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sha": {
-          "type": "string",
-          "default": "none"
+          "type": "string"
         },
         "task": {
-          "type": "string",
-          "default": "none"
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/deployments"
@@ -7337,16 +7143,16 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/downloads/:id"
@@ -7355,19 +7161,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/downloads"
@@ -7376,18 +7181,16 @@
       "method": "GET",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "type": {
-          "type": "string",
           "enum": [
             "all",
             "public",
@@ -7396,7 +7199,7 @@
             "sources",
             "member"
           ],
-          "default": "all"
+          "type": "string"
         }
       },
       "url": "/orgs/:org/repos"
@@ -7405,42 +7208,38 @@
       "method": "GET",
       "params": {
         "direction": {
-          "type": "string",
           "enum": [
             "asc",
             "desc"
           ],
-          "default": "desc"
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "created",
             "updated",
             "pushed",
             "full_name"
           ],
-          "default": "full_name"
+          "type": "string"
         },
         "type": {
-          "type": "string",
           "enum": [
             "all",
             "owner",
             "member"
           ],
-          "default": "owner"
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/repos"
@@ -7449,28 +7248,26 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "newest",
             "oldest",
             "stargazers"
           ],
-          "default": "newest"
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/forks"
@@ -7479,16 +7276,16 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/hooks/:id"
@@ -7497,19 +7294,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/hooks"
@@ -7518,12 +7314,12 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/invitations"
@@ -7532,19 +7328,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/languages"
@@ -7556,12 +7351,12 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pages/builds/latest"
@@ -7570,12 +7365,12 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/releases/latest"
@@ -7587,19 +7382,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pages"
@@ -7611,16 +7405,16 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pages/builds/:id"
@@ -7632,19 +7426,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pages/builds"
@@ -7653,19 +7446,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/traffic/popular/paths"
@@ -7674,23 +7466,22 @@
       "method": "GET",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins"
@@ -7699,23 +7490,22 @@
       "method": "GET",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews"
@@ -7724,23 +7514,22 @@
       "method": "GET",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks"
@@ -7749,23 +7538,22 @@
       "method": "GET",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
@@ -7774,23 +7562,22 @@
       "method": "GET",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions"
@@ -7799,23 +7586,22 @@
       "method": "GET",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
@@ -7824,23 +7610,22 @@
       "method": "GET",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
@@ -7852,8 +7637,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "since": {
           "type": "string"
@@ -7865,15 +7649,15 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "ref": {
           "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/readme"
@@ -7882,19 +7666,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/traffic/popular/referrers"
@@ -7903,16 +7686,16 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/releases/:id"
@@ -7921,16 +7704,16 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "tag": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/releases/tags/:tag"
@@ -7939,19 +7722,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/releases"
@@ -7960,17 +7742,17 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "ref": {
-          "type": "string",
+          "allow-empty": true,
           "required": true,
-          "allow-empty": true
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/commits/:ref"
@@ -7979,12 +7761,12 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/stats/code_frequency"
@@ -7993,12 +7775,12 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/stats/commit_activity"
@@ -8007,12 +7789,12 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/stats/contributors"
@@ -8021,12 +7803,12 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/stats/participation"
@@ -8035,12 +7817,12 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/stats/punch_card"
@@ -8049,23 +7831,22 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "ref": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/commits/:ref/statuses"
@@ -8074,19 +7855,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/tags"
@@ -8095,19 +7875,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/teams"
@@ -8119,19 +7898,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/topics"
@@ -8140,19 +7918,18 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/traffic/views"
@@ -8161,23 +7938,23 @@
       "method": "POST",
       "params": {
         "base": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "commit_message": {
           "type": "string"
         },
         "head": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/merges"
@@ -8186,16 +7963,16 @@
       "method": "POST",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/hooks/:id/pings"
@@ -8204,16 +7981,16 @@
       "method": "DELETE",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection"
@@ -8222,16 +7999,16 @@
       "method": "DELETE",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/collaborators/:username"
@@ -8240,16 +8017,16 @@
       "method": "DELETE",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins"
@@ -8258,16 +8035,16 @@
       "method": "DELETE",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews"
@@ -8276,16 +8053,16 @@
       "method": "DELETE",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks"
@@ -8294,21 +8071,21 @@
       "method": "DELETE",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "contexts": {
-          "type": "string[]",
+          "mapTo": "input",
           "required": true,
-          "mapTo": "input"
+          "type": "string[]"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
@@ -8317,16 +8094,16 @@
       "method": "DELETE",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions"
@@ -8335,21 +8112,21 @@
       "method": "DELETE",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "teams": {
-          "type": "string[]",
+          "mapTo": "input",
           "required": true,
-          "mapTo": "input"
+          "type": "string[]"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
@@ -8358,21 +8135,21 @@
       "method": "DELETE",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "users": {
-          "type": "string[]",
+          "mapTo": "input",
           "required": true,
-          "mapTo": "input"
+          "type": "string[]"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
@@ -8381,21 +8158,21 @@
       "method": "PUT",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "contexts": {
-          "type": "string[]",
+          "mapTo": "input",
           "required": true,
-          "mapTo": "input"
+          "type": "string[]"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
@@ -8404,21 +8181,21 @@
       "method": "PUT",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "teams": {
-          "type": "string[]",
+          "mapTo": "input",
           "required": true,
-          "mapTo": "input"
+          "type": "string[]"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
@@ -8427,21 +8204,21 @@
       "method": "PUT",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "users": {
-          "type": "string[]",
+          "mapTo": "input",
           "required": true,
-          "mapTo": "input"
+          "type": "string[]"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
@@ -8453,16 +8230,16 @@
       "method": "PUT",
       "params": {
         "names": {
-          "type": "string[]",
-          "required": true
+          "required": true,
+          "type": "string[]"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/topics"
@@ -8474,12 +8251,12 @@
       "method": "POST",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/pages/builds"
@@ -8488,16 +8265,16 @@
       "method": "GET",
       "params": {
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/collaborators/:username/permission"
@@ -8506,16 +8283,16 @@
       "method": "POST",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/hooks/:id/tests"
@@ -8524,47 +8301,46 @@
       "method": "PUT",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "dismissal_restrictions": {
-          "type": "json",
-          "allow-null": true
+          "allow-null": true,
+          "type": "json"
         },
         "enforce_admins": {
-          "type": "boolean",
+          "allow-null": false,
           "required": true,
-          "allow-null": false
+          "type": "boolean"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "required_pull_request_reviews": {
-          "type": "json",
+          "allow-null": true,
           "required": true,
-          "allow-null": true
+          "type": "json"
         },
         "required_status_checks": {
-          "type": "json",
+          "allow-null": true,
           "required": true,
-          "allow-null": true
+          "type": "json"
         },
         "restrictions": {
-          "type": "json",
+          "allow-null": true,
           "required": true,
-          "allow-null": true
+          "type": "json"
         }
       },
       "url": "/repos/:owner/:repo/branches/:branch/protection"
@@ -8573,20 +8349,20 @@
       "method": "PATCH",
       "params": {
         "body": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/comments/:id"
@@ -8604,28 +8380,28 @@
           "type": "json"
         },
         "content": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "message": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "path": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sha": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/contents/:path"
@@ -8634,24 +8410,24 @@
       "method": "PATCH",
       "params": {
         "invitation_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "permissions": {
-          "type": "string",
           "enum": [
             "read",
             "write",
             "admin"
-          ]
+          ],
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/repos/:owner/:repo/invitations/:invitation_id"
@@ -8660,23 +8436,23 @@
       "method": "PATCH",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "dismiss_stale_reviews": {
           "type": "boolean"
         },
         "dismissal_restrictions": {
-          "type": "json",
-          "allow-null": true
+          "allow-null": true,
+          "type": "json"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "require_code_owner_reviews": {
           "type": "boolean"
@@ -8688,19 +8464,19 @@
       "method": "PATCH",
       "params": {
         "branch": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "contexts": {
           "type": "string[]"
         },
         "owner": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repo": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "strict": {
           "type": "boolean"
@@ -8712,30 +8488,30 @@
       "method": "POST",
       "params": {
         "contentLength": {
-          "type": "number",
+          "mapTo": "headers.content-length",
           "required": true,
-          "mapTo": "headers.content-length"
+          "type": "number"
         },
         "contentType": {
-          "type": "string",
+          "mapTo": "headers.content-type",
           "required": true,
-          "mapTo": "headers.content-type"
+          "type": "string"
         },
         "file": {
-          "type": "string | object",
+          "mapTo": "input",
           "required": true,
-          "mapTo": "input"
+          "type": "string | object"
         },
         "label": {
           "type": "string"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "url": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": ":url"
@@ -8746,29 +8522,27 @@
       "method": "GET",
       "params": {
         "order": {
-          "type": "string",
           "enum": [
             "asc",
             "desc"
           ],
-          "default": "desc"
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "q": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "indexed"
-          ]
+          ],
+          "type": "string"
         }
       },
       "url": "/search/code"
@@ -8780,30 +8554,28 @@
       "method": "GET",
       "params": {
         "order": {
-          "type": "string",
           "enum": [
             "asc",
             "desc"
           ],
-          "default": "desc"
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "q": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "author-date",
             "committer-date"
-          ]
+          ],
+          "type": "string"
         }
       },
       "url": "/search/commits"
@@ -8812,31 +8584,29 @@
       "method": "GET",
       "params": {
         "order": {
-          "type": "string",
           "enum": [
             "asc",
             "desc"
           ],
-          "default": "desc"
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "q": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "comments",
             "created",
             "updated"
-          ]
+          ],
+          "type": "string"
         }
       },
       "url": "/search/issues"
@@ -8848,31 +8618,29 @@
       "method": "GET",
       "params": {
         "order": {
-          "type": "string",
           "enum": [
             "asc",
             "desc"
           ],
-          "default": "desc"
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "q": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "stars",
             "forks",
             "updated"
-          ]
+          ],
+          "type": "string"
         }
       },
       "url": "/search/repositories"
@@ -8881,31 +8649,29 @@
       "method": "GET",
       "params": {
         "order": {
-          "type": "string",
           "enum": [
             "asc",
             "desc"
           ],
-          "default": "desc"
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "q": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "sort": {
-          "type": "string",
           "enum": [
             "followers",
             "repositories",
             "joined"
-          ]
+          ],
+          "type": "string"
         }
       },
       "url": "/search/users"
@@ -8916,8 +8682,8 @@
       "method": "PATCH",
       "params": {
         "invitation_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/repository_invitations/:invitation_id"
@@ -8926,9 +8692,9 @@
       "method": "POST",
       "params": {
         "emails": {
-          "type": "string[]",
+          "mapTo": "input",
           "required": true,
-          "mapTo": "input"
+          "type": "string[]"
         }
       },
       "url": "/user/emails"
@@ -8940,12 +8706,12 @@
       "method": "PUT",
       "params": {
         "installation_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repository_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/installations/:installation_id/repositories/:repository_id"
@@ -8957,8 +8723,8 @@
       "method": "PUT",
       "params": {
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/blocks/:username"
@@ -8970,8 +8736,8 @@
       "method": "GET",
       "params": {
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/blocks/:username"
@@ -8980,8 +8746,8 @@
       "method": "GET",
       "params": {
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/following/:username"
@@ -8990,12 +8756,12 @@
       "method": "GET",
       "params": {
         "target_user": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/following/:target_user"
@@ -9007,8 +8773,8 @@
       "method": "POST",
       "params": {
         "armored_public_key": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/gpg_keys"
@@ -9017,12 +8783,12 @@
       "method": "POST",
       "params": {
         "key": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "title": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/keys"
@@ -9031,8 +8797,8 @@
       "method": "DELETE",
       "params": {
         "invitation_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/repository_invitations/:invitation_id"
@@ -9041,9 +8807,9 @@
       "method": "DELETE",
       "params": {
         "emails": {
-          "type": "string[]",
+          "mapTo": "input",
           "required": true,
-          "mapTo": "input"
+          "type": "string[]"
         }
       },
       "url": "/user/emails"
@@ -9055,8 +8821,8 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/gpg_keys/:id"
@@ -9065,8 +8831,8 @@
       "method": "DELETE",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/keys/:id"
@@ -9075,8 +8841,8 @@
       "method": "DELETE",
       "params": {
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/site_admin"
@@ -9085,15 +8851,15 @@
       "method": "PATCH",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "state": {
-          "type": "string",
-          "required": true,
           "enum": [
             "active"
-          ]
+          ],
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/memberships/orgs/:org"
@@ -9102,8 +8868,8 @@
       "method": "PUT",
       "params": {
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/following/:username"
@@ -9134,8 +8900,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/:id"
@@ -9147,8 +8913,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/user/emails"
@@ -9160,8 +8925,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/user/followers"
@@ -9173,12 +8937,11 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/followers"
@@ -9190,8 +8953,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/user/following"
@@ -9203,12 +8965,11 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/following"
@@ -9217,8 +8978,8 @@
       "method": "GET",
       "params": {
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username"
@@ -9230,8 +8991,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/gpg_keys/:id"
@@ -9246,8 +9007,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/user/gpg_keys"
@@ -9262,12 +9022,11 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/gpg_keys"
@@ -9276,15 +9035,14 @@
       "method": "GET",
       "params": {
         "installation_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "page": {
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/user/installations/:installation_id/repositories"
@@ -9299,8 +9057,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/user/installations"
@@ -9309,8 +9066,8 @@
       "method": "GET",
       "params": {
         "id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/keys/:id"
@@ -9322,8 +9079,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/user/keys"
@@ -9335,12 +9091,11 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         },
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/keys"
@@ -9355,8 +9110,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/user/marketplace_purchases"
@@ -9371,8 +9125,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/user/marketplace_purchases/stubbed"
@@ -9381,8 +9134,8 @@
       "method": "GET",
       "params": {
         "org": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/memberships/orgs/:org"
@@ -9391,11 +9144,11 @@
       "method": "GET",
       "params": {
         "state": {
-          "type": "string",
           "enum": [
             "active",
             "pending"
-          ]
+          ],
+          "type": "string"
         }
       },
       "url": "/user/memberships/orgs"
@@ -9407,8 +9160,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/user/orgs"
@@ -9420,8 +9172,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/user/public_emails"
@@ -9441,8 +9192,7 @@
           "type": "number"
         },
         "per_page": {
-          "type": "number",
-          "default": "30"
+          "type": "number"
         }
       },
       "url": "/user/teams"
@@ -9451,8 +9201,8 @@
       "method": "PUT",
       "params": {
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/site_admin"
@@ -9464,12 +9214,12 @@
       "method": "DELETE",
       "params": {
         "installation_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         },
         "repository_id": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/installations/:installation_id/repositories/:repository_id"
@@ -9478,8 +9228,8 @@
       "method": "PUT",
       "params": {
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/suspended"
@@ -9496,8 +9246,8 @@
       "method": "DELETE",
       "params": {
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/blocks/:username"
@@ -9506,8 +9256,8 @@
       "method": "DELETE",
       "params": {
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/user/following/:username"
@@ -9516,8 +9266,8 @@
       "method": "DELETE",
       "params": {
         "username": {
-          "type": "string",
-          "required": true
+          "required": true,
+          "type": "string"
         }
       },
       "url": "/users/:username/suspended"

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -4374,19 +4374,18 @@
       "method": "POST",
       "params": {
         "id": {
-          "required": true,
-          "type": "string"
+          "alias": "project_id"
         },
         "name": {
           "required": true,
           "type": "string"
         },
         "project_id": {
-          "alias": "id",
-          "deprecated": "`project_id` parameter has been renamed to `id`"
+          "required": true,
+          "type": "string"
         }
       },
-      "url": "/projects/:id/columns"
+      "url": "/projects/:project_id/columns"
     },
     "createRepoProject": {
       "headers": {
@@ -4419,11 +4418,14 @@
       "method": "DELETE",
       "params": {
         "id": {
+          "alias": "project_id"
+        },
+        "project_id": {
           "required": true,
           "type": "string"
         }
       },
-      "url": "/projects/:id"
+      "url": "/projects/:project_id"
     },
     "deleteProjectCard": {
       "headers": {
@@ -4431,12 +4433,15 @@
       },
       "method": "DELETE",
       "params": {
-        "id": {
+        "card_id": {
           "required": true,
           "type": "string"
+        },
+        "id": {
+          "alias": "card_id"
         }
       },
-      "url": "/projects/columns/cards/:id"
+      "url": "/projects/columns/cards/:card_id"
     },
     "deleteProjectColumn": {
       "headers": {
@@ -4444,12 +4449,15 @@
       },
       "method": "DELETE",
       "params": {
-        "id": {
+        "column_id": {
           "required": true,
           "type": "string"
+        },
+        "id": {
+          "alias": "column_id"
         }
       },
-      "url": "/projects/columns/:id"
+      "url": "/projects/columns/:column_id"
     },
     "getOrgProjects": {
       "headers": {
@@ -4485,11 +4493,14 @@
       "method": "GET",
       "params": {
         "id": {
+          "alias": "project_id"
+        },
+        "project_id": {
           "required": true,
           "type": "string"
         }
       },
-      "url": "/projects/:id"
+      "url": "/projects/:project_id"
     },
     "getProjectCard": {
       "headers": {
@@ -4497,12 +4508,15 @@
       },
       "method": "GET",
       "params": {
-        "id": {
+        "card_id": {
           "required": true,
           "type": "string"
+        },
+        "id": {
+          "alias": "card_id"
         }
       },
-      "url": "/projects/columns/cards/:id"
+      "url": "/projects/columns/cards/:card_id"
     },
     "getProjectCards": {
       "headers": {
@@ -4533,12 +4547,15 @@
       },
       "method": "GET",
       "params": {
-        "id": {
+        "column_id": {
           "required": true,
           "type": "string"
+        },
+        "id": {
+          "alias": "column_id"
         }
       },
-      "url": "/projects/columns/:id"
+      "url": "/projects/columns/:column_id"
     },
     "getProjectColumns": {
       "headers": {
@@ -4547,8 +4564,7 @@
       "method": "GET",
       "params": {
         "id": {
-          "required": true,
-          "type": "string"
+          "alias": "project_id"
         },
         "page": {
           "type": "number"
@@ -4557,11 +4573,11 @@
           "type": "number"
         },
         "project_id": {
-          "alias": "id",
-          "deprecated": "`project_id` parameter has been renamed to `id`"
+          "required": true,
+          "type": "string"
         }
       },
-      "url": "/projects/:id/columns"
+      "url": "/projects/:project_id/columns"
     },
     "getRepoProjects": {
       "headers": {
@@ -4600,12 +4616,15 @@
       },
       "method": "POST",
       "params": {
+        "card_id": {
+          "required": true,
+          "type": "string"
+        },
         "column_id": {
           "type": "string"
         },
         "id": {
-          "required": true,
-          "type": "string"
+          "alias": "card_id"
         },
         "position": {
           "required": true,
@@ -4613,7 +4632,7 @@
           "validation": "^(top|bottom|after:\\d+)$"
         }
       },
-      "url": "/projects/columns/cards/:id/moves"
+      "url": "/projects/columns/cards/:card_id/moves"
     },
     "moveProjectColumn": {
       "headers": {
@@ -4621,9 +4640,12 @@
       },
       "method": "POST",
       "params": {
-        "id": {
+        "column_id": {
           "required": true,
           "type": "string"
+        },
+        "id": {
+          "alias": "column_id"
         },
         "position": {
           "required": true,
@@ -4631,7 +4653,7 @@
           "validation": "^(first|last|after:\\d+)$"
         }
       },
-      "url": "/projects/columns/:id/moves"
+      "url": "/projects/columns/:column_id/moves"
     },
     "updateProject": {
       "headers": {
@@ -4643,12 +4665,27 @@
           "type": "string"
         },
         "id": {
-          "required": true,
-          "type": "string"
+          "alias": "project_id"
         },
         "name": {
           "required": true,
           "type": "string"
+        },
+        "organization_permission": {
+          "type": "string"
+        },
+        "page": {
+          "type": "integer"
+        },
+        "per_page": {
+          "type": "integer"
+        },
+        "project_id": {
+          "required": true,
+          "type": "string"
+        },
+        "public": {
+          "type": "boolean"
         },
         "state": {
           "enum": [
@@ -4659,7 +4696,7 @@
           "type": "string"
         }
       },
-      "url": "/projects/:id"
+      "url": "/projects/:project_id"
     },
     "updateProjectCard": {
       "headers": {
@@ -4667,15 +4704,18 @@
       },
       "method": "PATCH",
       "params": {
-        "id": {
+        "card_id": {
           "required": true,
           "type": "string"
+        },
+        "id": {
+          "alias": "card_id"
         },
         "note": {
           "type": "string"
         }
       },
-      "url": "/projects/columns/cards/:id"
+      "url": "/projects/columns/cards/:card_id"
     },
     "updateProjectColumn": {
       "headers": {
@@ -4683,16 +4723,19 @@
       },
       "method": "PATCH",
       "params": {
-        "id": {
+        "column_id": {
           "required": true,
           "type": "string"
+        },
+        "id": {
+          "alias": "column_id"
         },
         "name": {
           "required": true,
           "type": "string"
         }
       },
-      "url": "/projects/columns/:id"
+      "url": "/projects/columns/:column_id"
     }
   },
   "pullRequests": {

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -17,12 +17,6 @@
           "required": true,
           "type": "string"
         },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
-        },
         "repo": {
           "required": true,
           "type": "string"
@@ -277,12 +271,6 @@
         "owner": {
           "required": true,
           "type": "string"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
         },
         "repo": {
           "required": true,
@@ -822,12 +810,6 @@
         "id": {
           "required": true,
           "type": "string"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
         }
       },
       "url": "/applications/grants/:id"
@@ -1657,12 +1639,6 @@
         "owner": {
           "required": true,
           "type": "string"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
         },
         "repo": {
           "required": true,
@@ -4629,12 +4605,6 @@
           "required": true,
           "type": "string"
         },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
-        },
         "repo": {
           "required": true,
           "type": "string"
@@ -4916,12 +4886,6 @@
         "owner": {
           "required": true,
           "type": "string"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
         },
         "repo": {
           "required": true,
@@ -5707,12 +5671,6 @@
         "owner": {
           "required": true,
           "type": "string"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
         },
         "repo": {
           "required": true,
@@ -6681,12 +6639,6 @@
           "required": true,
           "type": "string"
         },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
-        },
         "repo": {
           "required": true,
           "type": "string"
@@ -6704,12 +6656,6 @@
         "owner": {
           "required": true,
           "type": "string"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
         },
         "repo": {
           "required": true,
@@ -6805,12 +6751,6 @@
         "owner": {
           "required": true,
           "type": "string"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
         },
         "ref": {
           "required": true,
@@ -7313,12 +7253,6 @@
           "required": true,
           "type": "string"
         },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
-        },
         "repo": {
           "required": true,
           "type": "string"
@@ -7366,12 +7300,6 @@
         "owner": {
           "required": true,
           "type": "string"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
         },
         "repo": {
           "required": true,
@@ -7431,12 +7359,6 @@
           "required": true,
           "type": "string"
         },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
-        },
         "repo": {
           "required": true,
           "type": "string"
@@ -7454,12 +7376,6 @@
         "owner": {
           "required": true,
           "type": "string"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
         },
         "repo": {
           "required": true,
@@ -7479,12 +7395,6 @@
           "required": true,
           "type": "string"
         },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
-        },
         "repo": {
           "required": true,
           "type": "string"
@@ -7502,12 +7412,6 @@
         "owner": {
           "required": true,
           "type": "string"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
         },
         "repo": {
           "required": true,
@@ -7527,12 +7431,6 @@
           "required": true,
           "type": "string"
         },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
-        },
         "repo": {
           "required": true,
           "type": "string"
@@ -7550,12 +7448,6 @@
         "owner": {
           "required": true,
           "type": "string"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
         },
         "repo": {
           "required": true,
@@ -7575,12 +7467,6 @@
           "required": true,
           "type": "string"
         },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
-        },
         "repo": {
           "required": true,
           "type": "string"
@@ -7598,12 +7484,6 @@
         "owner": {
           "required": true,
           "type": "string"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
         },
         "repo": {
           "required": true,
@@ -7650,12 +7530,6 @@
         "owner": {
           "required": true,
           "type": "string"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
         },
         "repo": {
           "required": true,
@@ -7883,12 +7757,6 @@
           "required": true,
           "type": "string"
         },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
-        },
         "repo": {
           "required": true,
           "type": "string"
@@ -7902,12 +7770,6 @@
         "owner": {
           "required": true,
           "type": "string"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
         },
         "repo": {
           "required": true,
@@ -8298,12 +8160,6 @@
         "owner": {
           "required": true,
           "type": "string"
-        },
-        "page": {
-          "type": "number"
-        },
-        "per_page": {
-          "type": "number"
         },
         "repo": {
           "required": true,

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -230,8 +230,14 @@
         "before": {
           "type": "string"
         },
+        "page": {
+          "type": "number"
+        },
         "participating": {
           "type": "boolean"
+        },
+        "per_page": {
+          "type": "number"
         },
         "since": {
           "type": "string"
@@ -252,8 +258,14 @@
           "required": true,
           "type": "string"
         },
+        "page": {
+          "type": "number"
+        },
         "participating": {
           "type": "boolean"
+        },
+        "per_page": {
+          "type": "number"
         },
         "repo": {
           "required": true,
@@ -554,6 +566,12 @@
         "id": {
           "required": true,
           "type": "string"
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
         }
       },
       "url": "/marketplace_listing/accounts/:id"
@@ -567,6 +585,12 @@
         "id": {
           "required": true,
           "type": "string"
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
         }
       },
       "url": "/marketplace_listing/stubbed/accounts/:id"
@@ -620,7 +644,14 @@
         "accept": "application/vnd.github.machine-man-preview"
       },
       "method": "GET",
-      "params": {},
+      "params": {
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
+        }
+      },
       "url": "/installation/repositories"
     },
     "getInstallations": {
@@ -1380,6 +1411,12 @@
         "gist_id": {
           "required": true,
           "type": "string"
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
         }
       },
       "url": "/gists/:gist_id/comments"
@@ -1390,6 +1427,12 @@
         "id": {
           "required": true,
           "type": "string"
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
         }
       },
       "url": "/gists/:id/commits"
@@ -1432,6 +1475,12 @@
     "getPublic": {
       "method": "GET",
       "params": {
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
+        },
         "since": {
           "type": "string"
         }
@@ -1455,6 +1504,12 @@
     "getStarred": {
       "method": "GET",
       "params": {
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
+        },
         "since": {
           "type": "string"
         }
@@ -2293,6 +2348,12 @@
           "required": true,
           "type": "string"
         },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
+        },
         "repo": {
           "required": true,
           "type": "string"
@@ -2676,6 +2737,12 @@
           "required": true,
           "type": "string"
         },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
+        },
         "repo": {
           "required": true,
           "type": "string"
@@ -2749,6 +2816,12 @@
         "owner": {
           "required": true,
           "type": "string"
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
         },
         "repo": {
           "required": true,
@@ -3965,6 +4038,12 @@
         "org": {
           "required": true,
           "type": "string"
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
         }
       },
       "url": "/orgs/:org/invitations"
@@ -3991,6 +4070,12 @@
         "org": {
           "required": true,
           "type": "string"
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
         }
       },
       "url": "/orgs/:org/public_members"
@@ -4376,6 +4461,12 @@
           "required": true,
           "type": "string"
         },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
+        },
         "state": {
           "enum": [
             "open",
@@ -4426,6 +4517,12 @@
         "id": {
           "required": true,
           "type": "string"
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
         }
       },
       "url": "/projects/columns/:id/cards"
@@ -4453,6 +4550,12 @@
           "required": true,
           "type": "string"
         },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
+        },
         "project_id": {
           "alias": "id",
           "deprecated": "`project_id` parameter has been renamed to `id`"
@@ -4469,6 +4572,12 @@
         "owner": {
           "required": true,
           "type": "string"
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
         },
         "repo": {
           "required": true,
@@ -5501,6 +5610,12 @@
           "required": true,
           "type": "string"
         },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
+        },
         "repo": {
           "required": true,
           "type": "string"
@@ -5532,6 +5647,12 @@
         "owner": {
           "required": true,
           "type": "string"
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
         },
         "repo": {
           "required": true,
@@ -5565,6 +5686,12 @@
           "required": true,
           "type": "string"
         },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
+        },
         "repo": {
           "required": true,
           "type": "string"
@@ -5596,6 +5723,12 @@
         "owner": {
           "required": true,
           "type": "string"
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
         },
         "repo": {
           "required": true,
@@ -6617,6 +6750,12 @@
           "required": true,
           "type": "string"
         },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
+        },
         "repo": {
           "required": true,
           "type": "string"
@@ -7014,6 +7153,12 @@
           "required": true,
           "type": "string"
         },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
+        },
         "repo": {
           "required": true,
           "type": "string"
@@ -7233,6 +7378,12 @@
         "owner": {
           "required": true,
           "type": "string"
+        },
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
         },
         "repo": {
           "required": true,
@@ -8714,6 +8865,12 @@
     "getAll": {
       "method": "GET",
       "params": {
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
+        },
         "since": {
           "type": "number"
         }
@@ -8975,6 +9132,12 @@
     "getOrgMemberships": {
       "method": "GET",
       "params": {
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
+        },
         "state": {
           "enum": [
             "active",
@@ -9011,7 +9174,14 @@
     },
     "getRepoInvites": {
       "method": "GET",
-      "params": {},
+      "params": {
+        "page": {
+          "type": "number"
+        },
+        "per_page": {
+          "type": "number"
+        }
+      },
       "url": "/user/repository_invitations"
     },
     "getTeams": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@gr2m/node-fetch": "^2.0.0",
     "@octokit/fixtures-server": "^2.0.1",
+    "@octokit/routes": "7.1.6",
     "@types/node": "^9.4.6",
     "apidoc": "^0.17.6",
     "bundlesize": "^0.17.0",
@@ -57,6 +58,7 @@
     "dotenv": "^5.0.0",
     "gh-pages-with-token": "^1.0.0",
     "glob": "^7.1.2",
+    "jsondiff": "0.0.0",
     "mkdirp": "^0.5.1",
     "mocha": "^5.0.0",
     "mustache": "^2.2.1",
@@ -99,6 +101,7 @@
     "build:browser:development": "webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json",
     "build:browser:production": "webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map",
     "generate-bundle-report": "webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html",
+    "generate-routes": "node scripts/generate-routes",
     "prevalidate:ts": "npm run -s build:ts",
     "validate:ts": "tsc --target es6 index.d.ts",
     "postvalidate:ts": "tsc --noEmit test/typescript-validate.ts",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@octokit/rest",
   "version": "0.0.0-semantically-released",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "next"
   },
   "description": "GitHub REST API client for Node.js",
   "keywords": [

--- a/scripts/generate-api-docs.js
+++ b/scripts/generate-api-docs.js
@@ -44,6 +44,7 @@ function toApiComment (namespaceName, apiName, api) {
   const url = api['url']
   const paramsObj = api['params']
   const params = Object.keys(paramsObj)
+    .filter(name => !paramsObj[name].alias)
     .sort(sortByRequired.bind(null, paramsObj))
 
   const commentLines = [
@@ -75,6 +76,13 @@ function toApiParamComment (paramsObj, param) {
   const paramRequired = paramInfo['required']
   const paramDescription = paramInfo['description'] || ''
   const paramDefaultVal = paramInfo['default']
+  try {
+    paramInfo['type']
+      .toLowerCase()
+  } catch (e) {
+    console.log(`\nparamInfo ==============================`)
+    console.log(paramInfo)
+  }
   const paramType = paramInfo['type']
     .toLowerCase()
     // https://github.com/octokit/rest.js/issues/721

--- a/scripts/generate-api-docs.js
+++ b/scripts/generate-api-docs.js
@@ -41,17 +41,18 @@ function toApiComment (namespaceName, apiName, api) {
   }
 
   const method = api['method'].toUpperCase()
-  // const paramsObj = api['params']
-  // const params = Object.keys(paramsObj)
-  //   .filter(name => !paramsObj[name].alias)
-  //   .sort(sortByRequired.bind(null, paramsObj))
   const params = api['params']
+
+  const descriptionWithLinkToV3Docs = [
+    api.description,
+    `<a href="${api.documentationUrl}">REST API doc</a>`
+  ].filter(Boolean).join(' ')
 
   const commentLines = [
     '/**',
     ` * @api {${method}} ${api.path} ${apiName}`,
     ` * @apiName ${apiName}`,
-    ` * @apiDescription ${api.description}`,
+    ` * @apiDescription ${descriptionWithLinkToV3Docs}`,
     ` * @apiGroup ${upperFirst(namespaceName)}`,
     ' *'
   ].concat(

--- a/scripts/generate-routes.js
+++ b/scripts/generate-routes.js
@@ -1,0 +1,278 @@
+const _ = require('lodash')
+const writeFileSync = require('fs').writeFileSync
+
+const NEW_ROUTES = require('@octokit/routes')
+const CURRENT_ROUTES = require('../lib/routes')
+
+function sortRoutesByKeys (routes) {
+  Object.keys(routes).forEach(scope => {
+    routes[scope] = sortByKeys(routes[scope])
+
+    Object.keys(routes[scope]).forEach(method => {
+      routes[scope][method] = sortByKeys(routes[scope][method])
+
+      // routes-for-api-docs keeps parameters as array, while lib/routes.json uses an object
+      if (Array.isArray(routes[scope][method].params)) {
+        return
+      }
+
+      routes[scope][method].params = sortByKeys(routes[scope][method].params)
+
+      Object.keys(routes[scope][method].params).forEach(paramName => {
+        routes[scope][method].params[paramName] = sortByKeys(routes[scope][method].params[paramName])
+      })
+    })
+  })
+
+  return sortByKeys(routes)
+}
+
+function sortByKeys (object) {
+  return _(object).toPairs().sortBy(0).fromPairs().value()
+}
+
+function matchesRoute (currentEndpoint, newEndpoint) {
+  if (newEndpoint.method !== currentEndpoint.method || newEndpoint.path !== currentEndpoint.url) {
+    return
+  }
+
+  // implement workaround for cases where different methods share same route
+  // by comparing an additional parameter
+  // 1. https://developer.github.com/v3/pulls/#create-a-pull-request
+  //    (POST /repos/:owner/:repo/pulls)
+  //    a. "Create a pull request" -> pulls.create
+  //    b. "Create a Pull Request from an existing Issue by passing an Issue number" -> pulls.createFromIssue
+  // 2. https://developer.github.com/v3/pulls/comments/#create-a-comment
+  //    (POST /repos/:owner/:repo/pulls/:number/comments)
+  //    a. pulls.createComment
+  //    b. pulls.createCommentReply
+  // 3. https://developer.github.com/v3/repos/contents/#create-a-file & https://developer.github.com/v3/repos/contents/#update-a-file
+  //    (PUT /repos/:owner/:repo/contents/:path)
+  //    a. repos.createFile
+  //    a. repos.updateFile
+  const route = `${newEndpoint.method} ${newEndpoint.path}`
+  const additionalParameter = {
+    'POST /repos/:owner/:repo/pulls': 'issues',
+    'POST /repos/:owner/:repo/pulls/:number/comments': 'in_reply_to',
+    'PUT /repos/:owner/:repo/contents/:path': 'sha'
+  }[route]
+
+  if (!additionalParameter) {
+    return true
+  }
+
+  const newEndpointHasAdditionalParam = !!newEndpoint.params.find(param => param.name === additionalParameter)
+  const currentEndpointHasAdditionalParam = !!currentEndpoint.params[additionalParameter]
+
+  return newEndpointHasAdditionalParam === currentEndpointHasAdditionalParam
+}
+
+const MISC_SCOPES = [
+  'codesOfConduct',
+  // 'emojis', https://github.com/octokit/routes/issues/50
+  'gitignore',
+  'licenses',
+  'markdown',
+  'rateLimit'
+]
+
+NEW_ROUTES['misc'] = [].concat(...MISC_SCOPES.map(scope => NEW_ROUTES[scope]))
+NEW_ROUTES['orgs'] = NEW_ROUTES['orgs'].concat(NEW_ROUTES['teams'])
+
+// move around some methods ¯\_(ツ)_/¯
+const ORG_USER_PATHS = [
+  '/user/orgs',
+  '/user/memberships/orgs',
+  '/user/memberships/orgs/:org',
+  '/user/teams'
+]
+const REPOS_USER_PATHS = [
+  '/user/repository_invitations',
+  '/user/repository_invitations/:invitation_id'
+]
+const APPS_USER_PATHS = [
+  '/user/installations',
+  '/user/installations/:installation_id/repositories',
+  '/user/installations/:installation_id/repositories/:repository_id',
+  '/user/marketplace_purchases',
+  '/user/marketplace_purchases/stubbed'
+]
+NEW_ROUTES['users'].push(...NEW_ROUTES['orgs'].filter(endpoint => ORG_USER_PATHS.includes(endpoint.path)))
+NEW_ROUTES['users'].push(...NEW_ROUTES['repos'].filter(endpoint => REPOS_USER_PATHS.includes(endpoint.path)))
+NEW_ROUTES['users'].push(...NEW_ROUTES['apps'].filter(endpoint => APPS_USER_PATHS.includes(endpoint.path)))
+
+// map scopes from @octokit/routes to what we currently have in lib/routes.json
+const mapScopes = {
+  activity: 'activity',
+  apps: 'apps',
+  codesOfConduct: false,
+  gists: 'gists',
+  git: 'gitdata',
+  gitignore: false,
+  issues: 'issues',
+  licenses: false,
+  markdown: false,
+  migration: 'migrations',
+  misc: 'misc',
+  oauthAuthorizations: 'authorization',
+  orgs: 'orgs',
+  projects: 'projects',
+  pulls: 'pullRequests',
+  rateLimit: false,
+  reactions: 'reactions',
+  repos: 'repos',
+  scim: false,
+  search: 'search',
+  teams: false,
+  users: 'users'
+}
+
+const newRoutes = {}
+const newDocRoutes = {}
+Object.keys(NEW_ROUTES).forEach(scope => {
+  const currentScopeName = mapScopes[scope]
+
+  if (!currentScopeName) {
+    return
+  }
+
+  NEW_ROUTES[currentScopeName] = NEW_ROUTES[scope]
+
+  newRoutes[currentScopeName] = {}
+  newDocRoutes[currentScopeName] = {}
+})
+// mutate the new routes to what we have today
+Object.keys(CURRENT_ROUTES).sort().forEach(scope => {
+  // enterprise is not part of @octokit/routes, we’ll leave it as-is.
+  if (scope === 'enterprise') {
+    return
+  }
+
+  // leave the deprecated integrations methods as they are for now
+  if (scope === 'integrations') {
+    return
+  }
+
+  Object.keys(CURRENT_ROUTES[scope]).map(methodName => {
+    const currentEndpoint = CURRENT_ROUTES[scope][methodName]
+
+    if (currentEndpoint.method === 'GET' && currentEndpoint.url === '/repos/:owner/:repo/git/refs') {
+      console.log('Ignoring custom override for GET /repos/:owner/:repo/git/refs (https://github.com/octokit/routes/commit/b7a9800)')
+      newRoutes[scope][methodName] = currentEndpoint
+      return
+    }
+
+    if (currentEndpoint.url === '/repos/:owner/:repo/git/refs/tags') {
+      console.log('Ignoring endpoint for getTags()')
+      newRoutes[scope][methodName] = currentEndpoint
+      return
+    }
+
+    if (currentEndpoint.deprecated) {
+      console.log(`No endpoint found for deprecated ${currentEndpoint.method} ${currentEndpoint.url}, leaving route as is.`)
+      newRoutes[scope][methodName] = currentEndpoint
+      return
+    }
+
+    // https://github.com/octokit/routes/issues/50
+    if (scope === 'misc' && (methodName === 'getMeta' || methodName === 'getEmojis')) {
+      newRoutes[scope][methodName] = currentEndpoint
+      return
+    }
+
+    if ([
+      '/users/:username/suspended',
+      '/users/:username/site_admin'
+    ].includes(currentEndpoint.url)) {
+      console.log('Ignoring endpoints belonging to enterprise admin')
+      return
+    }
+
+    const newEndpoint = NEW_ROUTES[mapScopes[scope] || scope].find(matchesRoute.bind(null, currentEndpoint))
+
+    if (!newEndpoint) {
+      throw new Error(`No endpoint found for ${currentEndpoint.method} ${currentEndpoint.url} (scope: ${scope}, ${JSON.stringify(currentEndpoint, null, 2)})`)
+    }
+
+    // reduce from params array to params object
+    const currentParams = currentEndpoint.params
+    const newParams = newEndpoint.params.reduce((map, param) => {
+      map[param.name] = _.clone(param)
+      delete map[param.name].name
+      return map
+    }, {})
+
+    currentEndpoint.url = newEndpoint.path
+    currentEndpoint.params = newParams
+
+    // we no longer need description, we can generate docs from @octokit/routes
+    delete currentEndpoint.description
+    Object.keys(currentEndpoint.params).forEach(name => {
+      delete currentEndpoint.params[name].description
+      delete currentEndpoint.params[name].default
+      if (currentEndpoint.params[name].required === false) {
+        delete currentEndpoint.params[name].required
+      }
+    })
+
+    // leave params with .alias or .mapTo property so we don’t break current code
+    Object.keys(currentParams).forEach(name => {
+      if (currentParams[name].alias || currentParams[name].mapTo) {
+        currentEndpoint.params[name] = currentParams[name]
+      }
+    })
+
+    // DEPRECATED: workaround to leave "validation" property. We won’t be able
+    // to get that from @octokit/routes, but we leave it in for now so to not
+    // break current behavior
+    Object.keys(currentParams).forEach(name => {
+      if (currentParams[name].validation) {
+        currentEndpoint.params[name].validation = currentParams[name].validation
+      }
+    })
+
+    // map header parameters to `headers.<parameter name>`
+    Object.keys(newParams).forEach(name => {
+      const location = newParams[name].location
+      delete newParams[name].location
+      if (location !== 'headers') {
+        return
+      }
+
+      currentEndpoint.params[`headers.${name.toLowerCase()}`] = currentEndpoint.params[name]
+      delete currentEndpoint.params[name]
+    })
+
+    // Workaround for https://github.com/octokit/routes/issues/121
+    Object.keys(currentParams).forEach(name => {
+      if (!currentEndpoint.params[name].enum) {
+        return
+      }
+
+      const placeholderValue = currentEndpoint.params[name].enum.find(value => /<\w+_id>/.test(value))
+
+      if (!placeholderValue) {
+        return
+      }
+
+      currentEndpoint.params[name].validation = `^(${currentEndpoint.params[name].enum.join('|')})$`.replace(/<\w+_id>/, '\\d+')
+      delete currentEndpoint.params[name].enum
+    })
+
+    newRoutes[scope][methodName] = currentEndpoint
+    newDocRoutes[scope][methodName] = newEndpoint
+  })
+})
+
+// don’t break the "enterprise" scope, it’s not part of @octokit/routes at this point
+newRoutes.enterprise = CURRENT_ROUTES.enterprise
+newRoutes.users.promote = CURRENT_ROUTES.users.promote
+newRoutes.users.demote = CURRENT_ROUTES.users.demote
+newRoutes.users.suspend = CURRENT_ROUTES.users.suspend
+newRoutes.users.unsuspend = CURRENT_ROUTES.users.unsuspend
+
+// don’t break the deprecated "integrations" scope
+newRoutes.integrations = CURRENT_ROUTES.integrations
+
+writeFileSync('lib/routes.json', JSON.stringify(sortRoutesByKeys(newRoutes), null, 2) + '\n')
+writeFileSync('scripts/routes-for-api-docs.json', JSON.stringify(sortRoutesByKeys(newDocRoutes), null, 2))

--- a/scripts/routes-for-api-docs.json
+++ b/scripts/routes-for-api-docs.json
@@ -1,0 +1,14257 @@
+{
+  "activity": {
+    "checkNotificationThreadSubscription": {
+      "description": "This checks to see if the current user is subscribed to a thread. You can also [get a Repository subscription](/v3/activity/watching/#get-a-repository-subscription).\n\nNote that subscriptions are only generated if a user is participating in a conversation--for example, they've replied to the thread, were **@mention**ed, or manually subscribe to a thread.",
+      "documentationUrl": "https://developer.github.com/v3/activity/notifications/#get-a-thread-subscription",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get a Thread Subscription",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/notifications/threads/:id/subscription"
+    },
+    "checkStarringRepo": {
+      "description": "Requires for the user to be authenticated.",
+      "documentationUrl": "https://developer.github.com/v3/activity/starring/#check-if-you-are-starring-a-repository",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Check if you are starring a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/starred/:owner/:repo"
+    },
+    "deleteNotificationThreadSubscription": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Delete a Thread Subscription",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/notifications/threads/:id/subscription"
+    },
+    "getEvents": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/activity/events/#list-public-events",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List public events",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/events"
+    },
+    "getEventsForOrg": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/activity/events/#list-public-events-for-an-organization",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List public events for an organization",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/orgs/:org/events"
+    },
+    "getEventsForRepo": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/activity/events/#list-repository-events",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List repository events",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/events"
+    },
+    "getEventsForRepoIssues": {
+      "description": "Repository issue events have a different format than other events, as documented in the [Issue Events API](/v3/issues/events/).",
+      "documentationUrl": "https://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List issue events for a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/events"
+    },
+    "getEventsForRepoNetwork": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/activity/events/#list-public-events-for-a-network-of-repositories",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List public events for a network of repositories",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/networks/:owner/:repo/events"
+    },
+    "getEventsForUser": {
+      "description": "If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.",
+      "documentationUrl": "https://developer.github.com/v3/activity/events/#list-events-performed-by-a-user",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List events performed by a user",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/users/:username/events"
+    },
+    "getEventsForUserOrg": {
+      "description": "This is the user's organization dashboard. You must be authenticated as the user to view this.",
+      "documentationUrl": "https://developer.github.com/v3/activity/events/#list-events-for-an-organization",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List events for an organization",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/users/:username/events/orgs/:org"
+    },
+    "getEventsForUserPublic": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/activity/events/#list-public-events-performed-by-a-user",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List public events performed by a user",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/users/:username/events/public"
+    },
+    "getEventsReceived": {
+      "description": "These are events that you've received by watching repos and following users. If you are authenticated as the given user, you will see private events. Otherwise, you'll only see public events.",
+      "documentationUrl": "https://developer.github.com/v3/activity/events/#list-events-that-a-user-has-received",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List events that a user has received",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/users/:username/received_events"
+    },
+    "getEventsReceivedPublic": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/activity/events/#list-public-events-that-a-user-has-received",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List public events that a user has received",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/users/:username/received_events/public"
+    },
+    "getFeeds": {
+      "description": "GitHub provides several timeline resources in [Atom](http://en.wikipedia.org/wiki/Atom_(standard)) format. The Feeds API lists all the feeds available to the authenticated user:\n\n*   **Timeline**: The GitHub global public timeline\n*   **User**: The public timeline for any user, using [URI template](/v3/#hypermedia)\n*   **Current user public**: The public timeline for the authenticated user\n*   **Current user**: The private timeline for the authenticated user\n*   **Current user actor**: The private timeline for activity created by the authenticated user\n*   **Current user organizations**: The private timeline for the organizations the authenticated user is a member of.\n\n**Note**: Private feeds are only returned when [authenticating via Basic Auth](/v3/#basic-authentication) since current feed URIs use the older, non revocable auth tokens.",
+      "documentationUrl": "https://developer.github.com/v3/activity/feeds/#list-feeds",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List Feeds",
+      "params": {},
+      "path": "/feeds"
+    },
+    "getNotificationThread": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/activity/notifications/#view-a-single-thread",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "View a single thread",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/notifications/threads/:id"
+    },
+    "getNotifications": {
+      "description": "List all notifications for the current user, sorted by most recently updated.",
+      "documentationUrl": "https://developer.github.com/v3/activity/notifications/#list-your-notifications",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List your notifications",
+      "params": {
+        "0": {
+          "default": false,
+          "description": "If `true`, show notifications marked as read.",
+          "name": "all",
+          "required": false,
+          "type": "boolean"
+        },
+        "1": {
+          "default": false,
+          "description": "If `true`, only shows notifications in which the user is directly participating or mentioned.",
+          "name": "participating",
+          "required": false,
+          "type": "boolean"
+        },
+        "2": {
+          "default": "Time.now",
+          "description": "Only show notifications updated after the given time. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "description": "Only show notifications updated before the given time. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "name": "before",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "5": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/notifications"
+    },
+    "getNotificationsForUser": {
+      "description": "List all notifications for the current user.",
+      "documentationUrl": "https://developer.github.com/v3/activity/notifications/#list-your-notifications-in-a-repository",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List your notifications in a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": false,
+          "description": "If `true`, show notifications marked as read.",
+          "name": "all",
+          "required": false,
+          "type": "boolean"
+        },
+        "3": {
+          "default": false,
+          "description": "If `true`, only shows notifications in which the user is directly participating or mentioned.",
+          "name": "participating",
+          "required": false,
+          "type": "boolean"
+        },
+        "4": {
+          "default": "Time.now",
+          "description": "Only show notifications updated after the given time. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "Only show notifications updated before the given time. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "name": "before",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "7": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/notifications"
+    },
+    "getRepoSubscription": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/activity/watching/#get-a-repository-subscription",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get a Repository Subscription",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/subscription"
+    },
+    "getStargazersForRepo": {
+      "description": "You can also find out _when_ stars were created by passing the following custom [media type](/v3/media/) via the `Accept` header:",
+      "documentationUrl": "https://developer.github.com/v3/activity/starring/#list-stargazers",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List Stargazers",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/stargazers"
+    },
+    "getStarredRepos": {
+      "description": "You can also find out _when_ stars were created by passing the following custom [media type](/v3/media/) via the `Accept` header:",
+      "documentationUrl": "https://developer.github.com/v3/activity/starring/#list-repositories-being-starred",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List repositories being starred by the authenticated user",
+      "params": {
+        "0": {
+          "default": "created",
+          "description": "One of `created` (when the repository was starred) or `updated` (when it was last pushed to).",
+          "enum": [
+            "created",
+            "updated"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "1": {
+          "default": "desc",
+          "description": "One of `asc` (ascending) or `desc` (descending).",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "direction",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/user/starred"
+    },
+    "getStarredReposForUser": {
+      "description": "You can also find out _when_ stars were created by passing the following custom [media type](/v3/media/) via the `Accept` header:",
+      "documentationUrl": "https://developer.github.com/v3/activity/starring/#list-repositories-being-starred",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List repositories being starred by a user",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": "created",
+          "description": "One of `created` (when the repository was starred) or `updated` (when it was last pushed to).",
+          "enum": [
+            "created",
+            "updated"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "default": "desc",
+          "description": "One of `asc` (ascending) or `desc` (descending).",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "direction",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/users/:username/starred"
+    },
+    "getWatchedRepos": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/activity/watching/#list-repositories-being-watched",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List repositories being watched by the authenticated user",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/user/subscriptions"
+    },
+    "getWatchedReposForUser": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/activity/watching/#list-repositories-being-watched",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List repositories being watched by a user",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/users/:username/subscriptions"
+    },
+    "getWatchersForRepo": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/activity/watching/#list-watchers",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List watchers",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/subscribers"
+    },
+    "markNotificationThreadAsRead": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "name": "Mark a thread as read",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/notifications/threads/:id"
+    },
+    "markNotificationsAsRead": {
+      "description": "Marking a notification as \"read\" removes it from the [default view on GitHub](https://github.com/notifications).",
+      "documentationUrl": "https://developer.github.com/v3/activity/notifications/#mark-as-read",
+      "enabledForApps": false,
+      "method": "PUT",
+      "name": "Mark as read",
+      "params": {
+        "0": {
+          "default": "Time.now",
+          "description": "Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "name": "last_read_at",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/notifications"
+    },
+    "markNotificationsAsReadForRepo": {
+      "description": "Marking all notifications in a repository as \"read\" removes them from the [default view on GitHub](https://github.com/notifications).",
+      "documentationUrl": "https://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository",
+      "enabledForApps": false,
+      "method": "PUT",
+      "name": "Mark notifications as read in a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": "Time.now",
+          "description": "Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "name": "last_read_at",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/notifications"
+    },
+    "setNotificationThreadSubscription": {
+      "description": "This lets you subscribe or unsubscribe from a conversation. Unsubscribing from a conversation mutes all future notifications (until you comment or get **@mention**ed once more).",
+      "documentationUrl": "https://developer.github.com/v3/activity/notifications/#set-a-thread-subscription",
+      "enabledForApps": false,
+      "method": "PUT",
+      "name": "Set a Thread Subscription",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "Determines if notifications should be received from this thread",
+          "name": "subscribed",
+          "required": false,
+          "type": "boolean"
+        },
+        "2": {
+          "description": "Determines if all notifications should be blocked from this thread",
+          "name": "ignored",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/notifications/threads/:id/subscription"
+    },
+    "setRepoSubscription": {
+      "description": "If you would like to watch a repository, set `subscribed` to `true`. If you would like to ignore notifications made within a repository, set `ignored` to `true`. If you would like to stop watching a repository, [delete the repository's subscription](#delete-a-repository-subscription) completely.",
+      "documentationUrl": "https://developer.github.com/v3/activity/watching/#set-a-repository-subscription",
+      "enabledForApps": false,
+      "method": "PUT",
+      "name": "Set a Repository Subscription",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "Determines if notifications should be received from this repository.",
+          "name": "subscribed",
+          "required": false,
+          "type": "boolean"
+        },
+        "3": {
+          "description": "Determines if all notifications should be blocked from this repository.",
+          "name": "ignored",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/repos/:owner/:repo/subscription"
+    },
+    "starRepo": {
+      "description": "Requires for the user to be authenticated.\n\nNote that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](/v3/#http-verbs).\"",
+      "documentationUrl": "https://developer.github.com/v3/activity/starring/#star-a-repository",
+      "enabledForApps": false,
+      "method": "PUT",
+      "name": "Star a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/starred/:owner/:repo"
+    },
+    "unstarRepo": {
+      "description": "Requires for the user to be authenticated.",
+      "documentationUrl": "https://developer.github.com/v3/activity/starring/#unstar-a-repository",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Unstar a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/starred/:owner/:repo"
+    },
+    "unwatchRepo": {
+      "description": "This endpoint should only be used to stop watching a repository. To control whether or not you wish to receive notifications from a repository, [set the repository's subscription manually](#set-a-repository-subscription).",
+      "documentationUrl": "https://developer.github.com/v3/activity/watching/#delete-a-repository-subscription",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Delete a Repository Subscription",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/subscription"
+    }
+  },
+  "apps": {
+    "addRepoToInstallation": {
+      "description": "Add a single repository to an installation.\n\nThe authenticated user must have admin access to the repository.",
+      "documentationUrl": "https://developer.github.com/v3/apps/installations/#add-repository-to-installation",
+      "enabledForApps": false,
+      "method": "PUT",
+      "name": "Add repository to installation",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "installation_id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repository_id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/installations/:installation_id/repositories/:repository_id"
+    },
+    "checkMarketplaceListingAccount": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#check-if-a-github-account-is-associated-with-any-marketplace-listing",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Check if a GitHub account is associated with any Marketplace listing",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/marketplace_listing/accounts/:id"
+    },
+    "checkMarketplaceListingStubbedAccount": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#check-if-a-github-account-is-associated-with-any-marketplace-listing",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Check if a GitHub account is associated with any Marketplace listing (stubbed)",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/marketplace_listing/stubbed/accounts/:id"
+    },
+    "createInstallationToken": {
+      "description": "Creates an access token that enables a GitHub App to make authenticated API requests for the app's installation on an organization or individual account. Installation tokens expire one hour from the time you create them. Using an expired token produces a status code of `401 - Unauthorized`, and requires creating a new installation token.",
+      "documentationUrl": "https://developer.github.com/v3/apps/#create-a-new-installation-token",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a new installation token",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "installation_id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/installations/:installation_id/access_tokens"
+    },
+    "get": {
+      "description": "Returns the GitHub App associated with the [authentication credentials](/apps/building-github-apps/authentication-options-for-github-apps#authenticating-as-a-github-app) used.",
+      "documentationUrl": "https://developer.github.com/v3/apps/#get-the-authenticated-github-app",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get the authenticated GitHub App",
+      "params": {},
+      "path": "/app"
+    },
+    "getForSlug": {
+      "description": "**Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).",
+      "documentationUrl": "https://developer.github.com/v3/apps/#get-a-single-github-app",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a single GitHub App",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "app_slug",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/apps/:app_slug"
+    },
+    "getInstallation": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/apps/#get-a-single-installation",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a single installation",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "installation_id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/app/installations/:installation_id"
+    },
+    "getInstallationRepositories": {
+      "description": "List repositories that are accessible to the authenticated installation.",
+      "documentationUrl": "https://developer.github.com/v3/apps/installations/#list-repositories",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List repositories",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/installation/repositories"
+    },
+    "getInstallations": {
+      "description": "The permissions the installation has are included under the `permissions` key.",
+      "documentationUrl": "https://developer.github.com/v3/apps/#find-installations",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Find installations",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/app/installations"
+    },
+    "getMarketplaceListingPlanAccounts": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#list-all-github-accounts-user-or-organization-on-a-specific-plan",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List all GitHub accounts (user or organization) on a specific plan",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": "created",
+          "description": "Sorts the GitHub accounts by the date they were created or last updated. Can be one of `created` or `updated`.",
+          "enum": [
+            "created",
+            "updated"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "description": "To return the oldest accounts first, set to `asc`. Can be one of `asc` or `desc`. Ignored without the `sort` parameter.",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "direction",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/marketplace_listing/plans/:id/accounts"
+    },
+    "getMarketplaceListingPlans": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#list-all-plans-for-your-marketplace-listing",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List all plans for your Marketplace listing",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/marketplace_listing/plans"
+    },
+    "getMarketplaceListingStubbedPlanAccounts": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#list-all-github-accounts-user-or-organization-on-a-specific-plan",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List all GitHub accounts (user or organization) on a specific plan (stubbed)",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": "created",
+          "description": "Sorts the GitHub accounts by the date they were created or last updated. Can be one of `created` or `updated`.",
+          "enum": [
+            "created",
+            "updated"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "description": "To return the oldest accounts first, set to `asc`. Can be one of `asc` or `desc`. Ignored without the `sort` parameter.",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "direction",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/marketplace_listing/stubbed/plans/:id/accounts"
+    },
+    "getMarketplaceListingStubbedPlans": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#list-all-plans-for-your-marketplace-listing",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List all plans for your Marketplace listing (stubbed)",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/marketplace_listing/stubbed/plans"
+    },
+    "removeRepoFromInstallation": {
+      "description": "Remove a single repository from an installation.\n\nThe authenticated user must have admin access to the repository.",
+      "documentationUrl": "https://developer.github.com/v3/apps/installations/#remove-repository-from-installation",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Remove repository from installation",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "installation_id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repository_id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/installations/:installation_id/repositories/:repository_id"
+    }
+  },
+  "authorization": {
+    "check": {
+      "description": "OAuth applications can use a special API method for checking OAuth token validity without running afoul of normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#check-an-authorization",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Check an authorization",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "client_id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "access_token",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/applications/:client_id/tokens/:access_token"
+    },
+    "create": {
+      "description": "If you need a small number of personal access tokens, implementing the [web flow](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-authorization-options-for-oauth-apps/) can be cumbersome. Instead, tokens can be created using the OAuth Authorizations API using [Basic Authentication](/v3/auth#basic-authentication). To create personal access tokens for a particular OAuth application, you must provide its client ID and secret, found on the OAuth application settings page, linked from your [OAuth applications listing on GitHub](https://github.com/settings/developers).\n\nIf your OAuth application intends to create multiple tokens for one user, use `fingerprint` to differentiate between them.\n\nYou can also create OAuth tokens through the web UI via the [personal access tokens settings](https://github.com/settings/tokens). Read more about these tokens on the [GitHub Help site](https://help.github.com/articles/creating-an-access-token-for-command-line-use).\n\nOrganizations that enforce SAML SSO require personal access tokens to be whitelisted. Read more about whitelisting tokens on the [GitHub Help site](https://help.github.com/articles/about-identity-and-access-management-with-saml-single-sign-on).",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Create a new authorization",
+      "params": {
+        "0": {
+          "description": "A list of scopes that this authorization is in.",
+          "name": "scopes",
+          "required": false,
+          "type": "array"
+        },
+        "1": {
+          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
+          "name": "note",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "name": "note_url",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "description": "The 20 character OAuth app client key for which to create the token.",
+          "name": "client_id",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "The 40 character OAuth app client secret for which to create the token.",
+          "name": "client_secret",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
+          "name": "fingerprint",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/authorizations"
+    },
+    "delete": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#delete-an-authorization",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Delete an authorization",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/authorizations/:id"
+    },
+    "deleteGrant": {
+      "description": "Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for your user. Once deleted, the application has no access to your account and is no longer listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#delete-a-grant",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Delete a grant",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/applications/grants/:id"
+    },
+    "get": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#get-a-single-authorization",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get a single authorization",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/authorizations/:id"
+    },
+    "getAll": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List your authorizations",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/authorizations"
+    },
+    "getGrant": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#get-a-single-grant",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get a single grant",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/applications/grants/:id"
+    },
+    "getGrants": {
+      "description": "You can use this API to list the set of OAuth applications that have been granted access to your account. Unlike the [list your authorizations](/v3/oauth_authorizations/#list-your-authorizations) API, this API does not manage individual tokens. This API will return one entry for each OAuth application that has been granted access to your account, regardless of the number of tokens an application has generated for your user. The list of OAuth applications returned matches what is shown on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized). The `scopes` returned are the union of scopes authorized for the application. For example, if an application has one token with `repo` scope and another token with `user` scope, the grant will return `[\"repo\", \"user\"]`.",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#list-your-grants",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List your grants",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/applications/grants"
+    },
+    "getOrCreateAuthorizationForApp": {
+      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application doesn't already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app",
+      "enabledForApps": false,
+      "method": "PUT",
+      "name": "Get-or-create an authorization for a specific app",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "client_id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+          "name": "client_secret",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "A list of scopes that this authorization is in.",
+          "name": "scopes",
+          "required": false,
+          "type": "array"
+        },
+        "3": {
+          "description": "A note to remind you what the OAuth token is for.",
+          "name": "note",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "name": "note_url",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "A unique string to distinguish an authorization from others created for the same client and user. If provided, this API is functionally equivalent to [Get-or-create an authorization for a specific app and fingerprint](/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint).",
+          "name": "fingerprint",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/authorizations/clients/:client_id"
+    },
+    "getOrCreateAuthorizationForAppAndFingerprint": {
+      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint",
+      "enabledForApps": false,
+      "method": "PUT",
+      "name": "Get-or-create an authorization for a specific app and fingerprint",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "client_id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "fingerprint",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+          "name": "client_secret",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "A list of scopes that this authorization is in.",
+          "name": "scopes",
+          "required": false,
+          "type": "array"
+        },
+        "4": {
+          "description": "A note to remind you what the OAuth token is for.",
+          "name": "note",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "name": "note_url",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/authorizations/clients/:client_id/:fingerprint"
+    },
+    "reset": {
+      "description": "OAuth applications can use this API method to reset a valid OAuth token without end user involvement. Applications must save the \"token\" property in the response, because changes take effect immediately. You must use [Basic Authentication](/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#reset-an-authorization",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Reset an authorization",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "client_id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "access_token",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/applications/:client_id/tokens/:access_token"
+    },
+    "revoke": {
+      "description": "OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`.",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#revoke-an-authorization-for-an-application",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Revoke an authorization for an application",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "client_id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "access_token",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/applications/:client_id/tokens/:access_token"
+    },
+    "revokeGrant": {
+      "description": "OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`. You must also provide a valid token as `:token` and the grant for the token's owner will be deleted.\n\nDeleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#revoke-a-grant-for-an-application",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Revoke a grant for an application",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "client_id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "access_token",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/applications/:client_id/grants/:access_token"
+    },
+    "update": {
+      "description": "You can only send one of these scope keys at a time.",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#update-an-existing-authorization",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "name": "Update an existing authorization",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "Replaces the authorization scopes with these.",
+          "name": "scopes",
+          "required": false,
+          "type": "array"
+        },
+        "2": {
+          "description": "A list of scopes to add to this authorization.",
+          "name": "add_scopes",
+          "required": false,
+          "type": "array"
+        },
+        "3": {
+          "description": "A list of scopes to remove from this authorization.",
+          "name": "remove_scopes",
+          "required": false,
+          "type": "array"
+        },
+        "4": {
+          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
+          "name": "note",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "name": "note_url",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
+          "name": "fingerprint",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/authorizations/:id"
+    }
+  },
+  "gists": {
+    "checkStar": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/gists/#check-if-a-gist-is-starred",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Check if a gist is starred",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/gists/:id/star"
+    },
+    "create": {
+      "description": "The keys in the `files` object are the `string` filename, and the value is another `object` with a key of `content`, and a value of the file contents. For example:\n\n**Note:** Don't name your files \"gistfile\" with a numerical suffix. This is the format of the automatic naming scheme that Gist uses internally.",
+      "documentationUrl": "https://developer.github.com/v3/gists/#create-a-gist",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Create a gist",
+      "params": {
+        "0": {
+          "description": "Files that make up this gist.",
+          "name": "files",
+          "required": true,
+          "type": "object"
+        },
+        "1": {
+          "description": "A description of the gist.",
+          "name": "description",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "default": false,
+          "description": "Indicates whether the gist is public.",
+          "name": "public",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/gists"
+    },
+    "createComment": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/gists/comments/#create-a-comment",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Create a comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "gist_id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "The comment text.",
+          "name": "body",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/gists/:gist_id/comments"
+    },
+    "delete": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/gists/#delete-a-gist",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Delete a gist",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/gists/:id"
+    },
+    "deleteComment": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/gists/comments/#delete-a-comment",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Delete a comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "gist_id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/gists/:gist_id/comments/:id"
+    },
+    "edit": {
+      "description": "The keys in the `files` object are the `string` filename. The value is another `object` with a key of `content` (indicating the new contents), or `filename` (indicating the new filename). For example:\n\n**Note**: All files from the previous version of the gist are carried over by default if not included in the object. Deletes can be performed by including the filename with a `null` object.",
+      "documentationUrl": "https://developer.github.com/v3/gists/#edit-a-gist",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "name": "Edit a gist",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "A description of the gist.",
+          "name": "description",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "description": "Files that make up this gist.",
+          "name": "files",
+          "required": false,
+          "type": "object"
+        },
+        "3": {
+          "description": "Updated file contents.",
+          "name": "content",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "New name for this file.",
+          "name": "filename",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/gists/:id"
+    },
+    "editComment": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/gists/comments/#edit-a-comment",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "name": "Edit a comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "gist_id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The comment text.",
+          "name": "body",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/gists/:gist_id/comments/:id"
+    },
+    "fork": {
+      "description": "**Note**: This was previously `/gists/:id/fork`.",
+      "documentationUrl": "https://developer.github.com/v3/gists/#fork-a-gist",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Fork a gist",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/gists/:id/forks"
+    },
+    "get": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/gists/#get-a-single-gist",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get a single gist",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/gists/:id"
+    },
+    "getAll": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/gists/#list-a-users-gists",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List the authenticated user's gists or if called anonymously, this will return all public gists",
+      "params": {
+        "0": {
+          "description": "A timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Only gists updated at or after this time are returned.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/gists"
+    },
+    "getComment": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/gists/comments/#get-a-single-comment",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get a single comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "gist_id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/gists/:gist_id/comments/:id"
+    },
+    "getComments": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/gists/comments/#list-comments-on-a-gist",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List comments on a gist",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "gist_id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/gists/:gist_id/comments"
+    },
+    "getCommits": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/gists/#list-gist-commits",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List gist commits",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/gists/:id/commits"
+    },
+    "getForUser": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/gists/#list-a-users-gists",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List public gists for the specified user",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "A timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Only gists updated at or after this time are returned.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/users/:username/gists"
+    },
+    "getForks": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/gists/#list-gist-forks",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List gist forks",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/gists/:id/forks"
+    },
+    "getPublic": {
+      "description": "List all public gists sorted by most recently updated to least recently updated.\n\nNote: With [pagination](/v3/#pagination), you can fetch up to 3000 gists. For example, you can fetch 100 pages with 30 gists per page or 30 pages with 100 gists per page.",
+      "documentationUrl": "https://developer.github.com/v3/gists/#list-all-public-gists",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List all public gists",
+      "params": {
+        "0": {
+          "description": "A timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Only gists updated at or after this time are returned.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/gists/public"
+    },
+    "getRevision": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/gists/#get-a-specific-revision-of-a-gist",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get a specific revision of a gist",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "sha",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/gists/:id/:sha"
+    },
+    "getStarred": {
+      "description": "List the authenticated user's starred gists:",
+      "documentationUrl": "https://developer.github.com/v3/gists/#list-starred-gists",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List starred gists",
+      "params": {
+        "0": {
+          "description": "A timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Only gists updated at or after this time are returned.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/gists/starred"
+    },
+    "star": {
+      "description": "Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](/v3/#http-verbs).\"",
+      "documentationUrl": "https://developer.github.com/v3/gists/#star-a-gist",
+      "enabledForApps": false,
+      "method": "PUT",
+      "name": "Star a gist",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/gists/:id/star"
+    },
+    "unstar": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/gists/#unstar-a-gist",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Unstar a gist",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/gists/:id/star"
+    }
+  },
+  "gitdata": {
+    "createBlob": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/git/blobs/#create-a-blob",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a Blob",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The new blob's content.",
+          "name": "content",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "default": "\"utf-8\"",
+          "description": "The encoding used for `content`. Currently, `\"utf-8\"` and `\"base64\"` are supported.",
+          "name": "encoding",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/git/blobs"
+    },
+    "createCommit": {
+      "description": "The `committer` section is optional and will be filled with the `author` data if omitted. If the `author` section is omitted, it will be filled in with the authenticated user's information and the current date.\n\nBoth the `author` and `committer` parameters have the same keys:\n\n| name  | type   | description                                                                                                             |\n| ----- | ------ | ----------------------------------------------------------------------------------------------------------------------- |\n| name  | string | The name of the author (or committer) of the commit                                                                     |\n| email | string | The email of the author (or committer) of the commit                                                                    |\n| date  | string | Indicates when this commit was authored (or committed). This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. |\n\nYou can also provide an optional string `signature` parameter. This value will be added to the `gpgsig` header of the created commit. For a commit signature to be verifiable by Git or GitHub, it must be an ASCII-armored detached PGP signature over the string commit as it would be written to the object database.\n\n**Note**: To pass a `signature` parameter, you need to first manually create a valid PGP signature, which can be complicated. You may find it easier to [use the command line](https://git-scm.com/book/id/v2/Git-Tools-Signing-Your-Work) to create signed commits.\n\nIn this example, the payload that the signature is over would have been:\n\n",
+      "documentationUrl": "https://developer.github.com/v3/git/commits/#create-a-commit",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a Commit",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The commit message",
+          "name": "message",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The SHA of the tree object this commit points to",
+          "name": "tree",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "description": "The SHAs of the commits that were the parents of this commit. If omitted or empty, the commit will be written as a root commit. For a single parent, an array of one SHA should be provided; for a merge commit, an array of more than one should be provided.",
+          "name": "parents",
+          "required": true,
+          "type": "array of strings"
+        },
+        "5": {
+          "description": "object containing information about the committer.",
+          "name": "committer",
+          "type": "object"
+        },
+        "6": {
+          "description": "object containing information about the author.",
+          "name": "author",
+          "type": "object"
+        }
+      },
+      "path": "/repos/:owner/:repo/git/commits"
+    },
+    "createReference": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/git/refs/#create-a-reference",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a Reference",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The name of the fully qualified reference (ie: `refs/heads/master`). If it doesn't start with 'refs' and have at least two slashes, it will be rejected.",
+          "name": "ref",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The SHA1 value to set this reference to",
+          "name": "sha",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/git/refs"
+    },
+    "createTag": {
+      "description": "Note that creating a tag object does not create the reference that makes a tag in Git. If you want to create an annotated tag in Git, you have to do this call to create the tag object, and then [create](/v3/git/refs/#create-a-reference) the `refs/tags/[tag]` reference. If you want to create a lightweight tag, you only have to [create](/v3/git/refs/#create-a-reference) the tag reference - this call would be unnecessary.",
+      "documentationUrl": "https://developer.github.com/v3/git/tags/#create-a-tag-object",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a Tag Object",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The tag",
+          "name": "tag",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "description": "The tag message",
+          "name": "message",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "The SHA of the git object this is tagging",
+          "name": "object",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "The type of the object we're tagging. Normally this is a `commit` but it can also be a `tree` or a `blob`.",
+          "name": "type",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "An object with information about the individual creating the tag.",
+          "name": "tagger",
+          "required": false,
+          "type": "object"
+        },
+        "7": {
+          "description": "The name of the author of the tag",
+          "name": "tagger.name",
+          "required": false,
+          "type": "string"
+        },
+        "8": {
+          "description": "The email of the author of the tag",
+          "name": "tagger.email",
+          "required": false,
+          "type": "string"
+        },
+        "9": {
+          "description": "When this object was tagged. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "name": "tagger.date",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/git/tags"
+    },
+    "createTree": {
+      "description": "The tree creation API will take nested entries as well. If both a tree and a nested path modifying that tree are specified, it will overwrite the contents of that tree with the new path contents and write a new tree out.",
+      "documentationUrl": "https://developer.github.com/v3/git/trees/#create-a-tree",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a Tree",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "Objects (of `path`, `mode`, `type`, and `sha`) specifying a tree structure",
+          "name": "tree",
+          "required": true,
+          "type": "array of objects"
+        },
+        "3": {
+          "description": "The file referenced in the tree",
+          "name": "tree.path",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "The file mode; one of `100644` for file (blob), `100755` for executable (blob), `040000` for subdirectory (tree), `160000` for submodule (commit), or `120000` for a blob that specifies the path of a symlink",
+          "enum": [
+            "100644",
+            "100755",
+            "040000",
+            "160000",
+            "120000"
+          ],
+          "name": "tree.mode",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "Either `blob`, `tree`, or `commit`",
+          "enum": [
+            "blob",
+            "tree",
+            "commit"
+          ],
+          "name": "tree.type",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "The SHA1 checksum ID of the object in the tree",
+          "name": "tree.sha",
+          "required": false,
+          "type": "string"
+        },
+        "7": {
+          "description": "The content you want this file to have. GitHub will write this blob out and use that SHA for this entry. Use either this, or `tree.sha`.",
+          "name": "tree.content",
+          "required": false,
+          "type": "string"
+        },
+        "8": {
+          "description": "The SHA1 of the tree you want to update with new data. If you don't set this, the commit will be created on top of everything; however, it will only contain your change, the rest of your files will show up as deleted.",
+          "name": "base_tree",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/git/trees"
+    },
+    "deleteReference": {
+      "description": "Example: Deleting a branch:\n\n```\nDELETE /repos/octocat/Hello-World/git/refs/heads/feature-a\n```\n\nExample: Deleting a tag:\n\n```\nDELETE /repos/octocat/Hello-World/git/refs/tags/v1.0\n```",
+      "documentationUrl": "https://developer.github.com/v3/git/refs/#delete-a-reference",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Delete a Reference",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "ref",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/git/refs/:ref"
+    },
+    "getBlob": {
+      "description": "The `content` in the response will always be Base64 encoded.\n\n_Note_: This API supports blobs up to 100 megabytes in size.",
+      "documentationUrl": "https://developer.github.com/v3/git/blobs/#get-a-blob",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a Blob",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "sha",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/git/blobs/:sha"
+    },
+    "getCommit": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/git/commits/#get-a-commit",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a Commit",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "sha",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/git/commits/:sha"
+    },
+    "getCommitSignatureVerification": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/git/commits/#get-a-commit",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a Commit",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "sha",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/git/commits/:sha"
+    },
+    "getReference": {
+      "description": "Returns a branch or tag reference. Other than the [REST API](https://developer.github.com/v3/git/refs/#get-a-reference) it always returns a single reference. If the REST API returns with an array then the method responds with an error.",
+      "documentationUrl": "https://developer.github.com/v3/git/refs/#get-a-reference",
+      "enabledForApps": true,
+      "isOverride": true,
+      "method": "GET",
+      "name": "Get a Reference",
+      "params": {
+        "0": {
+          "description": "Must be formatted as `heads/branch`, not just `branch`",
+          "name": "ref",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/git/refs/:ref"
+    },
+    "getTag": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/git/tags/#get-a-tag",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a Tag",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "sha",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/git/tags/:sha"
+    },
+    "getTagSignatureVerification": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/git/tags/#get-a-tag",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a Tag",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "sha",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/git/tags/:sha"
+    },
+    "getTree": {
+      "description": "If `truncated` is `true`, the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
+      "documentationUrl": "https://developer.github.com/v3/git/trees/#get-a-tree",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a Tree",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "sha",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/git/trees/:sha"
+    },
+    "updateReference": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/git/refs/#update-a-reference",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Update a Reference",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "ref",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The SHA1 value to set this reference to",
+          "name": "sha",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "default": false,
+          "description": "Indicates whether to force the update or to make sure the update is a fast-forward update. Leaving this out or setting it to `false` will make sure you're not overwriting work.",
+          "name": "force",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/repos/:owner/:repo/git/refs/:ref"
+    }
+  },
+  "issues": {
+    "addAssigneesToIssue": {
+      "description": "Adds up to 10 assignees to an issue. Users already assigned to an issue are not replaced.\n\nThis example adds two assignees to the existing `octocat` assignee.",
+      "documentationUrl": "https://developer.github.com/v3/issues/assignees/#add-assignees-to-an-issue",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Add assignees to an issue",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "Usernames of people to assign this issue to. _NOTE: Only users with push access can add assignees to an issue. Assignees are silently ignored otherwise._",
+          "name": "assignees",
+          "required": false,
+          "type": "array of strings"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/:number/assignees"
+    },
+    "addLabels": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Add labels to an issue",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/:number/labels"
+    },
+    "checkAssignee": {
+      "description": "Checks if a user has permission to be assigned to an issue in this repository.\n\nIf the `assignee` can be assigned to issues in the repository, a `204` header with no content is returned.\n\nOtherwise a `404` status code is returned.",
+      "documentationUrl": "https://developer.github.com/v3/issues/assignees/#check-assignee",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Check assignee",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "assignee",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/assignees/:assignee"
+    },
+    "create": {
+      "description": "Any user with pull access to a repository can create an issue.",
+      "documentationUrl": "https://developer.github.com/v3/issues/#create-an-issue",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create an issue",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The title of the issue.",
+          "name": "title",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The contents of the issue.",
+          "name": "body",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "Login for the user that this issue should be assigned to. _NOTE: Only users with push access can set the assignee for new issues. The assignee is silently dropped otherwise. **This field is deprecated.**_",
+          "name": "assignee",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "The `number` of the milestone to associate this issue with. _NOTE: Only users with push access can set the milestone for new issues. The milestone is silently dropped otherwise._",
+          "name": "milestone",
+          "required": false,
+          "type": "integer"
+        },
+        "6": {
+          "description": "Labels to associate with this issue. _NOTE: Only users with push access can set labels for new issues. Labels are silently dropped otherwise._",
+          "name": "labels",
+          "required": false,
+          "type": "array of strings"
+        },
+        "7": {
+          "description": "Logins for Users to assign to this issue. _NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise._",
+          "name": "assignees",
+          "required": false,
+          "type": "array of strings"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues"
+    },
+    "createComment": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/comments/#create-a-comment",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "The contents of the comment.",
+          "name": "body",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/:number/comments"
+    },
+    "createLabel": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/labels/#create-a-label",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a label",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The name of the label. Emoji can be added to label names, using either native emoji or colon-style markup. For example, typing `:strawberry:` will render the emoji ![:strawberry:](https://a248.e.akamai.net/assets.github.com/images/icons/emoji/unicode/1f353.png \":strawberry:\"). For a full list of available emoji and codes, see [emoji-cheat-sheet.com](http://emoji-cheat-sheet.com/).",
+          "name": "name",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The [hexadecimal color code](http://www.color-hex.com/) for the label, without the leading `#`.",
+          "name": "color",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "description": "A short description of the label.",
+          "name": "description",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/labels"
+    },
+    "createMilestone": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/milestones/#create-a-milestone",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a milestone",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The title of the milestone.",
+          "name": "title",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "default": "open",
+          "description": "The state of the milestone. Either `open` or `closed`.",
+          "enum": [
+            "open",
+            "closed"
+          ],
+          "name": "state",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "A description of the milestone.",
+          "name": "description",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "The milestone due date. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "name": "due_on",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/milestones"
+    },
+    "deleteComment": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/comments/#delete-a-comment",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Delete a comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/comments/:id"
+    },
+    "deleteLabel": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/labels/#delete-a-label",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Delete a label",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "name",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/labels/:name"
+    },
+    "deleteMilestone": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/milestones/#delete-a-milestone",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Delete a milestone",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/milestones/:number"
+    },
+    "edit": {
+      "description": "Issue owners and users with push access can edit an issue.",
+      "documentationUrl": "https://developer.github.com/v3/issues/#edit-an-issue",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Edit an issue",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "The title of the issue.",
+          "name": "title",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "The contents of the issue.",
+          "name": "body",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "Login for the user that this issue should be assigned to. **This field is deprecated.**",
+          "name": "assignee",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "State of the issue. Either `open` or `closed`.",
+          "enum": [
+            "open",
+            "closed"
+          ],
+          "name": "state",
+          "required": false,
+          "type": "string"
+        },
+        "7": {
+          "allowNull": true,
+          "description": "The `number` of the milestone to associate this issue with or `null` to remove current. _NOTE: Only users with push access can set the milestone for issues. The milestone is silently dropped otherwise._",
+          "name": "milestone",
+          "required": false,
+          "type": "integer"
+        },
+        "8": {
+          "description": "Labels to associate with this issue. Pass one or more Labels to _replace_ the set of Labels on this Issue. Send an empty array (`[]`) to clear all Labels from the Issue. _NOTE: Only users with push access can set labels for issues. Labels are silently dropped otherwise._",
+          "name": "labels",
+          "required": false,
+          "type": "array of strings"
+        },
+        "9": {
+          "description": "Logins for Users to assign to this issue. Pass one or more user logins to _replace_ the set of assignees on this Issue. Send an empty array (`[]`) to clear all assignees from the Issue. _NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise._",
+          "name": "assignees",
+          "required": false,
+          "type": "array of strings"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/:number"
+    },
+    "editComment": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/comments/#edit-a-comment",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Edit a comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The contents of the comment.",
+          "name": "body",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/comments/:id"
+    },
+    "get": {
+      "description": "**Note**: In the past, pull requests and issues were more closely aligned than they are now. As far as the API is concerned, every pull request is an issue, but not every issue is a pull request.\n\nThis endpoint may also return pull requests in the response. If an issue _is_ a pull request, the object will include a `pull_request` key.",
+      "documentationUrl": "https://developer.github.com/v3/issues/#get-a-single-issue",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a single issue",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/:number"
+    },
+    "getAll": {
+      "description": "**Note**: In the past, pull requests and issues were more closely aligned than they are now. As far as the API is concerned, every pull request is an issue, but not every issue is a pull request.\n\nThis endpoint may also return pull requests in the response. If an issue _is_ a pull request, the object will include a `pull_request` key.\n\nYou can use the `filter` query parameter to fetch issues that are not necessarily assigned to you. See the table below for more information.\n\n\n\n**Note:** If a user opened an issue via a GitHub App, the `performed_via_github_app` key contains information on that GitHub App.",
+      "documentationUrl": "https://developer.github.com/v3/issues/#list-issues",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List all issues assigned to the authenticated user across all visible repositories including owned repositories, member repositories, and organization repositories",
+      "params": {
+        "0": {
+          "default": "assigned",
+          "description": "Indicates which sorts of issues to return. Can be one of:  \n\\* `assigned`: Issues assigned to you  \n\\* `created`: Issues created by you  \n\\* `mentioned`: Issues mentioning you  \n\\* `subscribed`: Issues you're subscribed to updates for  \n\\* `all`: All issues the authenticated user can see, regardless of participation or creation",
+          "enum": [
+            "assigned",
+            "created",
+            "mentioned",
+            "subscribed",
+            "all"
+          ],
+          "name": "filter",
+          "required": false,
+          "type": "string"
+        },
+        "1": {
+          "default": "open",
+          "description": "Indicates the state of the issues to return. Can be either `open`, `closed`, or `all`.",
+          "enum": [
+            "open",
+            "closed",
+            "all"
+          ],
+          "name": "state",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "description": "A list of comma separated label names. Example: `bug,ui,@high`",
+          "name": "labels",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": "created",
+          "description": "What to sort results by. Can be either `created`, `updated`, `comments`.",
+          "enum": [
+            "created",
+            "updated",
+            "comments"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": "desc",
+          "description": "The direction of the sort. Can be either `asc` or `desc`.",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "direction",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "Only issues updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "7": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/issues"
+    },
+    "getAssignees": {
+      "description": "Lists the [available assignees](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) for issues in a repository.",
+      "documentationUrl": "https://developer.github.com/v3/issues/assignees/#list-assignees",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List assignees",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/assignees"
+    },
+    "getComment": {
+      "description": "\n\n**Note:** If a user created an issue comment via a GitHub App, the `performed_via_github_app` key will contain information on that GitHub App.",
+      "documentationUrl": "https://developer.github.com/v3/issues/comments/#get-a-single-comment",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a single comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/comments/:id"
+    },
+    "getComments": {
+      "description": "Issue Comments are ordered by ascending ID.",
+      "documentationUrl": "https://developer.github.com/v3/issues/comments/#list-comments-on-an-issue",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List comments on an issue",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "Only comments updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "5": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/:number/comments"
+    },
+    "getCommentsForRepo": {
+      "description": "By default, Issue Comments are ordered by ascending ID.",
+      "documentationUrl": "https://developer.github.com/v3/issues/comments/#list-comments-in-a-repository",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List comments in a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": "created",
+          "description": "Either `created` or `updated`.",
+          "enum": [
+            "created",
+            "updated"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "description": "Either `asc` or `desc`. Ignored without the `sort` parameter.",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "direction",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "Only comments updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/comments"
+    },
+    "getEvent": {
+      "description": "\n\n**Note:** If the event was triggered by a user via a GitHub App, the `performed_via_github_app` key will contain information on that GitHub App.",
+      "documentationUrl": "https://developer.github.com/v3/issues/events/#get-a-single-event",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a single event",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/events/:id"
+    },
+    "getEvents": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/events/#list-events-for-an-issue",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List events for an issue",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/:number/events"
+    },
+    "getEventsForRepo": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/events/#list-events-for-a-repository",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List events for a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/events"
+    },
+    "getEventsTimeline": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/timeline/#list-events-for-an-issue",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List events for an issue",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/:number/timeline"
+    },
+    "getForOrg": {
+      "description": "**Note**: In the past, pull requests and issues were more closely aligned than they are now. As far as the API is concerned, every pull request is an issue, but not every issue is a pull request.\n\nThis endpoint may also return pull requests in the response. If an issue _is_ a pull request, the object will include a `pull_request` key.\n\nYou can use the `filter` query parameter to fetch issues that are not necessarily assigned to you. See the table below for more information.\n\n\n\n**Note:** If a user opened an issue via a GitHub App, the `performed_via_github_app` key contains information on that GitHub App.",
+      "documentationUrl": "https://developer.github.com/v3/issues/#list-issues",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List all issues for a given organization assigned to the authenticated user",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": "assigned",
+          "description": "Indicates which sorts of issues to return. Can be one of:  \n\\* `assigned`: Issues assigned to you  \n\\* `created`: Issues created by you  \n\\* `mentioned`: Issues mentioning you  \n\\* `subscribed`: Issues you're subscribed to updates for  \n\\* `all`: All issues the authenticated user can see, regardless of participation or creation",
+          "enum": [
+            "assigned",
+            "created",
+            "mentioned",
+            "subscribed",
+            "all"
+          ],
+          "name": "filter",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "default": "open",
+          "description": "Indicates the state of the issues to return. Can be either `open`, `closed`, or `all`.",
+          "enum": [
+            "open",
+            "closed",
+            "all"
+          ],
+          "name": "state",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "description": "A list of comma separated label names. Example: `bug,ui,@high`",
+          "name": "labels",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": "created",
+          "description": "What to sort results by. Can be either `created`, `updated`, `comments`.",
+          "enum": [
+            "created",
+            "updated",
+            "comments"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "default": "desc",
+          "description": "The direction of the sort. Can be either `asc` or `desc`.",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "direction",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "Only issues updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        },
+        "7": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "8": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/orgs/:org/issues"
+    },
+    "getForRepo": {
+      "description": "**Note**: In the past, pull requests and issues were more closely aligned than they are now. As far as the API is concerned, every pull request is an issue, but not every issue is a pull request.\n\nThis endpoint may also return pull requests in the response. If an issue _is_ a pull request, the object will include a `pull_request` key.\n\n\n\n**Note:** If a user opened an issue via a GitHub App, the `performed_via_github_app` key contains information on that GitHub App.",
+      "documentationUrl": "https://developer.github.com/v3/issues/#list-issues-for-a-repository",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List issues for a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "If an `integer` is passed, it should refer to a milestone by its `number` field. If the string `*` is passed, issues with any milestone are accepted. If the string `none` is passed, issues without milestones are returned.",
+          "name": "milestone",
+          "required": false,
+          "type": "integer or string"
+        },
+        "3": {
+          "default": "open",
+          "description": "Indicates the state of the issues to return. Can be either `open`, `closed`, or `all`.",
+          "enum": [
+            "open",
+            "closed",
+            "all"
+          ],
+          "name": "state",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "Can be the name of a user. Pass in `none` for issues with no assigned user, and `*` for issues assigned to any user.",
+          "name": "assignee",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "The user that created the issue.",
+          "name": "creator",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "A user that's mentioned in the issue.",
+          "name": "mentioned",
+          "required": false,
+          "type": "string"
+        },
+        "7": {
+          "description": "A list of comma separated label names. Example: `bug,ui,@high`",
+          "name": "labels",
+          "required": false,
+          "type": "string"
+        },
+        "8": {
+          "default": "created",
+          "description": "What to sort results by. Can be either `created`, `updated`, `comments`.",
+          "enum": [
+            "created",
+            "updated",
+            "comments"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "9": {
+          "default": "desc",
+          "description": "The direction of the sort. Can be either `asc` or `desc`.",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "direction",
+          "required": false,
+          "type": "string"
+        },
+        "10": {
+          "description": "Only issues updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        },
+        "11": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "12": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues"
+    },
+    "getForUser": {
+      "description": "**Note**: In the past, pull requests and issues were more closely aligned than they are now. As far as the API is concerned, every pull request is an issue, but not every issue is a pull request.\n\nThis endpoint may also return pull requests in the response. If an issue _is_ a pull request, the object will include a `pull_request` key.\n\nYou can use the `filter` query parameter to fetch issues that are not necessarily assigned to you. See the table below for more information.\n\n\n\n**Note:** If a user opened an issue via a GitHub App, the `performed_via_github_app` key contains information on that GitHub App.",
+      "documentationUrl": "https://developer.github.com/v3/issues/#list-issues",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List all issues across owned and member repositories assigned to the authenticated user",
+      "params": {
+        "0": {
+          "default": "assigned",
+          "description": "Indicates which sorts of issues to return. Can be one of:  \n\\* `assigned`: Issues assigned to you  \n\\* `created`: Issues created by you  \n\\* `mentioned`: Issues mentioning you  \n\\* `subscribed`: Issues you're subscribed to updates for  \n\\* `all`: All issues the authenticated user can see, regardless of participation or creation",
+          "enum": [
+            "assigned",
+            "created",
+            "mentioned",
+            "subscribed",
+            "all"
+          ],
+          "name": "filter",
+          "required": false,
+          "type": "string"
+        },
+        "1": {
+          "default": "open",
+          "description": "Indicates the state of the issues to return. Can be either `open`, `closed`, or `all`.",
+          "enum": [
+            "open",
+            "closed",
+            "all"
+          ],
+          "name": "state",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "description": "A list of comma separated label names. Example: `bug,ui,@high`",
+          "name": "labels",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": "created",
+          "description": "What to sort results by. Can be either `created`, `updated`, `comments`.",
+          "enum": [
+            "created",
+            "updated",
+            "comments"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": "desc",
+          "description": "The direction of the sort. Can be either `asc` or `desc`.",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "direction",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "Only issues updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "7": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/user/issues"
+    },
+    "getIssueLabels": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/labels/#list-labels-on-an-issue",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List labels on an issue",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/:number/labels"
+    },
+    "getLabel": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/labels/#get-a-single-label",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a single label",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "name",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/labels/:name"
+    },
+    "getLabels": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List all labels for this repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/labels"
+    },
+    "getMilestone": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/milestones/#get-a-single-milestone",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a single milestone",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/milestones/:number"
+    },
+    "getMilestoneLabels": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get labels for every issue in a milestone",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/milestones/:number/labels"
+    },
+    "getMilestones": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List milestones for a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": "open",
+          "description": "The state of the milestone. Either `open`, `closed`, or `all`.",
+          "enum": [
+            "open",
+            "closed",
+            "all"
+          ],
+          "name": "state",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": "due_on",
+          "description": "What to sort results by. Either `due_on` or `completeness`.",
+          "enum": [
+            "due_on",
+            "completeness"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": "asc",
+          "description": "The direction of the sort. Either `asc` or `desc`.",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "direction",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "6": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/milestones"
+    },
+    "lock": {
+      "description": "Users with push access can lock an issue or pull request's conversation.\n\nNote that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](/v3/#http-verbs).\"",
+      "documentationUrl": "https://developer.github.com/v3/issues/#lock-an-issue",
+      "enabledForApps": true,
+      "method": "PUT",
+      "name": "Lock an issue",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "The reason for locking the issue or pull request conversation. Lock will fail if you don't use one of these reasons:  \n\\* `off-topic`  \n\\* `too heated`  \n\\* `resolved`  \n\\* `spam`",
+          "enum": [
+            "off-topic",
+            "too heated",
+            "resolved",
+            "spam"
+          ],
+          "name": "lock_reason",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/:number/lock"
+    },
+    "removeAllLabels": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Remove all labels from an issue",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/:number/labels"
+    },
+    "removeAssigneesFromIssue": {
+      "description": "Removes one or more assignees from an issue.\n\nThis example removes two of three assignees, leaving the `octocat` assignee.",
+      "documentationUrl": "https://developer.github.com/v3/issues/assignees/#remove-assignees-from-an-issue",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Remove assignees from an issue",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "Usernames of assignees to remove from an issue. _NOTE: Only users with push access can remove assignees from an issue. Assignees are silently ignored otherwise._",
+          "name": "assignees",
+          "required": false,
+          "type": "array of strings"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/:number/assignees"
+    },
+    "removeLabel": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Remove a label from an issue",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "",
+          "name": "name",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/:number/labels/:name"
+    },
+    "replaceAllLabels": {
+      "description": "Sending an empty array (`[]`) will remove all Labels from the Issue.",
+      "documentationUrl": "https://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue",
+      "enabledForApps": true,
+      "method": "PUT",
+      "name": "Replace all labels for an issue",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/:number/labels"
+    },
+    "unlock": {
+      "description": "Users with push access can unlock an issue's conversation.",
+      "documentationUrl": "https://developer.github.com/v3/issues/#unlock-an-issue",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Unlock an issue",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/:number/lock"
+    },
+    "updateLabel": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/labels/#update-a-label",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Update a label",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "oldname",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The name of the label. Emoji can be added to label names, using either native emoji or colon-style markup. For example, typing `:strawberry:` will render the emoji ![:strawberry:](https://a248.e.akamai.net/assets.github.com/images/icons/emoji/unicode/1f353.png \":strawberry:\"). For a full list of available emoji and codes, see [emoji-cheat-sheet.com](http://emoji-cheat-sheet.com/).",
+          "name": "name",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "The [hexadecimal color code](http://www.color-hex.com/) for the label, without the leading `#`.",
+          "name": "color",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "A short description of the label.",
+          "name": "description",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/labels/:oldname"
+    },
+    "updateMilestone": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/issues/milestones/#update-a-milestone",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Update a milestone",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "The title of the milestone.",
+          "name": "title",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": "open",
+          "description": "The state of the milestone. Either `open` or `closed`.",
+          "enum": [
+            "open",
+            "closed"
+          ],
+          "name": "state",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "A description of the milestone.",
+          "name": "description",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "The milestone due date. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "name": "due_on",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/milestones/:number"
+    }
+  },
+  "migrations": {
+    "cancelImport": {
+      "description": "Stop an import for a repository.",
+      "documentationUrl": "https://developer.github.com/v3/migration/source_imports/#cancel-an-import",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Cancel an import",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/import"
+    },
+    "deleteMigrationArchive": {
+      "description": "Deletes a previous migration archive. Migration archives are automatically deleted after seven days.",
+      "documentationUrl": "https://developer.github.com/v3/migration/migrations/#delete-a-migration-archive",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Delete a migration archive",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/migrations/:id/archive"
+    },
+    "getImportCommitAuthors": {
+      "description": "Each type of source control system represents authors in a different way. For example, a Git commit author has a display name and an email address, but a Subversion commit author just has a username. The GitHub Importer will make the author information valid, but the author might not be correct. For example, it will change the bare Subversion username `hubot` into something like `hubot <hubot@12341234-abab-fefe-8787-fedcba987654>`.\n\nThis API method and the \"Map a commit author\" method allow you to provide correct Git author information.",
+      "documentationUrl": "https://developer.github.com/v3/migration/source_imports/#get-commit-authors",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get commit authors",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "Only authors found after this id are returned. Provide the highest author ID you've seen so far. New authors may be added to the list at any point while the importer is performing the `raw` step.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/import/authors"
+    },
+    "getImportProgress": {
+      "description": "View the progress of an import.\n\n**Import status**\n\nThis section includes details about the possible values of the `status` field of the Import Progress response.\n\nAn import that does not have errors will progress through these steps:\n\n*   `detecting` \\- the \"detection\" step of the import is in progress because the request did not include a `vcs` parameter. The import is identifying the type of source control present at the URL.\n*   `importing` \\- the \"raw\" step of the import is in progress. This is where commit data is fetched from the original repository. The import progress response will include `commit_count` (the total number of raw commits that will be imported) and `percent` (0 - 100, the current progress through the import).\n*   `mapping` \\- the \"rewrite\" step of the import is in progress. This is where SVN branches are converted to Git branches, and where author updates are applied. The import progress response does not include progress information.\n*   `pushing` \\- the \"push\" step of the import is in progress. This is where the importer updates the repository on GitHub. The import progress response will include `push_percent`, which is the percent value reported by `git push` when it is \"Writing objects\".\n*   `complete` \\- the import is complete, and the repository is ready on GitHub.\n\nIf there are problems, you will see one of these in the `status` field:\n\n*   `auth_failed` \\- the import requires authentication in order to connect to the original repository. To update authentication for the import, please see the [Update Existing Import](#update-existing-import) section.\n*   `error` \\- the import encountered an error. The import progress response will include the `failed_step` and an error message. Contact [GitHub support](https://github.com/contact) for more information.\n*   `detection_needs_auth` \\- the importer requires authentication for the originating repository to continue detection. To update authentication for the import, please see the [Update Existing Import](#update-existing-import) section.\n*   `detection_found_nothing` \\- the importer didn't recognize any source control at the URL. To resolve, [Cancel the import](#cancel-an-import) and [retry](#start-an-import) with the correct URL.\n*   `detection_found_multiple` \\- the importer found several projects or repositories at the provided URL. When this is the case, the Import Progress response will also include a `project_choices` field with the possible project choices as values. To update project choice, please see the [Update Existing Import](#update-existing-import) section.\n\n**The project_choices field**\n\nWhen multiple projects are found at the provided URL, the response hash will include a `project_choices` field, the value of which is an array of hashes each representing a project choice. The exact key/value pairs of the project hashes will differ depending on the version control type.\n\n**Git LFS related fields**\n\nThis section includes details about Git LFS related fields that may be present in the Import Progress response.\n\n*   `use_lfs` \\- describes whether the import has been opted in or out of using Git LFS. The value can be `opt_in`, `opt_out`, or `undecided` if no action has been taken.\n*   `has_large_files` \\- the boolean value describing whether files larger than 100MB were found during the `importing` step.\n*   `large_files_size` \\- the total size in gigabytes of files larger than 100MB found in the originating repository.\n*   `large_files_count` \\- the total number of files larger than 100MB found in the originating repository. To see a list of these files, make a \"Get Large Files\" request.",
+      "documentationUrl": "https://developer.github.com/v3/migration/source_imports/#get-import-progress",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get import progress",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/import"
+    },
+    "getLargeImportFiles": {
+      "description": "List files larger than 100MB found during the import",
+      "documentationUrl": "https://developer.github.com/v3/migration/source_imports/#get-large-files",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get large files",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/import/large_files"
+    },
+    "getMigrationArchiveLink": {
+      "description": "Fetches the URL to a migration archive.\n\n",
+      "documentationUrl": "https://developer.github.com/v3/migration/migrations/#download-a-migration-archive",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Download a migration archive",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/migrations/:id/archive"
+    },
+    "getMigrationStatus": {
+      "description": "Fetches the status of a migration.\n\nThe `state` of a migration can be one of the following values:\n\n*   `pending`, which means the migration hasn't started yet.\n*   `exporting`, which means the migration is in progress.\n*   `exported`, which means the migration finished successfully.\n*   `failed`, which means the migration failed.",
+      "documentationUrl": "https://developer.github.com/v3/migration/migrations/#get-the-status-of-a-migration",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get the status of a migration",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/migrations/:id"
+    },
+    "getMigrations": {
+      "description": "Lists the most recent migrations.",
+      "documentationUrl": "https://developer.github.com/v3/migration/migrations/#get-a-list-of-migrations",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get a list of migrations",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/orgs/:org/migrations"
+    },
+    "mapImportCommitAuthor": {
+      "description": "Update an author's identity for the import. Your application can continue updating authors any time before you push new commits to the repository.",
+      "documentationUrl": "https://developer.github.com/v3/migration/source_imports/#map-a-commit-author",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Map a commit author",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "author_id",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The new Git author email.",
+          "name": "email",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "The new Git author name.",
+          "name": "name",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/import/authors/:author_id"
+    },
+    "setImportLfsPreference": {
+      "description": "You can import repositories from Subversion, Mercurial, and TFS that include files larger than 100MB. This ability is powered by [Git LFS](https://git-lfs.github.com). You can learn more about our LFS feature and working with large files [on our help site](https://help.github.com/articles/versioning-large-files/).",
+      "documentationUrl": "https://developer.github.com/v3/migration/source_imports/#set-git-lfs-preference",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Set Git LFS preference",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "Can be one of `opt_in` (large files will be stored using Git LFS) or `opt_out` (large files will be removed during the import).",
+          "enum": [
+            "opt_in",
+            "opt_out"
+          ],
+          "name": "use_lfs",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/import/lfs"
+    },
+    "startImport": {
+      "description": "Start a source import to a GitHub repository using GitHub Importer.",
+      "documentationUrl": "https://developer.github.com/v3/migration/source_imports/#start-an-import",
+      "enabledForApps": true,
+      "method": "PUT",
+      "name": "Start an import",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The URL of the originating repository.",
+          "name": "vcs_url",
+          "required": true,
+          "type": "url"
+        },
+        "3": {
+          "description": "The originating VCS type. Can be one of `subversion`, `git`, `mercurial`, or `tfvc`. Please be aware that without this parameter, the import job will take additional time to detect the VCS type before beginning the import. This detection step will be reflected in the response.",
+          "enum": [
+            "subversion",
+            "git",
+            "mercurial",
+            "tfvc"
+          ],
+          "name": "vcs",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "If authentication is required, the username to provide to `vcs_url`.",
+          "name": "vcs_username",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "If authentication is required, the password to provide to `vcs_url`.",
+          "name": "vcs_password",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "For a tfvc import, the name of the project that is being imported.",
+          "name": "tfvc_project",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/import"
+    },
+    "startMigration": {
+      "description": "Initiates the generation of a migration archive.",
+      "documentationUrl": "https://developer.github.com/v3/migration/migrations/#start-a-migration",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Start a migration",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "A list of arrays indicating which repositories should be migrated.",
+          "name": "repositories",
+          "required": true,
+          "type": "array of strings"
+        },
+        "2": {
+          "default": false,
+          "description": "Indicates whether repositories should be locked (to prevent manipulation) while migrating data.",
+          "name": "lock_repositories",
+          "required": false,
+          "type": "boolean"
+        },
+        "3": {
+          "default": false,
+          "description": "Indicates whether attachments should be excluded from the migration (to reduce migration archive file size).",
+          "name": "exclude_attachments",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/orgs/:org/migrations"
+    },
+    "unlockRepoLockedForMigration": {
+      "description": "Unlocks a repository that was locked for migration. You should unlock each migrated repository and [delete them](/v3/repos/#delete-a-repository) when the migration is complete and you no longer need the source data.",
+      "documentationUrl": "https://developer.github.com/v3/migration/migrations/#unlock-a-repository",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Unlock a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "repo_name",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/migrations/:id/repos/:repo_name/lock"
+    },
+    "updateImport": {
+      "description": "An import can be updated with credentials or a project choice by passing in the appropriate parameters in this API request. If no parameters are provided, the import will be restarted.\n\nSome servers (e.g. TFS servers) can have several projects at a single URL. In those cases the import progress will have the status `detection_found_multiple` and the Import Progress response will include a `project_choices` array. You can select the project to import by providing one of the objects in the `project_choices` array in the update request.\n\nThe following example demonstrates the workflow for updating an import with \"project1\" as the project choice. Given a `project_choices` array like such:\n\nTo restart an import, no parameters are provided in the update request.",
+      "documentationUrl": "https://developer.github.com/v3/migration/source_imports/#update-existing-import",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Update existing import",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The username to provide to the originating repository.",
+          "name": "vcs_username",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "description": "The password to provide to the originating repository.",
+          "name": "vcs_password",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/import"
+    }
+  },
+  "misc": {
+    "getCodeOfConduct": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/codes_of_conduct/#get-an-individual-code-of-conduct",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get an individual code of conduct",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "key",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/codes_of_conduct/:key"
+    },
+    "getCodesOfConduct": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/codes_of_conduct/#list-all-codes-of-conduct",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List all codes of conduct",
+      "params": {},
+      "path": "/codes_of_conduct"
+    },
+    "getGitignoreTemplate": {
+      "description": "The API also allows fetching the source of a single template.\n\nUse the raw [media type](/v3/media/) to get the raw contents.\n\n",
+      "documentationUrl": "https://developer.github.com/v3/gitignore/#get-a-single-template",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get a single template",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "name",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/gitignore/templates/:name"
+    },
+    "getGitignoreTemplates": {
+      "description": "List all templates available to pass as an option when [creating a repository](/v3/repos/#create).",
+      "documentationUrl": "https://developer.github.com/v3/gitignore/#listing-available-templates",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Listing available templates",
+      "params": {},
+      "path": "/gitignore/templates"
+    },
+    "getLicense": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/licenses/#get-an-individual-license",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get an individual license",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "license",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/licenses/:license"
+    },
+    "getLicenses": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/licenses/#list-all-licenses",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List all licenses",
+      "params": {},
+      "path": "/licenses"
+    },
+    "getRateLimit": {
+      "description": "Note: Accessing this endpoint does not count against your rate limit.\n\n\n\n**Understanding Your Rate Limit Status**\n\nThe Search API has a [custom rate limit](/v3/search/#rate-limit), separate from the rate limit governing the rest of the API. For that reason, the response (shown above) categorizes your rate limit by resource. Within the `\"resources\"` object, the `\"search\"` object provides your rate limit status for the [Search API](/v3/search). The `\"core\"` object provides your rate limit status for all the _rest_ of the API.\n\nThe `\"rate\"` object (shown at the bottom of the response above) is deprecated.\n\nIf you're writing new API client code (or updating your existing code), you should use the `\"core\"` object instead of the `\"rate\"` object. The `\"core\"` object contains the same information that is present in the `\"rate\"` object.",
+      "documentationUrl": "https://developer.github.com/v3/rate_limit/#get-your-current-rate-limit-status",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get your current rate limit status",
+      "params": {},
+      "path": "/rate_limit"
+    },
+    "getRepoCodeOfConduct": {
+      "description": "This method returns the contents of the repository's code of conduct file, if one is detected.",
+      "documentationUrl": "https://developer.github.com/v3/codes_of_conduct/#get-the-contents-of-a-repositorys-code-of-conduct",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get the contents of a repository's code of conduct",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/community/code_of_conduct"
+    },
+    "getRepoLicense": {
+      "description": "This method returns the contents of the repository's license file, if one is detected.\n\nSimilar to [the repository contents API](/v3/repos/contents/#get-contents), this method also supports [custom media types](/v3/repos/contents/#custom-media-types) for retrieving the raw license content or rendered license HTML.",
+      "documentationUrl": "https://developer.github.com/v3/licenses/#get-the-contents-of-a-repositorys-license",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get the contents of a repository's license",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/license"
+    },
+    "renderMarkdown": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/markdown/#render-an-arbitrary-markdown-document",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Render an arbitrary Markdown document",
+      "params": {
+        "0": {
+          "description": "The Markdown text to render in HTML. Markdown content must be 400 KB or less.",
+          "name": "text",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": "markdown",
+          "description": "The rendering mode. Can be either:  \n\\* `markdown` to render a document in plain Markdown, just like README.md files are rendered.  \n\\* `gfm` to render a document in [GitHub Flavored Markdown](https://github.github.com/gfm/), which creates links for user mentions as well as references to SHA-1 hashes, issues, and pull requests.",
+          "enum": [
+            "markdown",
+            "gfm"
+          ],
+          "name": "mode",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "description": "The repository context to use when creating references in `gfm` mode. Omit this parameter when using `markdown` mode.",
+          "name": "context",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/markdown"
+    },
+    "renderMarkdownRaw": {
+      "description": "You must send Markdown as plain text (using a `Content-Type` header of `text/plain` or `text/x-markdown`) to this endpoint, rather than using JSON format. In raw mode, [GitHub Flavored Markdown](https://github.github.com/gfm/) is not supported and Markdown will be rendered in plain format like a README.md file. Markdown content must be 400 KB or less.\n\n",
+      "documentationUrl": "https://developer.github.com/v3/markdown/#render-a-markdown-document-in-raw-mode",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Render a Markdown document in raw mode",
+      "params": {},
+      "path": "/markdown/raw"
+    }
+  },
+  "orgs": {
+    "addOrgMembership": {
+      "description": "Only authenticated organization owners can add a member to the organization or update the member's role.\n\n*   If the authenticated user is _adding_ a member to the organization, the invited user will receive an email inviting them to the organization. The user's [membership status](#get-organization-membership) will be `pending` until they accept the invitation.\n    \n*   Authenticated users can _update_ a user's membership by passing the `role` parameter. If the authenticated user changes a member's role to `admin`, the affected user will receive an email notifying them that they've been made an organization owner. If the authenticated user changes an owner's role to `member`, no email will be sent.\n\n**Rate limits**\n\nTo prevent abuse, the authenticated user is limited to 50 organization invitations per 24 hour period. If the organization is more than one month old or on a paid plan, the limit is 500 invitations per 24 hour period.",
+      "documentationUrl": "https://developer.github.com/v3/orgs/members/#add-or-update-organization-membership",
+      "enabledForApps": true,
+      "method": "PUT",
+      "name": "Add or update organization membership",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": "member",
+          "description": "The role to give the user in the organization. Can be one of:  \n\\* `admin` \\- The user will become an owner of the organization.  \n\\* `member` \\- The user will become a non-owner member of the organization.",
+          "enum": [
+            "admin",
+            "member"
+          ],
+          "name": "role",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/memberships/:username"
+    },
+    "addTeamMembership": {
+      "description": "If the user is already a member of the team's organization, this endpoint will add the user to the team. To add a membership between an organization member and a team, the authenticated user must be an organization owner or a maintainer of the team.\n\nIf the user is unaffiliated with the team's organization, this endpoint will send an invitation to the user via email. This newly-created membership will be in the \"pending\" state until the user accepts the invitation, at which point the membership will transition to the \"active\" state and the user will be added as a member of the team. To add a membership between an unaffiliated user and a team, the authenticated user must be an organization owner.\n\nIf the user is already a member of the team, this endpoint will update the role of the team member's role. To update the membership of a team member, the authenticated user must be an organization owner or a maintainer of the team.\n\nIf you attempt to add an organization to a team, you will get this:",
+      "documentationUrl": "https://developer.github.com/v3/teams/members/#add-or-update-team-membership",
+      "enabledForApps": true,
+      "method": "PUT",
+      "name": "Add or update team membership",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": "member",
+          "description": "The role that this user should have in the team. Can be one of:  \n\\* `member` \\- a normal member of the team.  \n\\* `maintainer` \\- a team maintainer. Able to add/remove other team members, promote other team members to team maintainer, and edit the team's name and description.",
+          "enum": [
+            "member",
+            "maintainer"
+          ],
+          "name": "role",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/teams/:id/memberships/:username"
+    },
+    "addTeamRepo": {
+      "description": "To add a repository to a team or update the team's permission on a repository, the authenticated user must have admin access to the repository, and must be able to see the team. Also, the repository must be owned by the organization, or a direct fork of a repository owned by the organization.\n\nNote that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](/v3/#http-verbs).\"\n\n",
+      "documentationUrl": "https://developer.github.com/v3/teams/#add-or-update-team-repository",
+      "enabledForApps": false,
+      "method": "PUT",
+      "name": "Add or update team repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The permission to grant the team on this repository. Can be one of:  \n\\* `pull` \\- team members can pull, but not push to or administer this repository.  \n\\* `push` \\- team members can pull and push, but not administer this repository.  \n\\* `admin` \\- team members can pull, push and administer this repository.  \n  \nIf no permission is specified, the team's `permission` attribute will be used to determine what permission to grant the team on this repository.  \n**Note**: If you pass the `hellcat-preview` media type, you can promote—but not demote—a `permission` attribute inherited through a parent team.",
+          "enum": [
+            "pull",
+            "push",
+            "admin"
+          ],
+          "name": "permission",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/teams/:id/repos/:org/:repo"
+    },
+    "blockUser": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/orgs/blocking/#block-a-user",
+      "enabledForApps": false,
+      "method": "PUT",
+      "name": "Block a user",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/blocks/:username"
+    },
+    "checkBlockedUser": {
+      "description": "If the user is blocked:\n\nIf the user is not blocked:",
+      "documentationUrl": "https://developer.github.com/v3/orgs/blocking/#check-whether-a-user-is-blocked-from-an-organization",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Check whether a user is blocked from an organization",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/blocks/:username"
+    },
+    "checkMembership": {
+      "description": "Check if a user is, publicly or privately, a member of the organization.",
+      "documentationUrl": "https://developer.github.com/v3/orgs/members/#check-membership",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Check membership",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/members/:username"
+    },
+    "checkPublicMembership": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/orgs/members/#check-public-membership",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Check public membership",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/public_members/:username"
+    },
+    "checkTeamRepo": {
+      "description": "**Note**: If you pass the `hellcat-preview` media type, repositories inherited through a parent team will be checked as well.\n\nYou can also get information about the specified repository, including what permissions the team grants on it, by passing the following custom [media type](/v3/media/) via the `Accept` header:",
+      "documentationUrl": "https://developer.github.com/v3/teams/#check-if-a-team-manages-a-repository",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Check if a team manages a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/teams/:id/repos/:owner/:repo"
+    },
+    "concealMembership": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/orgs/members/#conceal-a-users-membership",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Conceal a user's membership",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/public_members/:username"
+    },
+    "convertMemberToOutsideCollaborator": {
+      "description": "When an organization member is converted to an outside collaborator, they'll only have access to the repositories that their current team membership allows. The user will no longer be a member of the organization. For more information, see \"[Converting an organization member to an outside collaborator](https://help.github.com/articles/converting-an-organization-member-to-an-outside-collaborator/)\".",
+      "documentationUrl": "https://developer.github.com/v3/orgs/outside_collaborators/#convert-member-to-outside-collaborator",
+      "enabledForApps": true,
+      "method": "PUT",
+      "name": "Convert member to outside collaborator",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/outside_collaborators/:username"
+    },
+    "createHook": {
+      "description": "Here's how you can create a hook that posts payloads in JSON format:",
+      "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#create-a-hook",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Create a hook",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "Must be passed as \"web\".",
+          "name": "name",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "name": "config",
+          "required": true,
+          "type": "object"
+        },
+        "3": {
+          "description": "The URL to which the payloads will be delivered.",
+          "name": "config.url",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "name": "config.content_type",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/webhooks/#delivery-headers) header.",
+          "name": "config.secret",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "name": "config.insecure_ssl",
+          "required": false,
+          "type": "string"
+        },
+        "7": {
+          "default": "[\"push\"]",
+          "description": "Determines what [events](/v3/activity/events/types/) the hook is triggered for.",
+          "name": "events",
+          "required": false,
+          "type": "array"
+        },
+        "8": {
+          "default": true,
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "name": "active",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/orgs/:org/hooks"
+    },
+    "createTeam": {
+      "description": "To create a team, the authenticated user must be a member of `:org`.",
+      "documentationUrl": "https://developer.github.com/v3/teams/#create-team",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Create team",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "The name of the team.",
+          "name": "name",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The description of the team.",
+          "name": "description",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "description": "The logins of organization members to add as maintainers of the team.",
+          "name": "maintainers",
+          "required": false,
+          "type": "array of strings"
+        },
+        "4": {
+          "description": "The full name (e.g., \"organization-name/repository-name\") of repositories to add the team to.",
+          "name": "repo_names",
+          "required": false,
+          "type": "array of strings"
+        },
+        "5": {
+          "default": "secret",
+          "description": "The level of privacy this team should have. The options are:  \n**For a non-nested team:**  \n\\* `secret` \\- only visible to organization owners and members of this team.  \n\\* `closed` \\- visible to all members of this organization.  \nDefault: `secret`  \n**For a parent or child team:**  \n\\* `closed` \\- visible to all members of this organization.  \nDefault for child team: `closed`  \n**Note**: You must pass the `hellcat-preview` media type to set privacy default to `closed` for child teams. **For a parent or child team:**  ",
+          "name": "privacy",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "default": "pull",
+          "description": "**Deprecated**. The permission that new repositories will be added to the team with when none is specified. Can be one of:  \n\\* `pull` \\- team members can pull, but not push to or administer newly-added repositories.  \n\\* `push` \\- team members can pull and push, but not administer newly-added repositories.  \n\\* `admin` \\- team members can pull, push and administer newly-added repositories.",
+          "enum": [
+            "pull",
+            "push",
+            "admin"
+          ],
+          "name": "permission",
+          "required": false,
+          "type": "string"
+        },
+        "7": {
+          "description": "The ID of a team to set as the parent team. **Note**: You must pass the `hellcat-preview` media type to use this parameter.",
+          "name": "parent_team_id",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/orgs/:org/teams"
+    },
+    "deleteHook": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#delete-a-hook",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Delete a hook",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/hooks/:id"
+    },
+    "deleteTeam": {
+      "description": "To delete a team, the authenticated user must be a team maintainer or an owner of the org associated with the team.\n\nIf you are an organization owner and you pass the `hellcat-preview` media type, deleting a parent team will delete all of its child teams as well.",
+      "documentationUrl": "https://developer.github.com/v3/teams/#delete-team",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Delete team",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/teams/:id"
+    },
+    "deleteTeamRepo": {
+      "description": "If the authenticated user is an organization owner or a team maintainer, they can remove any repositories from the team. To remove a repository from a team as an organization member, the authenticated user must have admin access to the repository and must be able to see the team. NOTE: This does not delete the repository, it just removes it from the team.",
+      "documentationUrl": "https://developer.github.com/v3/teams/#remove-team-repository",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Remove team repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/teams/:id/repos/:owner/:repo"
+    },
+    "editHook": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#edit-a-hook",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "name": "Edit a hook",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
+          "name": "config",
+          "required": true,
+          "type": "object"
+        },
+        "3": {
+          "description": "The URL to which the payloads will be delivered.",
+          "name": "config.url",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "name": "config.content_type",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/webhooks/#delivery-headers) header.",
+          "name": "config.secret",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "name": "config.insecure_ssl",
+          "required": false,
+          "type": "string"
+        },
+        "7": {
+          "default": "[\"push\"]",
+          "description": "Determines what [events](/v3/activity/events/types/) the hook is triggered for.",
+          "name": "events",
+          "required": false,
+          "type": "array"
+        },
+        "8": {
+          "default": true,
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "name": "active",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/orgs/:org/hooks/:id"
+    },
+    "editTeam": {
+      "description": "To edit a team, the authenticated user must either be an owner of the org that the team is associated with, or a maintainer of the team.\n\n**Note:** With nested teams, the `privacy` for parent teams cannot be `secret`.",
+      "documentationUrl": "https://developer.github.com/v3/teams/#edit-team",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Edit team",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "The name of the team.",
+          "name": "name",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The description of the team.",
+          "name": "description",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "description": "The level of privacy this team should have. Editing teams without specifying this parameter leaves `privacy` intact. The options are:  \n**For a non-nested team:**  \n\\* `secret` \\- only visible to organization owners and members of this team.  \n\\* `closed` \\- visible to all members of this organization.  \n**For a parent or child team:**  \n\\* `closed` \\- visible to all members of this organization.",
+          "name": "privacy",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": "pull",
+          "description": "**Deprecated**. The permission that new repositories will be added to the team with when none is specified. Can be one of:  \n\\* `pull` \\- team members can pull, but not push to or administer newly-added repositories.  \n\\* `push` \\- team members can pull and push, but not administer newly-added repositories.  \n\\* `admin` \\- team members can pull, push and administer newly-added repositories.",
+          "enum": [
+            "pull",
+            "push",
+            "admin"
+          ],
+          "name": "permission",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "The ID of a team to set as the parent team. **Note**: You must pass the `hellcat-preview` media type to use this parameter.",
+          "name": "parent_team_id",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/teams/:id"
+    },
+    "get": {
+      "description": "**Note:** Many Organization response values require the user making the request to be authenticated, an organization owner, and have the admin:org scope authorized.",
+      "documentationUrl": "https://developer.github.com/v3/orgs/#get-an-organization",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get an organization",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org"
+    },
+    "getAll": {
+      "description": "Lists all organizations, in the order that they were created on GitHub.\n\n**Note:** Pagination is powered exclusively by the `since` parameter. Use the [Link header](/v3/#link-header) to get the URL for the next page of organizations.",
+      "documentationUrl": "https://developer.github.com/v3/orgs/#list-all-organizations",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List all organizations",
+      "params": {
+        "0": {
+          "description": "The integer ID of the last Organization that you've seen.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/organizations"
+    },
+    "getBlockedUsers": {
+      "description": "List the users blocked by an organization.",
+      "documentationUrl": "https://developer.github.com/v3/orgs/blocking/#list-blocked-users",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List blocked users",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/blocks"
+    },
+    "getChildTeams": {
+      "description": "At this time, the `hellcat-preview` media type is required to use this endpoint.\n\n",
+      "documentationUrl": "https://developer.github.com/v3/teams/#list-child-teams",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List child teams",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/teams/:id/teams"
+    },
+    "getForUser": {
+      "description": "List [public organization memberships](https://help.github.com/articles/publicizing-or-concealing-organization-membership) for the specified user.\n\nThis method only lists _public_ memberships, regardless of authentication. If you need to fetch all of the organization memberships (public and private) for the authenticated user, use the [List your organizations](#list-your-organizations) API instead.",
+      "documentationUrl": "https://developer.github.com/v3/orgs/#list-user-organizations",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List user organizations",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/users/:username/orgs"
+    },
+    "getHook": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#get-single-hook",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get single hook",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/hooks/:id"
+    },
+    "getHooks": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#list-hooks",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List hooks",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/orgs/:org/hooks"
+    },
+    "getMembers": {
+      "description": "List all users who are members of an organization. If the authenticated user is also a member of this organization then both concealed and public members will be returned.\n\n",
+      "documentationUrl": "https://developer.github.com/v3/orgs/members/#members-list",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Members list",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": "all",
+          "description": "Filter members returned in the list. Can be one of:  \n\\* `2fa_disabled` \\- Members without [two-factor authentication](https://github.com/blog/1614-two-factor-authentication) enabled. Available for organization owners.  \n\\* `all` \\- All members the authenticated user can see.",
+          "enum": [
+            "2fa_disabled",
+            "all"
+          ],
+          "name": "filter",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "default": "all",
+          "description": "Filter members returned by their role. Can be one of:  \n\\* `all` \\- All members of the organization, regardless of role.  \n\\* `admin` \\- Organization owners.  \n\\* `member` \\- Non-owner organization members.",
+          "enum": [
+            "all",
+            "admin",
+            "member"
+          ],
+          "name": "role",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/orgs/:org/members"
+    },
+    "getOrgMembership": {
+      "description": "In order to get a user's membership with an organization, the authenticated user must be an organization member.",
+      "documentationUrl": "https://developer.github.com/v3/orgs/members/#get-organization-membership",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get organization membership",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/memberships/:username"
+    },
+    "getOutsideCollaborators": {
+      "description": "List all users who are outside collaborators of an organization.\n\n",
+      "documentationUrl": "https://developer.github.com/v3/orgs/outside_collaborators/#list-outside-collaborators",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List outside collaborators",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": "all",
+          "description": "Filter the list of outside collaborators. Can be one of:  \n\\* `2fa_disabled`: Outside collaborators without [two-factor authentication](https://github.com/blog/1614-two-factor-authentication) enabled.  \n\\* `all`: All outside collaborators.",
+          "enum": [
+            "2fa_disabled",
+            "all"
+          ],
+          "name": "filter",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/orgs/:org/outside_collaborators"
+    },
+    "getPendingOrgInvites": {
+      "description": "The return hash contains a `role` field which refers to the Organization Invitation role and will be one of the following values: `direct_member`, `admin`, `billing_manager`, `hiring_manager`, or `reinstate`. If the invitee is not a GitHub member, the `login` field in the return hash will be `null`.",
+      "documentationUrl": "https://developer.github.com/v3/orgs/members/#list-pending-organization-invitations",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List pending organization invitations",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/orgs/:org/invitations"
+    },
+    "getPendingTeamInvites": {
+      "description": "The return hash contains a `role` field which refers to the Organization Invitation role and will be one of the following values: `direct_member`, `admin`, `billing_manager`, `hiring_manager`, or `reinstate`. If the invitee is not a GitHub member, the `login` field in the return hash will be `null`.",
+      "documentationUrl": "https://developer.github.com/v3/teams/members/#list-pending-team-invitations",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List pending team invitations",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/teams/:id/invitations"
+    },
+    "getPublicMembers": {
+      "description": "Members of an organization can choose to have their membership publicized or not.",
+      "documentationUrl": "https://developer.github.com/v3/orgs/members/#public-members-list",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Public members list",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/orgs/:org/public_members"
+    },
+    "getTeam": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/teams/#get-team",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get team",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/teams/:id"
+    },
+    "getTeamMembers": {
+      "description": "If you pass the `hellcat-preview` media type, team members will include the members of child teams.",
+      "documentationUrl": "https://developer.github.com/v3/teams/members/#list-team-members",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List team members",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": "all",
+          "description": "Filters members returned by their role in the team. Can be one of:  \n\\* `member` \\- normal members of the team.  \n\\* `maintainer` \\- team maintainers.  \n\\* `all` \\- all members of the team.",
+          "enum": [
+            "member",
+            "maintainer",
+            "all"
+          ],
+          "name": "role",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/teams/:id/members"
+    },
+    "getTeamMembership": {
+      "description": "If you pass the `hellcat-preview` media type, team members will include the members of child teams.\n\nTo get a user's membership with a team, the team must be visible to the authenticated user.\n\n**Note:** The `role` for organization owners returns as `maintainer`. For more information about `maintainer` roles, see [Create team](/v3/teams#create-team).",
+      "documentationUrl": "https://developer.github.com/v3/teams/members/#get-team-membership",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get team membership",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/teams/:id/memberships/:username"
+    },
+    "getTeamRepos": {
+      "description": "**Note**: If you pass the `hellcat-preview` media type, the response will include any repositories inherited through a parent team.",
+      "documentationUrl": "https://developer.github.com/v3/teams/#list-team-repos",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List team repos",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/teams/:id/repos"
+    },
+    "getTeams": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/teams/#list-teams",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List teams",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/orgs/:org/teams"
+    },
+    "pingHook": {
+      "description": "This will trigger a [ping event](/webhooks/#ping-event) to be sent to the hook.",
+      "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#ping-a-hook",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Ping a hook",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/hooks/:id/pings"
+    },
+    "publicizeMembership": {
+      "description": "The user can publicize their own membership. (A user cannot publicize the membership for another user.)\n\nNote that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](/v3/#http-verbs).\"",
+      "documentationUrl": "https://developer.github.com/v3/orgs/members/#publicize-a-users-membership",
+      "enabledForApps": false,
+      "method": "PUT",
+      "name": "Publicize a user's membership",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/public_members/:username"
+    },
+    "removeMember": {
+      "description": "Removing a user from this list will remove them from all teams and they will no longer have any access to the organization's repositories.",
+      "documentationUrl": "https://developer.github.com/v3/orgs/members/#remove-a-member",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Remove a member",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/members/:username"
+    },
+    "removeOrgMembership": {
+      "description": "In order to remove a user's membership with an organization, the authenticated user must be an organization owner.\n\nIf the specified user is an active member of the organization, this will remove them from the organization. If the specified user has been invited to the organization, this will cancel their invitation. The specified user will receive an email notification in both cases.",
+      "documentationUrl": "https://developer.github.com/v3/orgs/members/#remove-organization-membership",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Remove organization membership",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/memberships/:username"
+    },
+    "removeOutsideCollaborator": {
+      "description": "Removing a user from this list will remove them from all the organization's repositories.",
+      "documentationUrl": "https://developer.github.com/v3/orgs/outside_collaborators/#remove-outside-collaborator",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Remove outside collaborator",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/outside_collaborators/:username"
+    },
+    "removeTeamMembership": {
+      "description": "To remove a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. NOTE: This does not delete the user, it just removes their membership from the team.",
+      "documentationUrl": "https://developer.github.com/v3/teams/members/#remove-team-membership",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Remove team membership",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/teams/:id/memberships/:username"
+    },
+    "unblockUser": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/orgs/blocking/#unblock-a-user",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Unblock a user",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/orgs/:org/blocks/:username"
+    },
+    "update": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/orgs/#edit-an-organization",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "name": "Edit an organization",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "Billing email address. This address is not publicized.",
+          "name": "billing_email",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "description": "The company name.",
+          "name": "company",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "description": "The publicly visible email address.",
+          "name": "email",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "The location.",
+          "name": "location",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "The shorthand name of the company.",
+          "name": "name",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "The description of the company.",
+          "name": "description",
+          "required": false,
+          "type": "string"
+        },
+        "7": {
+          "description": "Toggles whether organization projects are enabled for the organization.",
+          "name": "has_organization_projects",
+          "required": false,
+          "type": "boolean"
+        },
+        "8": {
+          "description": "Toggles whether repository projects are enabled for repositories that belong to the organization.",
+          "name": "has_repository_projects",
+          "required": false,
+          "type": "boolean"
+        },
+        "9": {
+          "default": "read",
+          "description": "Default permission level members have for organization repositories:  \n\\* `read` \\- can pull, but not push to or administer this repository.  \n\\* `write` \\- can pull and push, but not administer this repository.  \n\\* `admin` \\- can pull, push, and administer this repository.  \n\\* `none` \\- no permissions granted by default.",
+          "name": "default_repository_permission",
+          "required": false,
+          "type": "string"
+        },
+        "10": {
+          "default": true,
+          "description": "Toggles ability of non-admin organization members to create repositories  \n\\* `true` \\- all organization members can create repositories.  \n\\* `false` \\- only admin members can create repositories.",
+          "name": "members_can_create_repositories",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/orgs/:org"
+    }
+  },
+  "projects": {
+    "createOrgProject": {
+      "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
+      "documentationUrl": "https://developer.github.com/v3/projects/#create-an-organization-project",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create an organization project",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "The name of the project.",
+          "name": "name",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The body of the project.",
+          "name": "body",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/orgs/:org/projects"
+    },
+    "createProjectCard": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/projects/cards/#create-a-project-card",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a project card",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "The card's note content. Only valid for cards without another type of content, so this must be omitted if `content_id` and `content_type` are specified.",
+          "name": "note",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "description": "The id of the issue to associate with this card.",
+          "name": "content_id",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "description": "**Required if you specify a content_id**. The type of content to associate with this card. Can only be \"Issue\" at this time.",
+          "name": "content_type",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/projects/columns/:id/cards"
+    },
+    "createProjectColumn": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/projects/columns/#create-a-project-column",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a project column",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "The name of the column.",
+          "name": "name",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/projects/:id/columns"
+    },
+    "createRepoProject": {
+      "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
+      "documentationUrl": "https://developer.github.com/v3/projects/#create-a-repository-project",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a repository project",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The name of the project.",
+          "name": "name",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The body of the project.",
+          "name": "body",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "5": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/projects"
+    },
+    "deleteProject": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/projects/#delete-a-project",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Delete a project",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/projects/:id"
+    },
+    "deleteProjectCard": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/projects/cards/#delete-a-project-card",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Delete a project card",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/projects/columns/cards/:id"
+    },
+    "deleteProjectColumn": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/projects/columns/#delete-a-project-column",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Delete a project column",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/projects/columns/:id"
+    },
+    "getOrgProjects": {
+      "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
+      "documentationUrl": "https://developer.github.com/v3/projects/#list-organization-projects",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List organization projects",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": "open",
+          "description": "Indicates the state of the projects to return. Can be either `open`, `closed`, or `all`.",
+          "enum": [
+            "open",
+            "closed",
+            "all"
+          ],
+          "name": "state",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/orgs/:org/projects"
+    },
+    "getProject": {
+      "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
+      "documentationUrl": "https://developer.github.com/v3/projects/#get-a-project",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a project",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/projects/:id"
+    },
+    "getProjectCard": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/projects/cards/#get-a-project-card",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a project card",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/projects/columns/cards/:id"
+    },
+    "getProjectCards": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/projects/cards/#list-project-cards",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List project cards",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/projects/columns/:id/cards"
+    },
+    "getProjectColumn": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/projects/columns/#get-a-project-column",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a project column",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/projects/columns/:id"
+    },
+    "getProjectColumns": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/projects/columns/#list-project-columns",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List project columns",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/projects/:id/columns"
+    },
+    "getRepoProjects": {
+      "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
+      "documentationUrl": "https://developer.github.com/v3/projects/#list-repository-projects",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List repository projects",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": "open",
+          "description": "Indicates the state of the projects to return. Can be either `open`, `closed`, or `all`.",
+          "enum": [
+            "open",
+            "closed",
+            "all"
+          ],
+          "name": "state",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/projects"
+    },
+    "moveProjectCard": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/projects/cards/#move-a-project-card",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Move a project card",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "Can be one of `top`, `bottom`, or `after:<card_id>`, where `<card_id>` is the `id` value of a card in the same column, or in the new column specified by `column_id`.",
+          "enum": [
+            "top",
+            "bottom",
+            "after:<card_id>"
+          ],
+          "name": "position",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The `id` value of a column in the same project.",
+          "name": "column_id",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/projects/columns/cards/:id/moves"
+    },
+    "moveProjectColumn": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/projects/columns/#move-a-project-column",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Move a project column",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "Can be one of `first`, `last`, or `after:<column_id>`, where `<column_id>` is the `id` value of a column in the same project.",
+          "enum": [
+            "first",
+            "last",
+            "after:<column_id>"
+          ],
+          "name": "position",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/projects/columns/:id/moves"
+    },
+    "updateProject": {
+      "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
+      "documentationUrl": "https://developer.github.com/v3/projects/#update-a-project",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Update a project",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "The name of the project.",
+          "name": "name",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "description": "The body of the project.",
+          "name": "body",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "description": "State of the project. Either `open` or `closed`.",
+          "enum": [
+            "open",
+            "closed"
+          ],
+          "name": "state",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "The permission level that all members of the project's organization will have on this project. If an organization member belongs to a team with a higher level of access or is a collaborator with a higher level of access, their permission level is not lowered by `organization_permission`. Updating a project's organization permission requires `admin` access to the project. Setting the organization permission is only available for organization projects.",
+          "name": "organization_permission",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "Sets visibility of the project within the organization. Updating a project's visibility requires `admin` access to the project. Setting visibility is only available for organization projects. Can be one of:  \n\\* `true` \\- Anyone that can view the organization can see the project.  \n\\* `false` \\- The project must be an organization project to set project visibility.",
+          "name": "public",
+          "required": false,
+          "type": "boolean"
+        },
+        "6": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "7": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/projects/:id"
+    },
+    "updateProjectCard": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/projects/cards/#update-a-project-card",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Update a project card",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "The card's note content. Only valid for cards without another type of content, so this cannot be specified if the card already has a `content_id` and `content_type`.",
+          "name": "note",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/projects/columns/cards/:id"
+    },
+    "updateProjectColumn": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/projects/columns/#update-a-project-column",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Update a project column",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "The new name of the column.",
+          "name": "name",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/projects/columns/:id"
+    }
+  },
+  "pullRequests": {
+    "checkMerged": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get if a pull request has been merged",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number/merge"
+    },
+    "create": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/pulls/#create-a-pull-request",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a pull request",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The title of the pull request.",
+          "name": "title",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The name of the branch where your changes are implemented. For cross-repository pull requests in the same network, namespace `head` with a user like this: `username:branch`.",
+          "name": "head",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "description": "The name of the branch you want the changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repository that requests a merge to a base of another repository.",
+          "name": "base",
+          "required": true,
+          "type": "string"
+        },
+        "5": {
+          "description": "The contents of the pull request.",
+          "name": "body",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "Indicates whether [maintainers can modify](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) the pull request.",
+          "name": "maintainer_can_modify",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls"
+    },
+    "createComment": {
+      "description": "**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
+      "documentationUrl": "https://developer.github.com/v3/pulls/comments/#create-a-comment",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "The text of the comment.",
+          "name": "body",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "description": "The SHA of the commit needing a comment. Not using the latest commit SHA may render your comment outdated if a subsequent commit modifies the line you specify as the `position`.",
+          "name": "commit_id",
+          "required": true,
+          "type": "string"
+        },
+        "5": {
+          "description": "The relative path to the file that necessitates a comment.",
+          "name": "path",
+          "required": true,
+          "type": "string"
+        },
+        "6": {
+          "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
+          "name": "position",
+          "required": true,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number/comments"
+    },
+    "createCommentReply": {
+      "description": "**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
+      "documentationUrl": "https://developer.github.com/v3/pulls/comments/#create-a-comment",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "The text of the comment.",
+          "name": "body",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "description": "The SHA of the commit needing a comment. Not using the latest commit SHA may render your comment outdated if a subsequent commit modifies the line you specify as the `position`.",
+          "name": "commit_id",
+          "required": true,
+          "type": "string"
+        },
+        "5": {
+          "description": "The relative path to the file that necessitates a comment.",
+          "name": "path",
+          "required": true,
+          "type": "string"
+        },
+        "6": {
+          "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
+          "name": "position",
+          "required": true,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number/comments"
+    },
+    "createFromIssue": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/pulls/#create-a-pull-request",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a pull request",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The title of the pull request.",
+          "name": "title",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The name of the branch where your changes are implemented. For cross-repository pull requests in the same network, namespace `head` with a user like this: `username:branch`.",
+          "name": "head",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "description": "The name of the branch you want the changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repository that requests a merge to a base of another repository.",
+          "name": "base",
+          "required": true,
+          "type": "string"
+        },
+        "5": {
+          "description": "The contents of the pull request.",
+          "name": "body",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "Indicates whether [maintainers can modify](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) the pull request.",
+          "name": "maintainer_can_modify",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls"
+    },
+    "createReview": {
+      "description": "**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
+      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a pull request review",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
+          "name": "commit_id",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
+          "name": "body",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
+          "enum": [
+            "APPROVE",
+            "REQUEST_CHANGES",
+            "COMMENT"
+          ],
+          "name": "event",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
+          "name": "comments",
+          "required": false,
+          "type": "array of draft review comment objects"
+        },
+        "7": {
+          "description": "**Required.** The relative path to the file that necessitates a review comment.",
+          "name": "comments.path",
+          "required": false,
+          "type": "string"
+        },
+        "8": {
+          "description": "**Required.** The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
+          "name": "comments.position",
+          "required": false,
+          "type": "integer"
+        },
+        "9": {
+          "description": "**Required.** Text of the review comment.",
+          "name": "comments.body",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number/reviews"
+    },
+    "createReviewRequest": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/pulls/review_requests/#create-a-review-request",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Create a review request",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "An array of user `login`s that will be requested.",
+          "name": "reviewers",
+          "required": false,
+          "type": "array of strings"
+        },
+        "4": {
+          "description": "An array of team `slug`s that will be requested.",
+          "name": "team_reviewers",
+          "required": false,
+          "type": "array of strings"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number/requested_reviewers"
+    },
+    "deleteComment": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/pulls/comments/#delete-a-comment",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Delete a comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/comments/:id"
+    },
+    "deletePendingReview": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#delete-a-pending-review",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Delete a pending review",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:id"
+    },
+    "deleteReviewRequest": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/pulls/review_requests/#delete-a-review-request",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Delete a review request",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "An array of user `login`s that will be removed.",
+          "name": "reviewers",
+          "required": false,
+          "type": "array of strings"
+        },
+        "4": {
+          "description": "An array of team `slug`s that will be removed.",
+          "name": "team_reviewers",
+          "required": false,
+          "type": "array of strings"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number/requested_reviewers"
+    },
+    "dismissReview": {
+      "description": "**Note:** To dismiss a pull request review on a [protected branch](/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
+      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#dismiss-a-pull-request-review",
+      "enabledForApps": false,
+      "method": "PUT",
+      "name": "Dismiss a pull request review",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "description": "**Required.** The message for the pull request review dismissal",
+          "name": "message",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:id/dismissals"
+    },
+    "editComment": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/pulls/comments/#edit-a-comment",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Edit a comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The text of the comment.",
+          "name": "body",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/comments/:id"
+    },
+    "get": {
+      "description": "Each time the pull request receives new commits, GitHub creates a merge commit to _test_ whether the pull request can be automatically merged into the base branch. (This _test_ commit is not added to the base branch or the head branch.)\n\nThe value of the `merge_commit_sha` attribute changes depending on the state of the pull request. Before a pull request is merged, the `merge_commit_sha` attribute holds the SHA of the _test_ merge commit. After a pull request is merged, the attribute changes depending on how the pull request was merged:\n\n*   If the pull request was merged as a merge commit, the attribute represents the SHA of the merge commit.\n*   If the pull request was merged via a squash, the attribute represents the SHA of the squashed commit on the base branch.\n*   If the pull request was rebased, the attribute represents the commit that the base branch was updated to.\n\nThe value of the `mergeable` attribute can be `true`, `false`, or `null`. If the value is `null`, this means that the mergeability hasn't been computed yet, and a background job was started to compute it. Give the job a few moments to complete, and then submit the request again. When the job is complete, the response will include a non-`null` value for the `mergeable` attribute.\n\nPass the appropriate [media type](/v3/media/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.",
+      "documentationUrl": "https://developer.github.com/v3/pulls/#get-a-single-pull-request",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a single pull request",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number"
+    },
+    "getAll": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/pulls/#list-pull-requests",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List pull requests",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": "open",
+          "description": "Either `open`, `closed`, or `all` to filter by state.",
+          "enum": [
+            "open",
+            "closed",
+            "all"
+          ],
+          "name": "state",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "description": "Filter pulls by head user and branch name in the format of `user:ref-name`. Example: `github:new-script-format`.",
+          "name": "head",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "Filter pulls by base branch name. Example: `gh-pages`.",
+          "name": "base",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "default": "created",
+          "description": "What to sort results by. Can be either `created`, `updated`, `popularity` (comment count) or `long-running` (age, filtering by pulls updated in the last month).",
+          "enum": [
+            "created",
+            "updated",
+            "popularity",
+            "long-running"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "default": "`desc` when sort is `created` or sort is not specified, otherwise `asc`",
+          "description": "The direction of the sort. Can be either `asc` or `desc`.",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "direction",
+          "required": false,
+          "type": "string"
+        },
+        "7": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "8": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls"
+    },
+    "getComment": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/pulls/comments/#get-a-single-comment",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a single comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/comments/:id"
+    },
+    "getComments": {
+      "description": "By default, review comments are ordered by ascending ID.",
+      "documentationUrl": "https://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List comments on a pull request",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "default": "created",
+          "description": "Can be either `created` or `updated` comments.",
+          "enum": [
+            "created",
+            "updated"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "Can be either `asc` or `desc`. Ignored without `sort` parameter.",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "direction",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Only returns comments `updated` at or after this time.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "7": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number/comments"
+    },
+    "getCommentsForRepo": {
+      "description": "By default, review comments are ordered by ascending ID.",
+      "documentationUrl": "https://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List comments in a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": "created",
+          "description": "Can be either `created` or `updated` comments.",
+          "enum": [
+            "created",
+            "updated"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "description": "Can be either `asc` or `desc`. Ignored without `sort` parameter.",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "direction",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Only returns comments `updated` at or after this time.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "6": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/comments"
+    },
+    "getCommits": {
+      "description": "**Note:** The response includes a maximum of 250 commits. To receive a complete commit list for pull requests with more than 250 commits, use the [Commit List API](/v3/repos/commits/#list-commits-on-a-repository).",
+      "documentationUrl": "https://developer.github.com/v3/pulls/#list-commits-on-a-pull-request",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List commits on a pull request",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number/commits"
+    },
+    "getFiles": {
+      "description": "**Note:** The response includes a maximum of 300 files.",
+      "documentationUrl": "https://developer.github.com/v3/pulls/#list-pull-requests-files",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List pull requests files",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number/files"
+    },
+    "getReview": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#get-a-single-review",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a single review",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:id"
+    },
+    "getReviewComments": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get comments for a single review",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "5": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:id/comments"
+    },
+    "getReviewRequests": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/pulls/review_requests/#list-review-requests",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List review requests",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number/requested_reviewers"
+    },
+    "getReviews": {
+      "description": "The list of reviews returns in chronological order.",
+      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List reviews on a pull request",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number/reviews"
+    },
+    "merge": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button",
+      "enabledForApps": false,
+      "method": "PUT",
+      "name": "Merge a pull request (Merge Button)",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "Title for the automatic commit message.",
+          "name": "commit_title",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "Extra detail to append to automatic commit message.",
+          "name": "commit_message",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "SHA that pull request head must match to allow merge.",
+          "name": "sha",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "Merge method to use. Possible values are `merge`, `squash` or `rebase`. Default is `merge`.",
+          "enum": [
+            "merge",
+            "squash",
+            "rebase"
+          ],
+          "name": "merge_method",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number/merge"
+    },
+    "submitReview": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Submit a pull request review",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "description": "The body text of the pull request review",
+          "name": "body",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "**Required.** The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
+          "enum": [
+            "APPROVE",
+            "REQUEST_CHANGES",
+            "COMMENT"
+          ],
+          "name": "event",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:id/events"
+    },
+    "update": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/pulls/#update-a-pull-request",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Update a pull request",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "The title of the pull request.",
+          "name": "title",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "The contents of the pull request.",
+          "name": "body",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "State of this Pull Request. Either `open` or `closed`.",
+          "enum": [
+            "open",
+            "closed"
+          ],
+          "name": "state",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "The name of the branch you want your changes pulled into. This should be an existing branch on the current repository. You cannot update the base branch on a pull request to point to another repository.",
+          "name": "base",
+          "required": false,
+          "type": "string"
+        },
+        "7": {
+          "description": "Indicates whether [maintainers can modify](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) the pull request.",
+          "name": "maintainer_can_modify",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/:number"
+    }
+  },
+  "reactions": {
+    "createForCommitComment": {
+      "description": "Create a reaction to a [commit comment](/v3/repos/comments/). A response with a `Status: 200 OK` means that you already added the reaction type to this commit comment.",
+      "documentationUrl": "https://developer.github.com/v3/reactions/#create-reaction-for-a-commit-comment",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Create reaction for a commit comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The [reaction type](/v3/reactions/#reaction-types) to add to the commit comment.",
+          "name": "content",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/comments/:id/reactions"
+    },
+    "createForIssue": {
+      "description": "Create a reaction to an [issue](/v3/issues/). A response with a `Status: 200 OK` means that you already added the reaction type to this issue.",
+      "documentationUrl": "https://developer.github.com/v3/reactions/#create-reaction-for-an-issue",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Create reaction for an issue",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "The [reaction type](/v3/reactions/#reaction-types) to add to the issue.",
+          "name": "content",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/:number/reactions"
+    },
+    "createForIssueComment": {
+      "description": "Create a reaction to an [issue comment](/v3/issues/comments/). A response with a `Status: 200 OK` means that you already added the reaction type to this issue comment.",
+      "documentationUrl": "https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Create reaction for an issue comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The [reaction type](/v3/reactions/#reaction-types) to add to the issue comment.",
+          "name": "content",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/comments/:id/reactions"
+    },
+    "createForPullRequestReviewComment": {
+      "description": "Create a reaction to a [pull request review comment](/v3/pulls/comments/). A response with a `Status: 200 OK` means that you already added the reaction type to this pull request review comment.",
+      "documentationUrl": "https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-review-comment",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Create reaction for a pull request review comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The [reaction type](/v3/reactions/#reaction-types) to add to the pull request review comment.",
+          "name": "content",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/comments/:id/reactions"
+    },
+    "delete": {
+      "description": "OAuth access tokens require the `read:discussion` [scope](/apps/building-oauth-apps/scopes-for-oauth-apps/), when deleting a [team discussion](/v3/teams/discussions/) or [team discussion comment](/v3/teams/discussion_comments/).",
+      "documentationUrl": "https://developer.github.com/v3/reactions/#delete-a-reaction",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Delete a reaction",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/reactions/:id"
+    },
+    "getForCommitComment": {
+      "description": "List the reactions to a [commit comment](/v3/repos/comments/).",
+      "documentationUrl": "https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List reactions for a commit comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "Returns a single [reaction type](/v3/reactions/#reaction-types). Omit this parameter to list all reactions to a commit comment.",
+          "name": "content",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "5": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/comments/:id/reactions"
+    },
+    "getForIssue": {
+      "description": "List the reactions to an [issue](/v3/issues/).",
+      "documentationUrl": "https://developer.github.com/v3/reactions/#list-reactions-for-an-issue",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List reactions for an issue",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "number",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "Returns a single [reaction type](/v3/reactions/#reaction-types). Omit this parameter to list all reactions to an issue.",
+          "name": "content",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "5": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/:number/reactions"
+    },
+    "getForIssueComment": {
+      "description": "List the reactions to an [issue comment](/v3/issues/comments/).",
+      "documentationUrl": "https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List reactions for an issue comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "Returns a single [reaction type](/v3/reactions/#reaction-types). Omit this parameter to list all reactions to an issue comment.",
+          "name": "content",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "5": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/issues/comments/:id/reactions"
+    },
+    "getForPullRequestReviewComment": {
+      "description": "List the reactions to a [pull request review comment](/v3/pulls/comments/).",
+      "documentationUrl": "https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List reactions for a pull request review comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "Returns a single [reaction type](/v3/reactions/#reaction-types). Omit this parameter to list all reactions to a pull request review comment.",
+          "name": "content",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "5": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/pulls/comments/:id/reactions"
+    }
+  },
+  "repos": {
+    "addCollaborator": {
+      "description": "Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](/v3/#http-verbs).\"\n\nThe invitee will receive a notification that they have been invited to the repository, which they must accept or decline. They may do this via the notifications page, the email they receive, or by using the [repository invitations API endpoints](/v3/repos/invitations/).\n\n**Rate limits**\n\nTo prevent abuse, you are limited to sending 50 invitations to a repository per 24 hour period. Note there is no limit if you are inviting organization members to an organization repository.",
+      "documentationUrl": "https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator",
+      "enabledForApps": true,
+      "method": "PUT",
+      "name": "Add user as a collaborator",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "default": "push",
+          "description": "The permission to grant the collaborator. **Only valid on organization-owned repositories.** Can be one of:  \n\\* `pull` \\- can pull, but not push to or administer this repository.  \n\\* `push` \\- can pull and push, but not administer this repository.  \n\\* `admin` \\- can pull, push and administer this repository.",
+          "enum": [
+            "pull",
+            "push",
+            "admin"
+          ],
+          "name": "permission",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/collaborators/:username"
+    },
+    "addDeployKey": {
+      "description": "Here's how you can create a read-only deploy key:\n\n",
+      "documentationUrl": "https://developer.github.com/v3/repos/keys/#add-a-new-deploy-key",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Add a new deploy key",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "A name for the key.",
+          "name": "title",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "description": "The contents of the key.",
+          "name": "key",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.",
+          "name": "read_only",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/repos/:owner/:repo/keys"
+    },
+    "addProtectedBranchAdminEnforcement": {
+      "description": "Adding admin enforcement requires admin or owner permissions to the repository and branch protection to be enabled.",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#add-admin-enforcement-of-protected-branch",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Add admin enforcement of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins"
+    },
+    "addProtectedBranchRequiredStatusChecksContexts": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#add-required-status-checks-contexts-of-protected-branch",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Add required status checks contexts of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
+    },
+    "addProtectedBranchTeamRestrictions": {
+      "description": "Pass the list of team `slug`s with push access.\n\n**Note**: The list of users and teams in total is limited to 100 items.",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#add-team-restrictions-of-protected-branch",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Add team restrictions of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
+    },
+    "addProtectedBranchUserRestrictions": {
+      "description": "Pass the list of user `login`s with push access.\n\n**Note**: The list of users and teams in total is limited to 100 items.",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#add-user-restrictions-of-protected-branch",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Add user restrictions of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
+    },
+    "checkCollaborator": {
+      "description": "For organization-owned repositories, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners.\n\nIf you pass the `hellcat-preview` media type, team members will include the members of child teams.",
+      "documentationUrl": "https://developer.github.com/v3/repos/collaborators/#check-if-a-user-is-a-collaborator",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Check if a user is a collaborator",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/collaborators/:username"
+    },
+    "compareCommits": {
+      "description": "Both `:base` and `:head` must be branch names in `:repo`. To compare branches across other repositories in the same network as `:repo`, use the format `<USERNAME>:branch`. For example:\n\n```\nGET /repos/:owner/:repo/compare/hubot:branchname...octocat:branchname\n```\n\nThe response from the API is equivalent to running the `git log base..head` command; however, commits are returned in reverse chronological order.\n\nPass the appropriate [media type](/v3/media/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.\n\n**Working with large comparisons**\n\nThe response will include a comparison of up to 250 commits. If you are working with a larger commit range, you can use the [Commit List API](/v3/repos/commits/#list-commits-on-a-repository) to enumerate all commits in the range.\n\nFor comparisons with extremely large diffs, you may receive an error response indicating that the diff took too long to generate. You can typically resolve this error by using a smaller commit range.",
+      "documentationUrl": "https://developer.github.com/v3/repos/commits/#compare-two-commits",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Compare two commits",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "base",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "",
+          "name": "head",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/compare/:base...:head"
+    },
+    "create": {
+      "description": "**Note**: There are two endpoints for creating a repository: one to create a repository on a user account, and one to create a repository in an organization. The organization endpoint is fully enabled for [GitHub Apps](/v3/apps/available-endpoints/), whereas the user endpoint is enabled only for [user-to-server requests](/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#user-to-server-requests).\n\n**OAuth scope requirements**\n\nWhen using [OAuth](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/), authorizations must include:\n\n*   `public_repo` scope or `repo` scope to create a public repository\n*   `repo` scope to create a private repository",
+      "documentationUrl": "https://developer.github.com/v3/repos/#create",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a new repository for the authenticated user",
+      "params": {
+        "0": {
+          "description": "The name of the repository.",
+          "name": "name",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "A short description of the repository.",
+          "name": "description",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "description": "A URL with more information about the repository.",
+          "name": "homepage",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": false,
+          "description": "Either `true` to create a private repository or `false` to create a public one. Creating private repositories requires a paid GitHub account.",
+          "name": "private",
+          "required": false,
+          "type": "boolean"
+        },
+        "4": {
+          "default": true,
+          "description": "Either `true` to enable issues for this repository or `false` to disable them.",
+          "name": "has_issues",
+          "required": false,
+          "type": "boolean"
+        },
+        "5": {
+          "default": true,
+          "description": "Either `true` to enable projects for this repository or `false` to disable them. **Note:** If you're creating a repository in an organization that has disabled repository projects, the default is `false`, and if you pass `true`, the API returns an error.",
+          "name": "has_projects",
+          "required": false,
+          "type": "boolean"
+        },
+        "6": {
+          "default": true,
+          "description": "Either `true` to enable the wiki for this repository or `false` to disable it.",
+          "name": "has_wiki",
+          "required": false,
+          "type": "boolean"
+        },
+        "7": {
+          "description": "The id of the team that will be granted access to this repository. This is only valid when creating a repository in an organization.",
+          "name": "team_id",
+          "required": false,
+          "type": "integer"
+        },
+        "8": {
+          "default": false,
+          "description": "Pass `true` to create an initial commit with empty README.",
+          "name": "auto_init",
+          "required": false,
+          "type": "boolean"
+        },
+        "9": {
+          "description": "Desired language or platform [.gitignore template](https://github.com/github/gitignore) to apply. Use the name of the template without the extension. For example, \"Haskell\".",
+          "name": "gitignore_template",
+          "required": false,
+          "type": "string"
+        },
+        "10": {
+          "description": "Choose an [open source license template](https://choosealicense.com/) that best suits your needs, and then use the [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type) as the `license_template` string. For example, \"mit\" or \"mpl-2.0\".",
+          "name": "license_template",
+          "required": false,
+          "type": "string"
+        },
+        "11": {
+          "default": true,
+          "description": "Either `true` to allow squash-merging pull requests, or `false` to prevent squash-merging.",
+          "name": "allow_squash_merge",
+          "required": false,
+          "type": "boolean"
+        },
+        "12": {
+          "default": true,
+          "description": "Either `true` to allow merging pull requests with a merge commit, or `false` to prevent merging pull requests with merge commits.",
+          "name": "allow_merge_commit",
+          "required": false,
+          "type": "boolean"
+        },
+        "13": {
+          "default": true,
+          "description": "Either `true` to allow rebase-merging pull requests, or `false` to prevent rebase-merging.",
+          "name": "allow_rebase_merge",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/user/repos"
+    },
+    "createCommitComment": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/comments/#create-a-commit-comment",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a commit comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "sha",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The contents of the comment.",
+          "name": "body",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "description": "Relative path of the file to comment on.",
+          "name": "path",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "Line index in the diff to comment on.",
+          "name": "position",
+          "required": false,
+          "type": "integer"
+        },
+        "6": {
+          "description": "**Deprecated**. Use **position** parameter instead. Line number in the file to comment on.",
+          "name": "line",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/commits/:sha/comments"
+    },
+    "createDeployment": {
+      "description": "Deployments offer a few configurable parameters with sane defaults.\n\nThe `ref` parameter can be any named branch, tag, or SHA. At GitHub we often deploy branches and verify them before we merge a pull request.\n\nThe `environment` parameter allows deployments to be issued to different runtime environments. Teams often have multiple environments for verifying their applications, such as `production`, `staging`, and `qa`. This allows for easy tracking of which environments had deployments requested. The default environment is `production`.\n\nThe `auto_merge` parameter is used to ensure that the requested ref is not behind the repository's default branch. If the ref _is_ behind the default branch for the repository, we will attempt to merge it for you. If the merge succeeds, the API will return a successful merge commit. If merge conflicts prevent the merge from succeeding, the API will return a failure response.\n\nBy default, [commit statuses](/v3/repos/statuses) for every submitted context must be in a `success` state. The `required_contexts` parameter allows you to specify a subset of contexts that must be `success`, or to specify contexts that have not yet been submitted. You are not required to use commit statuses to deploy. If you do not require any contexts or create any commit statuses, the deployment will always succeed.\n\nThe `payload` parameter is available for any extra information that a deployment system might need. It is a JSON text field that will be passed on when a deployment event is dispatched.\n\nThe `task` parameter is used by the deployment system to allow different execution paths. In the web world this might be `deploy:migrations` to run schema changes on the system. In the compiled world this could be a flag to compile an application with debugging enabled.\n\nUsers with `repo` or `repo_deployment` scopes can create a deployment for a given ref:\n\nA simple example putting the user and room into the payload to notify back to chat networks.\n\nA more advanced example specifying required commit statuses and bypassing auto-merging.\n\nThis error happens when the `auto_merge` option is enabled and when the default branch (in this case `master`), can't be merged into the branch that's being deployed (in this case `topic-branch`), due to merge conflicts.\n\nThis error happens when the `required_contexts` parameter indicates that one or more contexts need to have a `success` status for the commit to be deployed, but one or more of the required contexts do not have a state of `success`.",
+      "documentationUrl": "https://developer.github.com/v3/repos/deployments/#create-a-deployment",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a deployment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The ref to deploy. This can be a branch, tag, or SHA.",
+          "name": "ref",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "default": "deploy",
+          "description": "Specifies a task to execute (e.g., `deploy` or `deploy:migrations`).",
+          "name": "task",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": true,
+          "description": "Attempts to automatically merge the default branch into the requested ref, if it is behind the default branch.",
+          "name": "auto_merge",
+          "required": false,
+          "type": "boolean"
+        },
+        "5": {
+          "description": "The status contexts to verify against commit status checks. If this parameter is omitted, then all unique contexts will be verified before a deployment is created. To bypass checking entirely pass an empty array. Defaults to all unique contexts.",
+          "name": "required_contexts",
+          "required": false,
+          "type": "array"
+        },
+        "6": {
+          "default": "\"\"",
+          "description": "JSON payload with extra information about the deployment.",
+          "name": "payload",
+          "required": false,
+          "type": "string"
+        },
+        "7": {
+          "default": "production",
+          "description": "Name for the target deployment environment (e.g., `production`, `staging`, `qa`).",
+          "name": "environment",
+          "required": false,
+          "type": "string"
+        },
+        "8": {
+          "default": "\"\"",
+          "description": "Short description of the deployment.",
+          "name": "description",
+          "required": false,
+          "type": "string"
+        },
+        "9": {
+          "default": false,
+          "description": "Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future. **This parameter requires a custom media type to be specified. Please see more in the alert below.**",
+          "name": "transient_environment",
+          "required": false,
+          "type": "boolean"
+        },
+        "10": {
+          "default": "`true` when `environment` is `production` and `false` otherwise",
+          "description": "Specifies if the given environment is one that end-users directly interact with. **This parameter requires a custom media type to be specified. Please see more in the alert below.**",
+          "name": "production_environment",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/repos/:owner/:repo/deployments"
+    },
+    "createDeploymentStatus": {
+      "description": "Users with push access can create deployment statuses for a given deployment:",
+      "documentationUrl": "https://developer.github.com/v3/repos/deployments/#create-a-deployment-status",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a deployment status",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The state of the status. Can be one of `error`, `failure`, `inactive`, `pending`, or `success`. **The `inactive` state requires a custom media type to be specified. Please see more in the alert below.**",
+          "enum": [
+            "error",
+            "failure",
+            "inactive",
+            "pending",
+            "success"
+          ],
+          "name": "state",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "default": "\"\"",
+          "description": "The target URL to associate with this status. This URL should contain output to keep the user updated while the task is running or serve as historical information for what happened in the deployment.",
+          "name": "target_url",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "default": "\"\"",
+          "description": "This is functionally equivalent to `target_url`. We will continue accept `target_url` to support legacy uses, but we recommend modifying this to the new name to avoid confusion. **This parameter requires a custom media type to be specified. Please see more in the alert below.**",
+          "name": "log_url",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "default": "\"\"",
+          "description": "A short description of the status. Maximum length of 140 characters.",
+          "name": "description",
+          "required": false,
+          "type": "string"
+        },
+        "7": {
+          "default": "\"\"",
+          "description": "Sets the URL for accessing your environment. **This parameter requires a custom media type to be specified. Please see more in the alert below.**",
+          "name": "environment_url",
+          "required": false,
+          "type": "string"
+        },
+        "8": {
+          "default": true,
+          "description": "Adds a new `inactive` status to all non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment. **This parameter requires a custom media type to be specified. Please see more in the alert below.**",
+          "name": "auto_inactive",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/repos/:owner/:repo/deployments/:id/statuses"
+    },
+    "createFile": {
+      "description": "This method creates a new file in a repository\n\nThe `author` section is optional and is filled in with the `committer` information if omitted. If the `committer` information is omitted, the authenticated user's information is used.\n\nYou must provide values for both `name` and `email`, whether you choose to use `author` or `committer`. Otherwise, you'll receive a `422` status code.\n\nBoth the `author` and `committer` parameters have the same keys:\n\n| name  | type   | description                                          |\n| ----- | ------ | ---------------------------------------------------- |\n| name  | string | The name of the author (or committer) of the commit  |\n| email | string | The email of the author (or committer) of the commit |",
+      "documentationUrl": "https://developer.github.com/v3/repos/contents/#create-a-file",
+      "enabledForApps": true,
+      "method": "PUT",
+      "name": "Create a file",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The content path.",
+          "name": "path",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The commit message.",
+          "name": "message",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "description": "The new file content, Base64 encoded.",
+          "name": "content",
+          "required": true,
+          "type": "string"
+        },
+        "5": {
+          "default": "the repository’s default branch (usually `master`)",
+          "description": "The branch name.",
+          "name": "branch",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "object containing information about the committer.",
+          "name": "committer",
+          "type": "object"
+        },
+        "7": {
+          "description": "object containing information about the author.",
+          "name": "author",
+          "type": "object"
+        }
+      },
+      "path": "/repos/:owner/:repo/contents/:path"
+    },
+    "createForOrg": {
+      "description": "**Note**: There are two endpoints for creating a repository: one to create a repository on a user account, and one to create a repository in an organization. The organization endpoint is fully enabled for [GitHub Apps](/v3/apps/available-endpoints/), whereas the user endpoint is enabled only for [user-to-server requests](/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#user-to-server-requests).\n\n**OAuth scope requirements**\n\nWhen using [OAuth](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/), authorizations must include:\n\n*   `public_repo` scope or `repo` scope to create a public repository\n*   `repo` scope to create a private repository",
+      "documentationUrl": "https://developer.github.com/v3/repos/#create",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a new repository in this organization",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "The name of the repository.",
+          "name": "name",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "A short description of the repository.",
+          "name": "description",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "description": "A URL with more information about the repository.",
+          "name": "homepage",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": false,
+          "description": "Either `true` to create a private repository or `false` to create a public one. Creating private repositories requires a paid GitHub account.",
+          "name": "private",
+          "required": false,
+          "type": "boolean"
+        },
+        "5": {
+          "default": true,
+          "description": "Either `true` to enable issues for this repository or `false` to disable them.",
+          "name": "has_issues",
+          "required": false,
+          "type": "boolean"
+        },
+        "6": {
+          "default": true,
+          "description": "Either `true` to enable projects for this repository or `false` to disable them. **Note:** If you're creating a repository in an organization that has disabled repository projects, the default is `false`, and if you pass `true`, the API returns an error.",
+          "name": "has_projects",
+          "required": false,
+          "type": "boolean"
+        },
+        "7": {
+          "default": true,
+          "description": "Either `true` to enable the wiki for this repository or `false` to disable it.",
+          "name": "has_wiki",
+          "required": false,
+          "type": "boolean"
+        },
+        "8": {
+          "description": "The id of the team that will be granted access to this repository. This is only valid when creating a repository in an organization.",
+          "name": "team_id",
+          "required": false,
+          "type": "integer"
+        },
+        "9": {
+          "default": false,
+          "description": "Pass `true` to create an initial commit with empty README.",
+          "name": "auto_init",
+          "required": false,
+          "type": "boolean"
+        },
+        "10": {
+          "description": "Desired language or platform [.gitignore template](https://github.com/github/gitignore) to apply. Use the name of the template without the extension. For example, \"Haskell\".",
+          "name": "gitignore_template",
+          "required": false,
+          "type": "string"
+        },
+        "11": {
+          "description": "Choose an [open source license template](https://choosealicense.com/) that best suits your needs, and then use the [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type) as the `license_template` string. For example, \"mit\" or \"mpl-2.0\".",
+          "name": "license_template",
+          "required": false,
+          "type": "string"
+        },
+        "12": {
+          "default": true,
+          "description": "Either `true` to allow squash-merging pull requests, or `false` to prevent squash-merging.",
+          "name": "allow_squash_merge",
+          "required": false,
+          "type": "boolean"
+        },
+        "13": {
+          "default": true,
+          "description": "Either `true` to allow merging pull requests with a merge commit, or `false` to prevent merging pull requests with merge commits.",
+          "name": "allow_merge_commit",
+          "required": false,
+          "type": "boolean"
+        },
+        "14": {
+          "default": true,
+          "description": "Either `true` to allow rebase-merging pull requests, or `false` to prevent rebase-merging.",
+          "name": "allow_rebase_merge",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/orgs/:org/repos"
+    },
+    "createHook": {
+      "description": "**Note**: Repository service hooks (like email or Campfire) can have at most one configured at a time. Creating hooks for a service that already has one configured will [update the existing hook](#edit-a-hook).\n\nRepositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\nHere's how you can create a hook that posts payloads in JSON format:",
+      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#create-a-hook",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Create a hook",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "Must be passed as \"web\".",
+          "name": "name",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "name": "config",
+          "required": true,
+          "type": "object"
+        },
+        "4": {
+          "description": "The URL to which the payloads will be delivered.",
+          "name": "config.url",
+          "required": true,
+          "type": "string"
+        },
+        "5": {
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "name": "config.content_type",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/webhooks/#delivery-headers) header.",
+          "name": "config.secret",
+          "required": false,
+          "type": "string"
+        },
+        "7": {
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "name": "config.insecure_ssl",
+          "required": false,
+          "type": "string"
+        },
+        "8": {
+          "default": "[\"push\"]",
+          "description": "Determines what [events](/v3/activity/events/types/) the hook is triggered for.",
+          "name": "events",
+          "required": false,
+          "type": "array"
+        },
+        "9": {
+          "default": true,
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "name": "active",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/repos/:owner/:repo/hooks"
+    },
+    "createRelease": {
+      "description": "Users with push access to the repository can create a release.",
+      "documentationUrl": "https://developer.github.com/v3/repos/releases/#create-a-release",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a release",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The name of the tag.",
+          "name": "tag_name",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "default": "the repository's default branch (usually `master`).",
+          "description": "Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists.",
+          "name": "target_commitish",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "The name of the release.",
+          "name": "name",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "Text describing the contents of the tag.",
+          "name": "body",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "default": false,
+          "description": "`true` to create a draft (unpublished) release, `false` to create a published one.",
+          "name": "draft",
+          "required": false,
+          "type": "boolean"
+        },
+        "7": {
+          "default": false,
+          "description": "`true` to identify the release as a prerelease. `false` to identify the release as a full release.",
+          "name": "prerelease",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/repos/:owner/:repo/releases"
+    },
+    "createStatus": {
+      "description": "Users with push access can create commit statuses for a given ref:\n\nNote: there is a limit of 1000 statuses per `sha` and `context` within a repository. Attempts to create more than 1000 statuses will result in a validation error.",
+      "documentationUrl": "https://developer.github.com/v3/repos/statuses/#create-a-status",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a status",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "sha",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The state of the status. Can be one of `error`, `failure`, `pending`, or `success`.",
+          "enum": [
+            "error",
+            "failure",
+            "pending",
+            "success"
+          ],
+          "name": "state",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "description": "The target URL to associate with this status. This URL will be linked from the GitHub UI to allow users to easily see the source of the status.  \nFor example, if your continuous integration system is posting build status, you would want to provide the deep link for the build output for this specific SHA:  \n`http://ci.example.com/user/repo/build/sha`",
+          "name": "target_url",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "A short description of the status.",
+          "name": "description",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "default": "default",
+          "description": "A string label to differentiate this status from the status of other systems.",
+          "name": "context",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/statuses/:sha"
+    },
+    "delete": {
+      "description": "Deleting a repository requires admin access. If OAuth is used, the `delete_repo` scope is required.\n\nIf an organization owner has configured the organization to prevent members from deleting organization-owned repositories, a member will get this response:",
+      "documentationUrl": "https://developer.github.com/v3/repos/#delete-a-repository",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Delete a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo"
+    },
+    "deleteAsset": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/releases/#delete-a-release-asset",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Delete a release asset",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/releases/assets/:id"
+    },
+    "deleteCommitComment": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/comments/#delete-a-commit-comment",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Delete a commit comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/comments/:id"
+    },
+    "deleteDeployKey": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/keys/#remove-a-deploy-key",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Remove a deploy key",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/keys/:id"
+    },
+    "deleteDownload": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/downloads/#delete-a-download",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Delete a download",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/downloads/:id"
+    },
+    "deleteFile": {
+      "description": "This method deletes a file in a repository\n\nThe `author` section is optional and is filled in with the `committer` information if omitted. If the `committer` information is omitted, the authenticated user's information is used.\n\nYou must provide values for both `name` and `email`, whether you choose to use `author` or `committer`. Otherwise, you'll receive a `422` status code.\n\nBoth the `author` and `committer` parameters have the same keys:\n\n| name  | type   | description                                          |\n| ----- | ------ | ---------------------------------------------------- |\n| name  | string | The name of the author (or committer) of the commit  |\n| email | string | The email of the author (or committer) of the commit |",
+      "documentationUrl": "https://developer.github.com/v3/repos/contents/#delete-a-file",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Delete a file",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The content path.",
+          "name": "path",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The commit message.",
+          "name": "message",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "description": "The blob SHA of the file being replaced.",
+          "name": "sha",
+          "required": true,
+          "type": "string"
+        },
+        "5": {
+          "default": "the repository’s default branch (usually `master`)",
+          "description": "The branch name.",
+          "name": "branch",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "object containing information about the committer.",
+          "name": "committer",
+          "type": "object"
+        },
+        "7": {
+          "description": "object containing information about the author.",
+          "name": "author",
+          "type": "object"
+        }
+      },
+      "path": "/repos/:owner/:repo/contents/:path"
+    },
+    "deleteHook": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#delete-a-hook",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Delete a hook",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/hooks/:id"
+    },
+    "deleteInvite": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/invitations/#delete-a-repository-invitation",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Delete a repository invitation",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "invitation_id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/invitations/:invitation_id"
+    },
+    "deleteRelease": {
+      "description": "Users with push access to the repository can delete a release.",
+      "documentationUrl": "https://developer.github.com/v3/repos/releases/#delete-a-release",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Delete a release",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/releases/:id"
+    },
+    "edit": {
+      "description": "**Note**: To edit a repository's topics, use the [`topics` endpoint](#replace-all-topics-for-a-repository).",
+      "documentationUrl": "https://developer.github.com/v3/repos/#edit",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Edit",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The name of the repository.",
+          "name": "name",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "A short description of the repository.",
+          "name": "description",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "A URL with more information about the repository.",
+          "name": "homepage",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "default": false,
+          "description": "Either `true` to make the repository private or `false` to make it public. Creating private repositories requires a paid GitHub account. Default: `false`.  \n**Note**: You will get a `422` error if the organization restricts [changing repository visibility](https://help.github.com/articles/repository-permission-levels-for-an-organization#changing-the-visibility-of-repositories) to organization owners and a non-owner tries to change the value of private. **Note**: You will get a `422` error if the organization restricts [changing repository visibility](https://help.github.com/articles/repository-permission-levels-for-an-organization#changing-the-visibility-of-repositories) to organization owners and a non-owner tries to change the value of private.",
+          "name": "private",
+          "required": false,
+          "type": "boolean"
+        },
+        "6": {
+          "default": true,
+          "description": "Either `true` to enable issues for this repository or `false` to disable them.",
+          "name": "has_issues",
+          "required": false,
+          "type": "boolean"
+        },
+        "7": {
+          "default": true,
+          "description": "Either `true` to enable projects for this repository or `false` to disable them. **Note:** If you're creating a repository in an organization that has disabled repository projects, the default is `false`, and if you pass `true`, the API returns an error.",
+          "name": "has_projects",
+          "required": false,
+          "type": "boolean"
+        },
+        "8": {
+          "default": true,
+          "description": "Either `true` to enable the wiki for this repository or `false` to disable it.",
+          "name": "has_wiki",
+          "required": false,
+          "type": "boolean"
+        },
+        "9": {
+          "description": "Updates the default branch for this repository.",
+          "name": "default_branch",
+          "required": false,
+          "type": "string"
+        },
+        "10": {
+          "default": true,
+          "description": "Either `true` to allow squash-merging pull requests, or `false` to prevent squash-merging.",
+          "name": "allow_squash_merge",
+          "required": false,
+          "type": "boolean"
+        },
+        "11": {
+          "default": true,
+          "description": "Either `true` to allow merging pull requests with a merge commit, or `false` to prevent merging pull requests with merge commits.",
+          "name": "allow_merge_commit",
+          "required": false,
+          "type": "boolean"
+        },
+        "12": {
+          "default": true,
+          "description": "Either `true` to allow rebase-merging pull requests, or `false` to prevent rebase-merging.",
+          "name": "allow_rebase_merge",
+          "required": false,
+          "type": "boolean"
+        },
+        "13": {
+          "default": false,
+          "description": "`true` to archive this repository. **Note**: You cannot unarchive repositories through the API.",
+          "name": "archived",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/repos/:owner/:repo"
+    },
+    "editAsset": {
+      "description": "Users with push access to the repository can edit a release asset.",
+      "documentationUrl": "https://developer.github.com/v3/repos/releases/#edit-a-release-asset",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Edit a release asset",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The file name of the asset.",
+          "name": "name",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "An alternate short description of the asset. Used in place of the filename.",
+          "name": "label",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/releases/assets/:id"
+    },
+    "editHook": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#edit-a-hook",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "name": "Edit a hook",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "name": "config",
+          "required": true,
+          "type": "object"
+        },
+        "4": {
+          "description": "The URL to which the payloads will be delivered.",
+          "name": "config.url",
+          "required": true,
+          "type": "string"
+        },
+        "5": {
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "name": "config.content_type",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/webhooks/#delivery-headers) header.",
+          "name": "config.secret",
+          "required": false,
+          "type": "string"
+        },
+        "7": {
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "name": "config.insecure_ssl",
+          "required": false,
+          "type": "string"
+        },
+        "8": {
+          "default": "[\"push\"]",
+          "description": "Determines what [events](/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
+          "name": "events",
+          "required": false,
+          "type": "array"
+        },
+        "9": {
+          "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
+          "name": "add_events",
+          "required": false,
+          "type": "array"
+        },
+        "10": {
+          "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
+          "name": "remove_events",
+          "required": false,
+          "type": "array"
+        },
+        "11": {
+          "default": true,
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "name": "active",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/repos/:owner/:repo/hooks/:id"
+    },
+    "editRelease": {
+      "description": "Users with push access to the repository can edit a release.",
+      "documentationUrl": "https://developer.github.com/v3/repos/releases/#edit-a-release",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Edit a release",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The name of the tag.",
+          "name": "tag_name",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": "the repository's default branch (usually `master`).",
+          "description": "Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists.",
+          "name": "target_commitish",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "The name of the release.",
+          "name": "name",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "Text describing the contents of the tag.",
+          "name": "body",
+          "required": false,
+          "type": "string"
+        },
+        "7": {
+          "description": "`true` makes the release a draft, and `false` publishes the release.",
+          "name": "draft",
+          "required": false,
+          "type": "boolean"
+        },
+        "8": {
+          "description": "`true` to identify the release as a prerelease, `false` to identify the release as a full release.",
+          "name": "prerelease",
+          "required": false,
+          "type": "boolean"
+        }
+      },
+      "path": "/repos/:owner/:repo/releases/:id"
+    },
+    "fork": {
+      "description": "Create a fork for the authenticated user.\n\nForking a Repository happens asynchronously. Therefore, you may have to wait a short period before accessing the git objects. If this takes longer than 5 minutes, be sure to contact [GitHub support](https://github.com/contact).",
+      "documentationUrl": "https://developer.github.com/v3/repos/forks/#create-a-fork",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Create a fork",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "Optional parameter to specify the organization name if forking into an organization.",
+          "name": "organization",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/forks"
+    },
+    "get": {
+      "description": "The `parent` and `source` objects are present when the repository is a fork. `parent` is the repository this repository was forked from, `source` is the ultimate source for the network.",
+      "documentationUrl": "https://developer.github.com/v3/repos/#get",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo"
+    },
+    "getAll": {
+      "description": "List repositories that are accessible to the authenticated user.\n\nThis includes repositories owned by the authenticated user, repositories where the authenticated user is a collaborator, and repositories that the authenticated user has access to through an organization membership.",
+      "documentationUrl": "https://developer.github.com/v3/repos/#list-your-repositories",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List your repositories",
+      "params": {
+        "0": {
+          "default": "all",
+          "description": "Can be one of `all`, `public`, or `private`.",
+          "enum": [
+            "all",
+            "public",
+            "private"
+          ],
+          "name": "visibility",
+          "required": false,
+          "type": "string"
+        },
+        "1": {
+          "default": "owner,collaborator,organization_member",
+          "description": "Comma-separated list of values. Can include:  \n\\* `owner`: Repositories that are owned by the authenticated user.  \n\\* `collaborator`: Repositories that the user has been added to as a collaborator.  \n\\* `organization_member`: Repositories that the user has access to through being a member of an organization. This includes every repository on every team that the user is on.",
+          "enum": [
+            "owner",
+            "collaborator",
+            "organization_member"
+          ],
+          "name": "affiliation",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "default": "all",
+          "description": "Can be one of `all`, `owner`, `public`, `private`, `member`. Default: `all`  \n  \nWill cause a `422` error if used in the same request as **visibility** or **affiliation**. Will cause a `422` error if used in the same request as **visibility** or **affiliation**.",
+          "enum": [
+            "all",
+            "owner",
+            "public",
+            "private",
+            "member"
+          ],
+          "name": "type",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": "full_name",
+          "description": "Can be one of `created`, `updated`, `pushed`, `full_name`.",
+          "enum": [
+            "created",
+            "updated",
+            "pushed",
+            "full_name"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": "when using `full_name`: `asc`; otherwise `desc`",
+          "description": "Can be one of `asc` or `desc`.",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "direction",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "6": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/user/repos"
+    },
+    "getAllCommitComments": {
+      "description": "Commit Comments use [these custom media types](#custom-media-types). You can read more about the use of media types in the API [here](/v3/media/).\n\nComments are ordered by ascending ID.",
+      "documentationUrl": "https://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List commit comments for a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/comments"
+    },
+    "getArchiveLink": {
+      "description": "This method will return a `302` to a URL to download a tarball or zipball archive for a repository. Please make sure your HTTP framework is configured to follow redirects or you will need to use the `Location` header to make a second `GET` request.\n\n_Note_: For private repositories, these links are temporary and expire after five minutes.\n\nTo follow redirects with curl, use the `-L` switch:\n\n",
+      "documentationUrl": "https://developer.github.com/v3/repos/contents/#get-archive-link",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get archive link",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": "tarball",
+          "description": "Can be either `tarball` or `zipball`.",
+          "enum": [
+            "tarball",
+            "zipball"
+          ],
+          "name": "archive_format",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "default": "the repository’s default branch (usually `master`)",
+          "description": "A valid Git reference.",
+          "name": "ref",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/:archive_format/:ref"
+    },
+    "getAsset": {
+      "description": "To download the asset's binary content, set the `Accept` header of the request to [`application/octet-stream`](/v3/media/#media-types). The API will either redirect the client to the location, or stream it directly if possible. API clients should handle both a `200` or `302` response.",
+      "documentationUrl": "https://developer.github.com/v3/repos/releases/#get-a-single-release-asset",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a single release asset",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/releases/assets/:id"
+    },
+    "getAssets": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/releases/#list-assets-for-a-release",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List assets for a release",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/releases/:id/assets"
+    },
+    "getBranch": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#get-branch",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch"
+    },
+    "getBranchProtection": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#get-branch-protection",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get branch protection",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection"
+    },
+    "getBranches": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#list-branches",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List branches",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "Setting to `true` returns only protected branches.",
+          "name": "protected",
+          "required": false,
+          "type": "boolean"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches"
+    },
+    "getClones": {
+      "description": "Get the total number of clones and breakdown per day or week for the last 14 days. Timestamps are aligned to UTC midnight of the beginning of the day or week. Week begins on Monday.",
+      "documentationUrl": "https://developer.github.com/v3/repos/traffic/#clones",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Clones",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": "day",
+          "description": "Must be one of: `day`, `week`.",
+          "enum": [
+            "day",
+            "week"
+          ],
+          "name": "per",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/traffic/clones"
+    },
+    "getCollaborators": {
+      "description": "For organization-owned repositories, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners.\n\nIf you pass the `hellcat-preview` media type, team members will include the members of child teams.",
+      "documentationUrl": "https://developer.github.com/v3/repos/collaborators/#list-collaborators",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List collaborators",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": "all",
+          "description": "Filter collaborators returned by their affiliation. Can be one of:  \n\\* `outside`: All outside collaborators of an organization-owned repository.  \n\\* `direct`: All collaborators with permissions to an organization-owned repository, regardless of organization membership status.  \n\\* `all`: All collaborators the authenticated user can see.",
+          "enum": [
+            "outside",
+            "direct",
+            "all"
+          ],
+          "name": "affiliation",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/collaborators"
+    },
+    "getCombinedStatusForRef": {
+      "description": "Users with pull access can access a combined view of commit statuses for a given ref.\n\nThe most recent status for each context is returned, up to 100. This field [paginates](/v3/#pagination) if there are over 100 contexts.\n\nAdditionally, a combined `state` is returned. The `state` is one of:\n\n*   **failure** if any of the contexts report as `error` or `failure`\n*   **pending** if there are no statuses or a context is `pending`\n*   **success** if the latest status for all contexts is `success`",
+      "documentationUrl": "https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get the combined status for a specific ref",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "Ref to fetch the status for. It can be a SHA, a branch name, or a tag name.",
+          "name": "ref",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/commits/:ref/status"
+    },
+    "getCommit": {
+      "description": "Diffs with binary data will have no 'patch' property. Pass the appropriate [media type](/v3/media/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.",
+      "documentationUrl": "https://developer.github.com/v3/repos/commits/#get-a-single-commit",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a single commit",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "sha",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/commits/:sha"
+    },
+    "getCommitComment": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/comments/#get-a-single-commit-comment",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a single commit comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/comments/:id"
+    },
+    "getCommitComments": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List comments for a single commit",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "ref",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/commits/:ref/comments"
+    },
+    "getCommits": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List commits on a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": "the repository’s default branch (usually `master`).",
+          "description": "SHA or branch to start listing commits from.",
+          "name": "sha",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "description": "Only commits containing this file path will be returned.",
+          "name": "path",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "GitHub login or email address by which to filter by commit author.",
+          "name": "author",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "Only commits after this date will be returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "Only commits before this date will be returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "name": "until",
+          "required": false,
+          "type": "string"
+        },
+        "7": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "8": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/commits"
+    },
+    "getCommunityProfileMetrics": {
+      "description": "This endpoint will return all community profile metrics, including an overall health score, repository description, the presence of documentation, detected code of conduct, detected license, and the presence of ISSUE\\_TEMPLATE, PULL\\_REQUEST_TEMPLATE, README, and CONTRIBUTING files.",
+      "documentationUrl": "https://developer.github.com/v3/repos/community/#retrieve-community-profile-metrics",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Retrieve community profile metrics",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "name",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:name/community/profile"
+    },
+    "getContent": {
+      "description": "This method returns the contents of a file or directory in a repository.\n\nFiles and symlinks support [a custom media type](#custom-media-types) for retrieving the raw content or rendered HTML (when supported). All content types support [a custom media type](#custom-media-types) to ensure the content is returned in a consistent object format.\n\n**Note**:\n\n*   To get a repository's contents recursively, you can [recursively get the tree](/v3/git/trees/).\n*   This API has an upper limit of 1,000 files for a directory. If you need to retrieve more files, use the [Git Trees API](/v3/git/trees/#get-a-tree).\n*   This API supports files up to 1 megabyte in size.\n\nThe response will be an array of objects, one object for each item in the directory.\n\nWhen listing the contents of a directory, submodules have their \"type\" specified as \"file\". Logically, the value _should_ be \"submodule\". This behavior exists in API v3 [for backwards compatibility purposes](https://git.io/v1YCW). In the next major version of the API, the type will be returned as \"submodule\".\n\nIf the requested `:path` points to a symlink, and the symlink's target is a normal file in the repository, then the API responds with the content of the file (in the [format shown above](#response-if-content-is-a-file)).\n\nOtherwise, the API responds with an object describing the symlink itself:\n\nThe `submodule_git_url` identifies the location of the submodule repository, and the `sha` identifies a specific commit within the submodule repository. Git uses the given URL when cloning the submodule repository, and checks out the submodule at that specific commit.\n\nIf the submodule repository is not hosted on github.com, the Git URLs (`git_url` and `_links[\"git\"]`) and the github.com URLs (`html_url` and `_links[\"html\"]`) will have null values.",
+      "documentationUrl": "https://developer.github.com/v3/repos/contents/#get-contents",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get contents",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The content path.",
+          "name": "path",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "default": "the repository’s default branch (usually `master`)",
+          "description": "The name of the commit/branch/tag.",
+          "name": "ref",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/contents/:path"
+    },
+    "getContributors": {
+      "description": "Lists contributors to the specified repository and sorts them by the number of commits per contributor in descending order. This endpoint may return information that is a few hours old because the GitHub REST API v3 caches contributor data to improve performance.\n\nGitHub identifies contributors by author email address. This endpoint groups contribution counts by GitHub user, which includes all associated email addresses. To improve performance, only the first 500 author email addresses in the repository link to GitHub users. The rest will appear as anonymous contributors without associated GitHub user information.",
+      "documentationUrl": "https://developer.github.com/v3/repos/#list-contributors",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List contributors",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "Set to `1` or `true` to include anonymous contributors in results.",
+          "name": "anon",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/contributors"
+    },
+    "getDeployKey": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/keys/#get-a-deploy-key",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a deploy key",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/keys/:id"
+    },
+    "getDeployKeys": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/keys/#list-deploy-keys",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List deploy keys",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/keys"
+    },
+    "getDeployment": {
+      "description": "\n\n**Note:** If a user created a deployment via a GitHub App, the `performed_via_github_app` key will contain information on that GitHub App.",
+      "documentationUrl": "https://developer.github.com/v3/repos/deployments/#get-a-single-deployment",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a single deployment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/deployments/:id"
+    },
+    "getDeploymentStatus": {
+      "description": "Users with pull access can view a deployment status for a deployment:\n\n\n\n**Note:** If a user created a deployment status via a GitHub App, the `performed_via_github_app` key will contain information on that GitHub App.",
+      "documentationUrl": "https://developer.github.com/v3/repos/deployments/#get-a-single-deployment-status",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a single deployment status",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The deployment ID to list the statuses from.",
+          "name": "id",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "description": "The deployment status ID.",
+          "name": "status_id",
+          "required": true,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/deployments/:id/statuses/:status_id"
+    },
+    "getDeploymentStatuses": {
+      "description": "Users with pull access can view deployment statuses for a deployment:",
+      "documentationUrl": "https://developer.github.com/v3/repos/deployments/#list-deployment-statuses",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List deployment statuses",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The deployment ID to list the statuses from.",
+          "name": "id",
+          "required": true,
+          "type": "integer"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/deployments/:id/statuses"
+    },
+    "getDeployments": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/deployments/#list-deployments",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List deployments",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": "none",
+          "description": "The SHA that was recorded at creation time.",
+          "name": "sha",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": "none",
+          "description": "The name of the ref. This can be a branch, tag, or SHA.",
+          "name": "ref",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": "none",
+          "description": "The name of the task for the deployment (e.g., `deploy` or `deploy:migrations`).",
+          "name": "task",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "default": "none",
+          "description": "The name of the environment that was deployed to (e.g., `staging` or `production`).",
+          "name": "environment",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "7": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/deployments"
+    },
+    "getDownload": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/downloads/#get-a-single-download",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get a single download",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/downloads/:id"
+    },
+    "getDownloads": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/downloads/#list-downloads-for-a-repository",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List downloads for a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/downloads"
+    },
+    "getForOrg": {
+      "description": "List repositories for the specified org.",
+      "documentationUrl": "https://developer.github.com/v3/repos/#list-organization-repositories",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List organization repositories",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": "all",
+          "description": "Can be one of `all`, `public`, `private`, `forks`, `sources`, `member`.",
+          "enum": [
+            "all",
+            "public",
+            "private",
+            "forks",
+            "sources",
+            "member"
+          ],
+          "name": "type",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/orgs/:org/repos"
+    },
+    "getForUser": {
+      "description": "List public repositories for the specified user.",
+      "documentationUrl": "https://developer.github.com/v3/repos/#list-user-repositories",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List user repositories",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": "owner",
+          "description": "Can be one of `all`, `owner`, `member`.",
+          "enum": [
+            "all",
+            "owner",
+            "member"
+          ],
+          "name": "type",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "default": "full_name",
+          "description": "Can be one of `created`, `updated`, `pushed`, `full_name`.",
+          "enum": [
+            "created",
+            "updated",
+            "pushed",
+            "full_name"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": "when using `full_name`: `asc`, otherwise `desc`",
+          "description": "Can be one of `asc` or `desc`.",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "direction",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "5": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/users/:username/repos"
+    },
+    "getForks": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/forks/#list-forks",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List forks",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": "newest",
+          "description": "The sort order. Can be either `newest`, `oldest`, or `stargazers`.",
+          "enum": [
+            "newest",
+            "oldest",
+            "stargazers"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/forks"
+    },
+    "getHook": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#get-single-hook",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get single hook",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/hooks/:id"
+    },
+    "getHooks": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#list-hooks",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List hooks",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/hooks"
+    },
+    "getInvites": {
+      "description": "When authenticating as a user with admin rights to a repository, this endpoint will list all currently open repository invitations.\n\n",
+      "documentationUrl": "https://developer.github.com/v3/repos/invitations/#list-invitations-for-a-repository",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List invitations for a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/invitations"
+    },
+    "getLanguages": {
+      "description": "Lists languages for the specified repository. The value shown for each language is the number of bytes of code written in that language.",
+      "documentationUrl": "https://developer.github.com/v3/repos/#list-languages",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List languages",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/languages"
+    },
+    "getLatestPagesBuild": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/pages/#list-latest-pages-build",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List latest Pages build",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/pages/builds/latest"
+    },
+    "getLatestRelease": {
+      "description": "View the latest published full release for the repository. Draft releases and prereleases are not returned by this endpoint.",
+      "documentationUrl": "https://developer.github.com/v3/repos/releases/#get-the-latest-release",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get the latest release",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/releases/latest"
+    },
+    "getPages": {
+      "description": "Responses during the preview period contain two additional fields:\n\n*   `html_url`: The absolute URL (with scheme) to the rendered site. For example, `https://username.github.io`.\n*   `source`: Information about the source branch and directory for the rendered site. The source field includes:\n    *   `branch`: The repo branch for [site source files](https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/) For example, _master_ or _gh-pages_.\n    *   `path`: The repo directory from which the site publishes. Can be either `/` or `/docs`.",
+      "documentationUrl": "https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get information about a Pages site",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/pages"
+    },
+    "getPagesBuild": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/pages/#list-a-specific-pages-build",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List a specific Pages build",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/pages/builds/:id"
+    },
+    "getPagesBuilds": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/pages/#list-pages-builds",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List Pages builds",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/pages/builds"
+    },
+    "getPaths": {
+      "description": "Get the top 10 popular contents over the last 14 days.",
+      "documentationUrl": "https://developer.github.com/v3/repos/traffic/#list-paths",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List paths",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/traffic/popular/paths"
+    },
+    "getProtectedBranchAdminEnforcement": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#get-admin-enforcement-of-protected-branch",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get admin enforcement of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins"
+    },
+    "getProtectedBranchPullRequestReviewEnforcement": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#get-pull-request-review-enforcement-of-protected-branch",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get pull request review enforcement of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews"
+    },
+    "getProtectedBranchRequiredStatusChecks": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#get-required-status-checks-of-protected-branch",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get required status checks of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks"
+    },
+    "getProtectedBranchRequiredStatusChecksContexts": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#list-required-status-checks-contexts-of-protected-branch",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List required status checks contexts of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
+    },
+    "getProtectedBranchRestrictions": {
+      "description": "**Note**: Teams and users `restrictions` are only available for organization-owned repositories.",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#get-restrictions-of-protected-branch",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get restrictions of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions"
+    },
+    "getProtectedBranchTeamRestrictions": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#list-team-restrictions-of-protected-branch",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List team restrictions of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
+    },
+    "getProtectedBranchUserRestrictions": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#list-user-restrictions-of-protected-branch",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List user restrictions of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
+    },
+    "getPublic": {
+      "description": "This provides a dump of every public repository, in the order that they were created.\n\nNote: Pagination is powered exclusively by the `since` parameter. Use the [Link header](/v3/#link-header) to get the URL for the next page of repositories.",
+      "documentationUrl": "https://developer.github.com/v3/repos/#list-all-public-repositories",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List all public repositories",
+      "params": {
+        "0": {
+          "description": "The integer ID of the last Repository that you've seen.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repositories"
+    },
+    "getReadme": {
+      "description": "This method returns the preferred README for a repository.\n\nREADMEs support [custom media types](#custom-media-types) for retrieving the raw content or rendered HTML.",
+      "documentationUrl": "https://developer.github.com/v3/repos/contents/#get-the-readme",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get the README",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": "the repository’s default branch (usually `master`)",
+          "description": "The name of the commit/branch/tag.",
+          "name": "ref",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/readme"
+    },
+    "getReferrers": {
+      "description": "Get the top 10 referrers over the last 14 days.",
+      "documentationUrl": "https://developer.github.com/v3/repos/traffic/#list-referrers",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List referrers",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/traffic/popular/referrers"
+    },
+    "getRelease": {
+      "description": "**Note:** This returns an `upload_url` key corresponding to the endpoint for uploading release assets. This key is a [hypermedia resource](/v3/#hypermedia).",
+      "documentationUrl": "https://developer.github.com/v3/repos/releases/#get-a-single-release",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a single release",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/releases/:id"
+    },
+    "getReleaseByTag": {
+      "description": "Get a published release with the specified tag.",
+      "documentationUrl": "https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a release by tag name",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "tag",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/releases/tags/:tag"
+    },
+    "getReleases": {
+      "description": "This returns a list of releases, which does not include regular Git tags that have not been associated with a release. To get a list of Git tags, use the [Repository Tags API](/v3/repos/#list-tags).\n\nInformation about published releases are available to everyone. Only users with push access will receive listings for draft releases.",
+      "documentationUrl": "https://developer.github.com/v3/repos/releases/#list-releases-for-a-repository",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List releases for a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/releases"
+    },
+    "getShaOfCommitRef": {
+      "description": "Users with read access can get the SHA-1 of a commit reference:\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n\n\nTo check if a remote reference's SHA-1 is the same as your local reference's SHA-1, make a `GET` request and provide the current SHA-1 for the local reference as the ETag.\n\nThe SHA-1 of the commit reference.\n\n",
+      "documentationUrl": "https://developer.github.com/v3/repos/commits/#get-the-sha-1-of-a-commit-reference",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get the SHA-1 of a commit reference",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "ref",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/commits/:ref"
+    },
+    "getStatsCodeFrequency": {
+      "description": "Returns a weekly aggregate of the number of additions and deletions pushed to a repository.\n\n",
+      "documentationUrl": "https://developer.github.com/v3/repos/statistics/#get-the-number-of-additions-and-deletions-per-week",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get the number of additions and deletions per week",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/stats/code_frequency"
+    },
+    "getStatsCommitActivity": {
+      "description": "Returns the last year of commit activity grouped by week. The `days` array is a group of commits per day, starting on `Sunday`.\n\n",
+      "documentationUrl": "https://developer.github.com/v3/repos/statistics/#get-the-last-year-of-commit-activity-data",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get the last year of commit activity data",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/stats/commit_activity"
+    },
+    "getStatsContributors": {
+      "description": "*   `total` \\- The Total number of commits authored by the contributor.\n\nWeekly Hash (`weeks` array):\n\n*   `w` \\- Start of the week, given as a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time).\n*   `a` \\- Number of additions\n*   `d` \\- Number of deletions\n*   `c` \\- Number of commits\n\n",
+      "documentationUrl": "https://developer.github.com/v3/repos/statistics/#get-contributors-list-with-additions-deletions-and-commit-counts",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get contributors list with additions, deletions, and commit counts",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/stats/contributors"
+    },
+    "getStatsParticipation": {
+      "description": "Returns the total commit counts for the `owner` and total commit counts in `all`. `all` is everyone combined, including the `owner` in the last 52 weeks. If you'd like to get the commit counts for non-owners, you can subtract `owner` from `all`.\n\nThe array order is oldest week (index 0) to most recent week.\n\n",
+      "documentationUrl": "https://developer.github.com/v3/repos/statistics/#get-the-weekly-commit-count-for-the-repository-owner-and-everyone-else",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get the weekly commit count for the repository owner and everyone else",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/stats/participation"
+    },
+    "getStatsPunchCard": {
+      "description": "Each array contains the day number, hour number, and number of commits:\n\n*   `0-6`: Sunday - Saturday\n*   `0-23`: Hour of day\n*   Number of commits\n\nFor example, `[2, 14, 25]` indicates that there were 25 total commits, during the 2:00pm hour on Tuesdays. All times are based on the time zone of individual commits.",
+      "documentationUrl": "https://developer.github.com/v3/repos/statistics/#get-the-number-of-commits-per-hour-in-each-day",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get the number of commits per hour in each day",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/stats/punch_card"
+    },
+    "getStatuses": {
+      "description": "Users with pull access can view commit statuses for a given ref:\n\nThis resource is also available via a legacy route: `GET /repos/:owner/:repo/statuses/:ref`.\n\nStatuses are returned in reverse chronological order. The first status in the list will be the latest one.",
+      "documentationUrl": "https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List statuses for a specific ref",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "Ref to list the statuses from. It can be a SHA, a branch name, or a tag name.",
+          "name": "ref",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/commits/:ref/statuses"
+    },
+    "getTags": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/#list-tags",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List tags",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/tags"
+    },
+    "getTeams": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/#list-teams",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List teams",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "3": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/teams"
+    },
+    "getTopics": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/#list-all-topics-for-a-repository",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List all topics for a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/topics"
+    },
+    "getViews": {
+      "description": "Get the total number of views and breakdown per day or week for the last 14 days. Timestamps are aligned to UTC midnight of the beginning of the day or week. Week begins on Monday.",
+      "documentationUrl": "https://developer.github.com/v3/repos/traffic/#views",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Views",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "default": "day",
+          "description": "Must be one of: `day`, `week`.",
+          "enum": [
+            "day",
+            "week"
+          ],
+          "name": "per",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/traffic/views"
+    },
+    "merge": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/merging/#perform-a-merge",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Perform a merge",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The name of the base branch that the head will be merged into.",
+          "name": "base",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The head to merge. This can be a branch name or a commit SHA1.",
+          "name": "head",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "description": "Commit message to use for the merge commit. If omitted, a default message will be used.",
+          "name": "commit_message",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/merges"
+    },
+    "pingHook": {
+      "description": "This will trigger a [ping event](/webhooks/#ping-event) to be sent to the hook.",
+      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#ping-a-hook",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Ping a hook",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/hooks/:id/pings"
+    },
+    "removeBranchProtection": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#remove-branch-protection",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Remove branch protection",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection"
+    },
+    "removeCollaborator": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/collaborators/#remove-user-as-a-collaborator",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Remove user as a collaborator",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/collaborators/:username"
+    },
+    "removeProtectedBranchAdminEnforcement": {
+      "description": "Removing admin enforcement requires admin or owner permissions to the repository and branch protection to be enabled.",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#remove-admin-enforcement-of-protected-branch",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Remove admin enforcement of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins"
+    },
+    "removeProtectedBranchPullRequestReviewEnforcement": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#remove-pull-request-review-enforcement-of-protected-branch",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Remove pull request review enforcement of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews"
+    },
+    "removeProtectedBranchRequiredStatusChecks": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#remove-required-status-checks-of-protected-branch",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Remove required status checks of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks"
+    },
+    "removeProtectedBranchRequiredStatusChecksContexts": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#remove-required-status-checks-contexts-of-protected-branch",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Remove required status checks contexts of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
+    },
+    "removeProtectedBranchRestrictions": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#remove-restrictions-of-protected-branch",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Remove restrictions of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions"
+    },
+    "removeProtectedBranchTeamRestrictions": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#remove-team-restrictions-of-protected-branch",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Remove team restrictions of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
+    },
+    "removeProtectedBranchUserRestrictions": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#remove-user-restrictions-of-protected-branch",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "name": "Remove user restrictions of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
+    },
+    "replaceProtectedBranchRequiredStatusChecksContexts": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#replace-required-status-checks-contexts-of-protected-branch",
+      "enabledForApps": true,
+      "method": "PUT",
+      "name": "Replace required status checks contexts of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
+    },
+    "replaceProtectedBranchTeamRestrictions": {
+      "description": "Pass the list of team `slug`s with push access.\n\n**Note**: The list of users and teams in total is limited to 100 items.",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#replace-team-restrictions-of-protected-branch",
+      "enabledForApps": true,
+      "method": "PUT",
+      "name": "Replace team restrictions of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
+    },
+    "replaceProtectedBranchUserRestrictions": {
+      "description": "Pass the list of user `login`s with push access.\n\n**Note**: The list of users and teams in total is limited to 100 items.",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#replace-user-restrictions-of-protected-branch",
+      "enabledForApps": true,
+      "method": "PUT",
+      "name": "Replace user restrictions of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
+    },
+    "replaceTopics": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/#replace-all-topics-for-a-repository",
+      "enabledForApps": true,
+      "method": "PUT",
+      "name": "Replace all topics for a repository",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "An array of topics to add to the repository. Pass one or more topics to _replace_ the set of existing topics. Send an empty array (`[]`) to clear all topics from the repository.",
+          "name": "names",
+          "required": true,
+          "type": "array of strings"
+        }
+      },
+      "path": "/repos/:owner/:repo/topics"
+    },
+    "requestPageBuild": {
+      "description": "You can request that your site be built from the latest revision on the default branch. This has the same effect as pushing a commit to your default branch, but does not require an additional commit. Manually triggering page builds can be helpful when diagnosing build warnings and failures.\n\nBuild requests are limited to one concurrent build per repository and one concurrent build per requester. If you request a build while another is still in progress, the second request will be queued until the first completes.",
+      "documentationUrl": "https://developer.github.com/v3/repos/pages/#request-a-page-build",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Request a page build",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/pages/builds"
+    },
+    "reviewUserPermissionLevel": {
+      "description": "Possible values for the `permission` key: `admin`, `write`, `read`, `none`.",
+      "documentationUrl": "https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Review a user's permission level",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/collaborators/:username/permission"
+    },
+    "testHook": {
+      "description": "This will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:id/test`",
+      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#test-a-push-hook",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Test a push hook",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/hooks/:id/tests"
+    },
+    "updateBranchProtection": {
+      "description": "Protecting a branch requires admin or owner permissions to the repository.\n\n**Note**: Passing new arrays of `users` and `teams` replaces their previous values.\n\n**Note**: The list of users and teams in total is limited to 100 items.",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#update-branch-protection",
+      "enabledForApps": true,
+      "method": "PUT",
+      "name": "Update branch protection",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The list of user `login`s with dismissal access",
+          "name": "dismissal_restrictions.users",
+          "required": false,
+          "type": "array"
+        },
+        "4": {
+          "description": "The list of team `slug`s with dismissal access",
+          "name": "dismissal_restrictions.teams",
+          "required": false,
+          "type": "array"
+        },
+        "5": {
+          "allowNull": true,
+          "description": "Require status checks to pass before merging. Set to `null` to disable.",
+          "name": "required_status_checks",
+          "required": true,
+          "type": "object"
+        },
+        "6": {
+          "description": "Require branches to be up to date before merging.",
+          "name": "required_status_checks.strict",
+          "required": true,
+          "type": "boolean"
+        },
+        "7": {
+          "description": "The list of status checks to require in order to merge into this branch",
+          "name": "required_status_checks.contexts",
+          "required": true,
+          "type": "array"
+        },
+        "8": {
+          "allowNull": true,
+          "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable.",
+          "name": "enforce_admins",
+          "required": true,
+          "type": "boolean"
+        },
+        "9": {
+          "allowNull": true,
+          "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
+          "name": "required_pull_request_reviews",
+          "required": true,
+          "type": "object"
+        },
+        "10": {
+          "description": "Specify which users and teams can dismiss pull request reviews. Pass an empty `dismissal_restrictions` object to disable. User and team `dismissal_restrictions` are only available for organization-owned repositories. Omit this parameter for personal repositories.",
+          "name": "required_pull_request_reviews.dismissal_restrictions",
+          "required": false,
+          "type": "object"
+        },
+        "11": {
+          "description": "Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit.",
+          "name": "required_pull_request_reviews.dismiss_stale_reviews",
+          "required": false,
+          "type": "boolean"
+        },
+        "12": {
+          "description": "Blocks merging pull requests until code owners review them.",
+          "name": "required_pull_request_reviews.require_code_owner_reviews",
+          "required": false,
+          "type": "boolean"
+        },
+        "13": {
+          "description": "Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6.",
+          "name": "required_pull_request_reviews.required_approving_review_count",
+          "required": false,
+          "type": "integer"
+        },
+        "14": {
+          "allowNull": true,
+          "description": "Restrict who can push to this branch. Team and user `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
+          "name": "restrictions",
+          "required": true,
+          "type": "object"
+        },
+        "15": {
+          "description": "The list of user `login`s with push access",
+          "name": "restrictions.users",
+          "required": false,
+          "type": "array"
+        },
+        "16": {
+          "description": "The list of team `slug`s with push access",
+          "name": "restrictions.teams",
+          "required": false,
+          "type": "array"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection"
+    },
+    "updateCommitComment": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/comments/#update-a-commit-comment",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Update a commit comment",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The contents of the comment",
+          "name": "body",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/comments/:id"
+    },
+    "updateFile": {
+      "description": "This method creates a new file in a repository\n\nThe `author` section is optional and is filled in with the `committer` information if omitted. If the `committer` information is omitted, the authenticated user's information is used.\n\nYou must provide values for both `name` and `email`, whether you choose to use `author` or `committer`. Otherwise, you'll receive a `422` status code.\n\nBoth the `author` and `committer` parameters have the same keys:\n\n| name  | type   | description                                          |\n| ----- | ------ | ---------------------------------------------------- |\n| name  | string | The name of the author (or committer) of the commit  |\n| email | string | The email of the author (or committer) of the commit |",
+      "documentationUrl": "https://developer.github.com/v3/repos/contents/#create-a-file",
+      "enabledForApps": true,
+      "method": "PUT",
+      "name": "Create a file",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The content path.",
+          "name": "path",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The commit message.",
+          "name": "message",
+          "required": true,
+          "type": "string"
+        },
+        "4": {
+          "description": "The new file content, Base64 encoded.",
+          "name": "content",
+          "required": true,
+          "type": "string"
+        },
+        "5": {
+          "default": "the repository’s default branch (usually `master`)",
+          "description": "The branch name.",
+          "name": "branch",
+          "required": false,
+          "type": "string"
+        },
+        "6": {
+          "description": "object containing information about the committer.",
+          "name": "committer",
+          "type": "object"
+        },
+        "7": {
+          "description": "object containing information about the author.",
+          "name": "author",
+          "type": "object"
+        }
+      },
+      "path": "/repos/:owner/:repo/contents/:path"
+    },
+    "updateInvite": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/invitations/#update-a-repository-invitation",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "name": "Update a repository invitation",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "invitation_id",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "The permissions that the associated user will have on the repository. Valid values are `read`, `write`, and `admin`.",
+          "enum": [
+            "read",
+            "write",
+            "admin"
+          ],
+          "name": "permissions",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/repos/:owner/:repo/invitations/:invitation_id"
+    },
+    "updateProtectedBranchPullRequestReviewEnforcement": {
+      "description": "Updating pull request review enforcement requires admin or owner permissions to the repository and branch protection to be enabled.\n\n**Note**: Passing new arrays of `users` and `teams` replaces their previous values.",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#update-pull-request-review-enforcement-of-protected-branch",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Update pull request review enforcement of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "Specify which users and teams can dismiss pull request reviews. Pass an empty `dismissal_restrictions` object to disable. User and team `dismissal_restrictions` are only available for organization-owned repositories. Omit this parameter for personal repositories.",
+          "name": "dismissal_restrictions",
+          "required": false,
+          "type": "object"
+        },
+        "4": {
+          "description": "The list of user `login`s with dismissal access",
+          "name": "dismissal_restrictions.users",
+          "required": false,
+          "type": "array"
+        },
+        "5": {
+          "description": "The list of team `slug`s with dismissal access",
+          "name": "dismissal_restrictions.teams",
+          "required": false,
+          "type": "array"
+        },
+        "6": {
+          "description": "Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit.",
+          "name": "dismiss_stale_reviews",
+          "required": false,
+          "type": "boolean"
+        },
+        "7": {
+          "description": "Blocks merging pull requests until code owners have reviewed.",
+          "name": "require_code_owner_reviews",
+          "required": false,
+          "type": "boolean"
+        },
+        "8": {
+          "description": "Specifies the number of reviewers required to approve pull requests. Use a number between 1 and 6.",
+          "name": "required_approving_review_count",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews"
+    },
+    "updateProtectedBranchRequiredStatusChecks": {
+      "description": "Updating required status checks requires admin or owner permissions to the repository and branch protection to be enabled.",
+      "documentationUrl": "https://developer.github.com/v3/repos/branches/#update-required-status-checks-of-protected-branch",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "name": "Update required status checks of protected branch",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "owner",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repo",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "",
+          "name": "branch",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "Require branches to be up to date before merging.",
+          "name": "strict",
+          "required": false,
+          "type": "boolean"
+        },
+        "4": {
+          "description": "The list of status checks to require in order to merge into this branch",
+          "name": "contexts",
+          "required": false,
+          "type": "array"
+        }
+      },
+      "path": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks"
+    },
+    "uploadAsset": {
+      "description": "This endpoint makes use of [a Hypermedia relation](/v3/#hypermedia) to determine which URL to access. This endpoint is provided by a URI template in [the release's API response](#get-a-single-release). You need to use an HTTP client which supports [SNI](http://en.wikipedia.org/wiki/Server_Name_Indication) to make calls to this endpoint.\n\nThe asset data is expected in its raw binary form, rather than JSON. Everything else about the endpoint is the same as the rest of the API. For example, you'll still need to pass your authentication to be able to upload an asset.\n\nSend the raw binary content of the asset as the request body.\n\nThis may leave an empty asset with a state of `\"new\"`. It can be safely deleted.",
+      "documentationUrl": "https://developer.github.com/v3/repos/releases/#upload-a-release-asset",
+      "enabledForApps": true,
+      "method": "POST",
+      "name": "Upload a release asset",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "url",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "The content type of the asset. This should be set in the Header. Example: `\"application/zip\"`. For a list of acceptable types, refer this list of [media types](https://www.iana.org/assignments/media-types/media-types.xhtml).",
+          "name": "Content-Type",
+          "required": true,
+          "type": "string"
+        },
+        "2": {
+          "description": "The file name of the asset. This should be set in a URI query parameter.",
+          "name": "name",
+          "required": true,
+          "type": "string"
+        },
+        "3": {
+          "description": "An alternate short description of the asset. Used in place of the filename. This should be set in a URI query parameter.",
+          "name": "label",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": ":url"
+    }
+  },
+  "search": {
+    "code": {
+      "description": "Find file contents via various criteria. This method returns up to 100 results [per page](/v3/#pagination).\n\n**Note:** You must [authenticate](/v3/#authentication) to search for code across all public repositories.\n\n**Considerations for code search**\n\nDue to the complexity of searching code, there are a few restrictions on how searches are performed:\n\n*   Only the _default branch_ is considered. In most cases, this will be the `master` branch.\n*   Only files smaller than 384 KB are searchable.\n*   You must always include at least one search term when searching source code. For example, searching for [`language:go`](https://github.com/search?utf8=%E2%9C%93&q=language%3Ago&type=Code) is not valid, while [`amazing language:go`](https://github.com/search?utf8=%E2%9C%93&q=amazing+language%3Ago&type=Code) is.\n\nThe `q` search term can also contain any combination of the supported code search qualifiers as described by the in-browser [code search documentation](https://help.github.com/articles/searching-code/) and [search syntax documentation](https://help.github.com/articles/search-syntax/):\n\n*   [`in`](https://help.github.com/articles/searching-code#scope-the-search-fields) Qualifies which fields are searched. With this qualifier you can restrict the search to the file contents (`file`), the file path (`path`), or both.\n*   [`language`](https://help.github.com/articles/searching-code#search-by-language) Searches code based on the language it's written in.\n*   [`fork`](https://help.github.com/articles/searching-code#search-by-the-number-of-forks-the-parent-repository-has) Specifies that code from forked repositories should be searched (`true`). Repository forks will not be searchable unless the fork has more stars than the parent repository.\n*   [`size`](https://help.github.com/articles/searching-code#search-by-the-size-of-the-parent-repository) Finds files that match a certain size (in bytes).\n*   [`path`](https://help.github.com/articles/searching-code#search-by-the-location-of-a-file-within-the-repository) Specifies the path prefix that the resulting file must be under.\n*   [`filename`](https://help.github.com/articles/searching-code#search-by-filename) Matches files by a substring of the filename.\n*   [`extension`](https://help.github.com/articles/searching-code#search-by-the-file-extension) Matches files with a certain extension after a dot.\n*   [`user` or `repo`](https://help.github.com/articles/searching-code#search-within-a-users-or-organizations-repositories) Limits searches to a specific user or repository.\n\nSuppose you want to find the definition of the `addClass` function inside [jQuery](https://github.com/jquery/jquery). Your query would look something like this:\n\n\n\nHere, we're searching for the keyword `addClass` within a file's contents. We're making sure that we're only looking in files where the language is JavaScript. And we're scoping the search to the `repo:jquery/jquery` repository.\n\n**Highlighting code search results**\n\nYou might want to highlight the matching search terms when displaying search results. The API offers additional metadata to support this use case. To get this metadata in your search results, specify the `text-match` media type in your `Accept` header. For example, via cURL, the above query would look like this:\n\nThis produces the same JSON payload as above, with an extra key called `text_matches`, an array of objects. These objects provide information such as the position of your search terms within the text, as well as the `property` that included the search term.\n\nWhen searching for code, you can get text match metadata for the file **content** and file **path** fields. For details on the attributes present in the `text_matches` array, see [text match metadata](#text-match-metadata).\n\nHere's an example response:",
+      "documentationUrl": "https://developer.github.com/v3/search/#search-code",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Search code",
+      "params": {
+        "0": {
+          "description": "The search terms.",
+          "name": "q",
+          "required": false,
+          "type": "string"
+        },
+        "1": {
+          "default": "results are sorted by best match.",
+          "description": "The sort field. Can only be `indexed`, which indicates how recently a file has been indexed by the GitHub search infrastructure.",
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "default": "desc",
+          "description": "The sort order if `sort` parameter is provided. One of `asc` or `desc`.",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "order",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/search/code"
+    },
+    "commits": {
+      "description": "Find commits via various criteria. This method returns up to 100 results [per page](/v3/#pagination).\n\n**Considerations for commit search**\n\nOnly the _default branch_ is considered. In most cases, this will be the `master` branch.\n\nThe `q` search term can also contain any combination of the supported commit search qualifiers as described by the in-browser [commit search documentation](https://help.github.com/articles/searching-commits/) and [search syntax documentation](https://help.github.com/articles/search-syntax/):\n\n*   [`author`](https://help.github.com/articles/searching-commits#search-by-author-or-committer) Matches commits authored by a user (based on email settings).\n*   [`committer`](https://help.github.com/articles/searching-commits#search-by-author-or-committer) Matches commits committed by a user (based on email settings).\n*   [`author-name`](https://help.github.com/articles/searching-commits#search-by-author-or-committer) Matches commits by author name.\n*   [`committer-name`](https://help.github.com/articles/searching-commits#search-by-author-or-committer) Matches commits by committer name.\n*   [`author-email`](https://help.github.com/articles/searching-commits#search-by-author-or-committer) Matches commits by author email.\n*   [`committer-email`](https://help.github.com/articles/searching-commits#search-by-author-or-committer) Matches commits by committer email.\n*   [`author-date`](https://help.github.com/articles/searching-commits#search-by-authored-or-committed-date) Matches commits by author date range.\n*   [`committer-date`](https://help.github.com/articles/searching-commits/#search-by-authored-or-committed-date) Matches commits by committer date range.\n*   [`merge`](https://help.github.com/articles/searching-commits#filter-merge-commits) `true` filters to merge commits, `false` filters out merge commits.\n*   [`hash`](https://help.github.com/articles/searching-commits#search-by-hash) Matches commits by hash.\n*   [`parent`](https://help.github.com/articles/searching-commits#search-by-parent) Matches commits that have a particular parent.\n*   [`tree`](https://help.github.com/articles/searching-commits#search-by-tree) Matches commits by tree hash.\n*   [`is`](https://help.github.com/articles/searching-commits#filter-to-public-or-private-repositories) Matches `public` or `private` repositories.\n*   [`user`, `org`, or `repo`](https://help.github.com/articles/searching-commits#search-within-a-users-or-organizations-repositories) Limits searches to a specific user, organization, or repository.\n\nSuppose you want to find commits related to CSS in the [octocat/Spoon-Knife](https://github.com/octocat/Spoon-Knife) repository. Your query would look something like this:\n\n\n\n**Highlighting code search results**\n\nWhen searching for commits, you can get text match metadata for the **message** field. See the section on [text match metadata](#text-match-metadata) for full details.",
+      "documentationUrl": "https://developer.github.com/v3/search/#search-commits",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Search commits",
+      "params": {
+        "0": {
+          "description": "The search terms.",
+          "name": "q",
+          "required": false,
+          "type": "string"
+        },
+        "1": {
+          "default": "results are sorted by best match.",
+          "description": "The sort field. Can be `author-date` or `committer-date`.",
+          "enum": [
+            "author-date",
+            "committer-date"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "default": "desc",
+          "description": "The sort order if `sort` parameter is provided. One of `asc` or `desc`.",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "order",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/search/commits"
+    },
+    "issues": {
+      "description": "Find issues by state and keyword. This method returns up to 100 results [per page](/v3/#pagination).\n\nThe `q` search term can also contain any combination of the supported issue search qualifiers as described by the in-browser [issue search documentation](https://help.github.com/articles/searching-issues/) and [search syntax documentation](https://help.github.com/articles/search-syntax/):\n\n*   [`type`](https://help.github.com/articles/searching-issues#search-issues-or-pull-requests) With this qualifier you can restrict the search to issues (`issue`) or pull request (`pr`) only.\n*   [`in`](https://help.github.com/articles/searching-issues#scope-the-search-fields) Qualifies which fields are searched. With this qualifier you can restrict the search to just the title (`title`), body (`body`), comments (`comments`), or any combination of these.\n*   [`author`](https://help.github.com/articles/searching-issues#search-by-the-author-of-an-issue-or-pull-request) Finds issues or pull requests created by a certain user.\n*   [`assignee`](https://help.github.com/articles/searching-issues#search-by-the-assignee-of-an-issue-or-pull-request) Finds issues or pull requests that are assigned to a certain user.\n*   [`mentions`](https://help.github.com/articles/searching-issues#search-by-a-mentioned-user-within-an-issue-or-pull-request) Finds issues or pull requests that mention a certain user.\n*   [`commenter`](https://help.github.com/articles/searching-issues#search-by-a-commenter-within-an-issue-or-pull-request) Finds issues or pull requests that a certain user commented on.\n*   [`involves`](https://help.github.com/articles/searching-issues#search-by-a-user-thats-involved-within-an-issue-or-pull-request) Finds issues or pull requests that were either created by a certain user, assigned to that user, mention that user, or were commented on by that user.\n*   [`team`](https://help.github.com/articles/searching-issues/#search-by-a-team-thats-mentioned-within-an-issue-or-pull-request) For organizations you're a member of, finds issues or pull requests that @mention a team within the organization.\n*   [`state`](https://help.github.com/articles/searching-issues#search-based-on-whether-an-issue-or-pull-request-is-open) Filter issues or pull requests based on whether they're open or closed.\n*   [`labels`](https://help.github.com/articles/searching-issues#search-by-the-labels-on-an-issue) Filters issues or pull requests based on their labels.\n*   [`no`](https://help.github.com/articles/searching-issues#search-by-missing-metadata-on-an-issue-or-pull-request) Filters items missing certain metadata, such as `label`, `milestone`, or `assignee`\n*   [`language`](https://help.github.com/articles/searching-issues#search-by-the-main-language-of-a-repository) Searches for issues or pull requests within repositories that match a certain language.\n*   [`is`](https://help.github.com/articles/searching-issues#search-based-on-the-state-of-an-issue-or-pull-request) Searches for items within repositories that match a certain state, such as `open`, `closed`, or `merged`\n*   [`created` or `updated`](https://help.github.com/articles/searching-issues#search-based-on-when-an-issue-or-pull-request-was-created-or-last-updated) Filters issues or pull requests based on date of creation, or when they were last updated.\n*   [`merged`](https://help.github.com/articles/searching-issues#search-based-on-when-a-pull-request-was-merged) Filters pull requests based on the date when they were merged.\n*   [`status`](https://help.github.com/articles/searching-issues#search-based-on-commit-status) Filters pull requests based on the commit status.\n*   [`head` or `base`](https://help.github.com/articles/searching-issues#search-based-on-branch-names) Filters pull requests based on the branch that they came from or that they are modifying.\n*   [`closed`](https://help.github.com/articles/searching-issues#search-based-on-when-an-issue-or-pull-request-was-closed) Filters issues or pull requests based on the date when they were closed.\n*   [`comments`](https://help.github.com/articles/searching-issues#search-by-the-number-of-comments-an-issue-or-pull-request-has) Filters issues or pull requests based on the quantity of comments.\n*   [`user` or `repo`](https://help.github.com/articles/searching-issues#search-within-a-users-or-organizations-repositories) Limits searches to a specific user or repository.\n*   [`project`](https://help.github.com/articles/searching-issues/#search-by-project-board) Limits searches to a specific project board in a repository or organization.\n*   [`archived`](https://help.github.com/articles/searching-issues/#search-within-archived-repositories) Filters issues or pull requests based on whether they are in an archived repository.\n\nIf you know the specific SHA hash of a commit, you can use also [use it to search for pull requests](https://help.github.com/articles/searching-issues#search-by-the-commit-shas-within-a-pull-request) that contain that SHA. Note that the SHA syntax must be at least seven characters.\n\nLet's say you want to find the oldest unresolved Python bugs on Windows. Your query might look something like this.\n\n\n\nIn this query, we're searching for the keyword `windows`, within any open issue that's labeled as `bug`. The search runs across repositories whose primary language is Python. We’re sorting by creation date in ascending order, so that the oldest issues appear first in the search results.\n\n**Highlighting issue search results**\n\nYou might want to highlight the matching search terms when displaying search results. The API offers additional metadata to support this use case. To get this metadata in your search results, specify the `text-match` media type in your `Accept` header. For example, via cURL, the above query would look like this:\n\nThis produces the same JSON payload as above, with an extra key called `text_matches`, an array of objects. These objects provide information such as the position of your search terms within the text, as well as the `property` that included the search term.\n\nWhen searching for issues, you can get text match metadata for the issue **title**, issue **body**, and issue **comment body** fields. For details on the attributes present in the `text_matches` array, see [text match metadata](#text-match-metadata).\n\nHere's an example response:",
+      "documentationUrl": "https://developer.github.com/v3/search/#search-issues",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Search issues",
+      "params": {
+        "0": {
+          "description": "The search terms.",
+          "name": "q",
+          "required": false,
+          "type": "string"
+        },
+        "1": {
+          "default": "results are sorted by best match.",
+          "description": "The sort field. Can be `comments`, `created`, or `updated`.",
+          "enum": [
+            "comments",
+            "created",
+            "updated"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "default": "desc",
+          "description": "The sort order if `sort` parameter is provided. One of `asc` or `desc`.",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "order",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/search/issues"
+    },
+    "repos": {
+      "description": "Find repositories via various criteria. This method returns up to 100 results [per page](/v3/#pagination).\n\nThe `q` search term can also contain any combination of the supported repository search qualifiers as described by the in-browser [repository search documentation](https://help.github.com/articles/searching-repositories/) and [search syntax documentation](https://help.github.com/articles/search-syntax/):\n\n*   [`created` or `pushed`](https://help.github.com/articles/searching-repositories#search-based-on-when-a-repository-was-created-or-last-updated) Filters repositories based on date of creation, or when they were last updated.\n*   [`fork`](https://help.github.com/articles/searching-repositories#search-based-on-the-number-of-forks-the-parent-repository-has) Filters whether forked repositories should be included (`true`) or only forked repositories should be returned (`only`).\n*   [`forks`](https://help.github.com/articles/searching-repositories#search-based-on-the-number-of-forks-the-parent-repository-has) Filters repositories based on the number of forks.\n*   [`in`](https://help.github.com/articles/searching-repositories#scope-the-search-fields) Qualifies which fields are searched. With this qualifier you can restrict the search to just the repository name, description, readme, or any combination of these.\n*   [`language`](https://help.github.com/articles/searching-repositories#search-based-on-the-main-language-of-a-repository) Searches repositories based on the language they're written in.\n*   [`license`](https://help.github.com/articles/searching-repositories#search-by-license) Filters repositories by license or license family, using the [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type).\n*   [`repo` or `user`](https://help.github.com/articles/searching-repositories#search-within-a-users-or-organizations-repositories) Limits searches to a specific repository or user.\n*   [`size`](https://help.github.com/articles/searching-repositories#search-based-on-the-size-of-a-repository) Finds repositories that match a certain size (in kilobytes).\n*   [`stars`](https://help.github.com/articles/searching-repositories#search-based-on-the-number-of-stars-a-repository-has) Searches repositories based on the number of stars.\n*   [`topic`](https://help.github.com/articles/classifying-your-repository-with-topics/) Filters repositories based on the specified topic.\n*   [`archived`](https://help.github.com/articles/searching-repositories/#search-based-on-whether-a-repository-is-archived) Filters whether archived repositories should be included (`true`) or not (`false`).\n    \n    You can search for multiple topics by adding more `topic:` instances. For example:\n    \n    ```\n    curl -H \"Authentication: token TOKEN\" \\\n    -H \"Accept: application/vnd.github.mercy-preview+json\" \\\n    https://api.github.com/search/repositories?q=topic:ruby+topic:rails\n    \n    ```\n\nSuppose you want to search for popular Tetris repositories written in Assembly. Your query might look like this.\n\n\n\nIn this request, we're searching for repositories with the word `tetris` in the name, the description, or the README. We're limiting the results to only find repositories where the primary language is Assembly. We're sorting by stars in descending order, so that the most popular repositories appear first in the search results.\n\n**Highlighting repository search results**\n\nYou might want to highlight the matching search terms when displaying search results. The API offers additional metadata to support this use case. To get this metadata in your search results, specify the `text-match` media type in your `Accept` header. For example, via cURL, the above query would look like this:\n\nThis produces the same JSON payload as above, with an extra key called `text_matches`, an array of objects. These objects provide information such as the position of your search terms within the text, as well as the `property` that included the search term.\n\nWhen searching for repositories, you can get text match metadata for the **name** and **description** fields. For details on the attributes present in the `text_matches` array, see [text match metadata](#text-match-metadata).\n\nHere's an example response:",
+      "documentationUrl": "https://developer.github.com/v3/search/#search-repositories",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Search repositories",
+      "params": {
+        "0": {
+          "description": "The search keywords, as well as any qualifiers.",
+          "name": "q",
+          "required": false,
+          "type": "string"
+        },
+        "1": {
+          "default": "results are sorted by best match.",
+          "description": "The sort field. One of `stars`, `forks`, or `updated`.",
+          "enum": [
+            "stars",
+            "forks",
+            "updated"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "default": "desc",
+          "description": "The sort order if `sort` parameter is provided. One of `asc` or `desc`.",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "order",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/search/repositories"
+    },
+    "users": {
+      "description": "Find users via various criteria. This method returns up to 100 results [per page](/v3/#pagination).\n\nThe `q` search term can also contain any combination of the supported user search qualifiers as described by the in-browser [user search documentation](https://help.github.com/articles/searching-users/) and [search syntax documentation](https://help.github.com/articles/search-syntax/):\n\n*   [`type`](https://help.github.com/articles/searching-users#search-for-users-or-organizations) With this qualifier you can restrict the search to just personal accounts (`user`) or just organization accounts (`org`).\n*   [`in`](https://help.github.com/articles/searching-users#scope-the-search-fields) Qualifies which fields are searched. With this qualifier you can restrict the search to just the username (`login`), public email (`email`), full name (`fullname`), or any combination of these.\n*   [`repos`](https://help.github.com/articles/searching-users#search-based-on-the-number-of-repositories-a-user-has) Filters users based on the number of repositories they have.\n*   [`location`](https://help.github.com/articles/searching-users#search-based-on-the-location-where-a-user-resides) Filter users by the location indicated in their profile.\n*   [`language`](https://help.github.com/articles/searching-users#search-based-on-the-languages-of-a-users-repositories) Search for users that have repositories that match a certain language.\n*   [`created`](https://help.github.com/articles/searching-users#search-based-on-when-a-user-joined-github) Filter users based on when they joined.\n*   [`followers`](https://help.github.com/articles/searching-users#search-based-on-the-number-of-followers-a-user-has) Filter users based on the number of followers they have.\n\nImagine you're looking for a list of popular users. You might try out this query:\n\n\n\nHere, we're looking at users with the name Tom. We're only interested in those with more than 42 repositories, and only if they have over 1,000 followers.\n\n**Highlighting user search results**\n\nYou might want to highlight the matching search terms when displaying search results. The API offers additional metadata to support this use case. To get this metadata in your search results, specify the `text-match` media type in your `Accept` header. For example, via cURL, the above query would look like this:\n\nThis produces the same JSON payload as above, with an extra key called `text_matches`, an array of objects. These objects provide information such as the position of your search terms within the text, as well as the `property` that included the search term.\n\nWhen searching for users, you can get text match metadata for the issue **login**, **email**, and **name** fields. For details on the attributes present in the `text_matches` array, see [text match metadata](#text-match-metadata).",
+      "documentationUrl": "https://developer.github.com/v3/search/#search-users",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Search users",
+      "params": {
+        "0": {
+          "description": "The search terms.",
+          "name": "q",
+          "required": false,
+          "type": "string"
+        },
+        "1": {
+          "default": "results are sorted by best match.",
+          "description": "The sort field. Can be `followers`, `repositories`, or `joined`.",
+          "enum": [
+            "followers",
+            "repositories",
+            "joined"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "default": "desc",
+          "description": "The sort order if `sort` parameter is provided. One of `asc` or `desc`.",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "name": "order",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "4": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/search/users"
+    }
+  },
+  "users": {
+    "acceptRepoInvite": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/invitations/#accept-a-repository-invitation",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "name": "Accept a repository invitation",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "invitation_id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/repository_invitations/:invitation_id"
+    },
+    "addEmails": {
+      "description": "You can post a single email address or an array of addresses:",
+      "documentationUrl": "https://developer.github.com/v3/users/emails/#add-email-addresses",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Add email address(es)",
+      "params": {},
+      "path": "/user/emails"
+    },
+    "addRepoToInstallation": {
+      "description": "Add a single repository to an installation.\n\nThe authenticated user must have admin access to the repository.",
+      "documentationUrl": "https://developer.github.com/v3/apps/installations/#add-repository-to-installation",
+      "enabledForApps": false,
+      "method": "PUT",
+      "name": "Add repository to installation",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "installation_id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repository_id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/installations/:installation_id/repositories/:repository_id"
+    },
+    "blockUser": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/users/blocking/#block-a-user",
+      "enabledForApps": false,
+      "method": "PUT",
+      "name": "Block a user",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/blocks/:username"
+    },
+    "checkBlockedUser": {
+      "description": "If the user is blocked:\n\nIf the user is not blocked:",
+      "documentationUrl": "https://developer.github.com/v3/users/blocking/#check-whether-youve-blocked-a-user",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Check whether you've blocked a user",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/blocks/:username"
+    },
+    "checkFollowing": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/users/followers/#check-if-you-are-following-a-user",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Check if you are following a user",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/following/:username"
+    },
+    "checkIfOneFollowersOther": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/users/followers/#check-if-one-user-follows-another",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Check if one user follows another",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "target_user",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/users/:username/following/:target_user"
+    },
+    "createGpgKey": {
+      "description": "Creates a GPG key. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:gpg_key` [scope](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
+      "documentationUrl": "https://developer.github.com/v3/users/gpg_keys/#create-a-gpg-key",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Create a GPG key",
+      "params": {},
+      "path": "/user/gpg_keys"
+    },
+    "createKey": {
+      "description": "Creates a public key. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
+      "documentationUrl": "https://developer.github.com/v3/users/keys/#create-a-public-key",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Create a public key",
+      "params": {},
+      "path": "/user/keys"
+    },
+    "declineRepoInvite": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/repos/invitations/#decline-a-repository-invitation",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Decline a repository invitation",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "invitation_id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/repository_invitations/:invitation_id"
+    },
+    "deleteEmails": {
+      "description": "You can include a single email address or an array of addresses:",
+      "documentationUrl": "https://developer.github.com/v3/users/emails/#delete-email-addresses",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Delete email address(es)",
+      "params": {},
+      "path": "/user/emails"
+    },
+    "deleteGpgKey": {
+      "description": "Removes a GPG key. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:gpg_key` [scope](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
+      "documentationUrl": "https://developer.github.com/v3/users/gpg_keys/#delete-a-gpg-key",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Delete a GPG key",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/gpg_keys/:id"
+    },
+    "deleteKey": {
+      "description": "Removes a public key. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
+      "documentationUrl": "https://developer.github.com/v3/users/keys/#delete-a-public-key",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Delete a public key",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/keys/:id"
+    },
+    "editOrgMembership": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/orgs/members/#edit-your-organization-membership",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "name": "Edit your organization membership",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "The state that the membership should be in. Only `\"active\"` will be accepted.",
+          "name": "state",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/memberships/orgs/:org"
+    },
+    "followUser": {
+      "description": "Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](/v3/#http-verbs).\"\n\nFollowing a user requires the user to be logged in and authenticated with basic auth or OAuth with the `user:follow` scope.",
+      "documentationUrl": "https://developer.github.com/v3/users/followers/#follow-a-user",
+      "enabledForApps": false,
+      "method": "PUT",
+      "name": "Follow a user",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/following/:username"
+    },
+    "get": {
+      "description": "Lists public and private profile information when authenticated through basic auth or OAuth with the `user` scope.\n\nLists public profile information when authenticated through OAuth without the `user` scope.",
+      "documentationUrl": "https://developer.github.com/v3/users/#get-the-authenticated-user",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get the authenticated user",
+      "params": {},
+      "path": "/user"
+    },
+    "getAll": {
+      "description": "Lists all users, in the order that they signed up on GitHub. This list includes personal user accounts and organization accounts.\n\nNote: Pagination is powered exclusively by the `since` parameter. Use the [Link header](/v3/#link-header) to get the URL for the next page of users.",
+      "documentationUrl": "https://developer.github.com/v3/users/#get-all-users",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get all users",
+      "params": {
+        "0": {
+          "description": "The integer ID of the last User that you've seen.",
+          "name": "since",
+          "required": false,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/users"
+    },
+    "getBlockedUsers": {
+      "description": "List the users you've blocked on your personal account.",
+      "documentationUrl": "https://developer.github.com/v3/users/blocking/#list-blocked-users",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List blocked users",
+      "params": {},
+      "path": "/user/blocks"
+    },
+    "getEmails": {
+      "description": "This endpoint is accessible with the user:email scope.",
+      "documentationUrl": "https://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List email addresses for a user",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/user/emails"
+    },
+    "getFollowers": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/users/followers/#list-followers-of-a-user",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List the authenticated user's followers",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/user/followers"
+    },
+    "getFollowersForUser": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/users/followers/#list-followers-of-a-user",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List a user's followers",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/users/:username/followers"
+    },
+    "getFollowing": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/users/followers/#list-users-followed-by-another-user",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List who the authenticated user is following",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/user/following"
+    },
+    "getFollowingForUser": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/users/followers/#list-users-followed-by-another-user",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List who a user is following",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/users/:username/following"
+    },
+    "getForUser": {
+      "description": "Note: The returned email is the user's publicly visible email address (or `null` if the user has not [specified a public email address in their profile](https://github.com/settings/profile)). The publicly visible email address only displays for authenticated API users.",
+      "documentationUrl": "https://developer.github.com/v3/users/#get-a-single-user",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "Get a single user",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/users/:username"
+    },
+    "getGpgKey": {
+      "description": "View extended details for a single GPG key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:gpg_key` [scope](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
+      "documentationUrl": "https://developer.github.com/v3/users/gpg_keys/#get-a-single-gpg-key",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get a single GPG key",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/gpg_keys/:id"
+    },
+    "getGpgKeys": {
+      "description": "Lists the current user's GPG keys. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:gpg_key` [scope](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
+      "documentationUrl": "https://developer.github.com/v3/users/gpg_keys/#list-your-gpg-keys",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List your GPG keys",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/user/gpg_keys"
+    },
+    "getGpgKeysForUser": {
+      "description": "Lists the GPG keys for a user. This information is accessible by anyone.",
+      "documentationUrl": "https://developer.github.com/v3/users/gpg_keys/#list-gpg-keys-for-a-user",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List GPG keys for a user",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/users/:username/gpg_keys"
+    },
+    "getInstallationRepos": {
+      "description": "List repositories that are accessible to the authenticated user for an installation.\n\nThe access the user has to each repository is included in the hash under the `permissions` key.",
+      "documentationUrl": "https://developer.github.com/v3/apps/installations/#list-repositories-accessible-to-the-user-for-an-installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List repositories accessible to the user for an installation",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "installation_id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/user/installations/:installation_id/repositories"
+    },
+    "getInstallations": {
+      "description": "List installations that are accessible to the authenticated user.\n\nThe permissions the installation has are included under the `permissions` key.",
+      "documentationUrl": "https://developer.github.com/v3/apps/#list-installations-for-user",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List installations for user",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/user/installations"
+    },
+    "getKey": {
+      "description": "View extended details for a single public key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
+      "documentationUrl": "https://developer.github.com/v3/users/keys/#get-a-single-public-key",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get a single public key",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/keys/:id"
+    },
+    "getKeys": {
+      "description": "Lists the current user's keys. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
+      "documentationUrl": "https://developer.github.com/v3/users/keys/#list-your-public-keys",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List your public keys",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/user/keys"
+    },
+    "getKeysForUser": {
+      "description": "Lists the _verified_ public keys for a user. This is accessible by anyone.",
+      "documentationUrl": "https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user",
+      "enabledForApps": true,
+      "method": "GET",
+      "name": "List public keys for a user",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/users/:username/keys"
+    },
+    "getMarketplacePurchases": {
+      "description": "**Note:** This call must be authenticated with a user's OAuth token.",
+      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#get-a-users-marketplace-purchases",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get a user's Marketplace purchases",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/user/marketplace_purchases"
+    },
+    "getMarketplaceStubbedPurchases": {
+      "description": "**Note:** This call must be authenticated with a user's OAuth token.",
+      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#get-a-users-marketplace-purchases",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get a user's Marketplace purchases (stubbed)",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/user/marketplace_purchases/stubbed"
+    },
+    "getOrgMembership": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/orgs/members/#get-your-organization-membership",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get your organization membership",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "org",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/memberships/orgs/:org"
+    },
+    "getOrgMemberships": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/orgs/members/#list-your-organization-memberships",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List your organization memberships",
+      "params": {
+        "0": {
+          "description": "Indicates the state of the memberships to return. Can be either `active` or `pending`. If not specified, the API returns both active and pending memberships.",
+          "enum": [
+            "active",
+            "pending"
+          ],
+          "name": "state",
+          "required": false,
+          "type": "string"
+        },
+        "1": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "2": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/user/memberships/orgs"
+    },
+    "getOrgs": {
+      "description": "List organizations for the authenticated user.\n\n**OAuth scope requirements**\n\nThis only lists organizations that your authorization allows you to operate on in some way (e.g., you can list teams with `read:org` scope, you can publicize your organization membership with `user` scope, etc.). Therefore, this API requires at least `user` or `read:org` scope. OAuth requests with insufficient scope receive a `403 Forbidden` response.",
+      "documentationUrl": "https://developer.github.com/v3/orgs/#list-your-organizations",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List your organizations",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/user/orgs"
+    },
+    "getPublicEmails": {
+      "description": "This endpoint is accessible with the `user:email` scope.",
+      "documentationUrl": "https://developer.github.com/v3/users/emails/#list-public-email-addresses-for-a-user",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List public email addresses for a user",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/user/public_emails"
+    },
+    "getRepoInvites": {
+      "description": "When authenticating as a user, this endpoint will list all currently open repository invitations for that user.\n\n",
+      "documentationUrl": "https://developer.github.com/v3/repos/invitations/#list-a-users-repository-invitations",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List a user's repository invitations",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/user/repository_invitations"
+    },
+    "getTeams": {
+      "description": "List all of the teams across all of the organizations to which the authenticated user belongs. This method requires `user`, `repo`, or `read:org` [scope](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/) when authenticating via [OAuth](/apps/building-integrations/setting-up-and-registering-oauth-apps/).",
+      "documentationUrl": "https://developer.github.com/v3/teams/#list-user-teams",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "List user teams",
+      "params": {
+        "0": {
+          "default": 30,
+          "description": "Results per page (max 100)",
+          "name": "per_page",
+          "required": false,
+          "type": "integer"
+        },
+        "1": {
+          "default": 1,
+          "description": "Page number of the results to fetch.",
+          "name": "page",
+          "required": false,
+          "type": "integer"
+        }
+      },
+      "path": "/user/teams"
+    },
+    "removeRepoFromInstallation": {
+      "description": "Remove a single repository from an installation.\n\nThe authenticated user must have admin access to the repository.",
+      "documentationUrl": "https://developer.github.com/v3/apps/installations/#remove-repository-from-installation",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Remove repository from installation",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "installation_id",
+          "required": true,
+          "type": "string"
+        },
+        "1": {
+          "description": "",
+          "name": "repository_id",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/installations/:installation_id/repositories/:repository_id"
+    },
+    "togglePrimaryEmailVisibility": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/users/emails/#toggle-primary-email-visibility",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "name": "Toggle primary email visibility",
+      "params": {},
+      "path": "/user/email/visibility"
+    },
+    "unblockUser": {
+      "description": "",
+      "documentationUrl": "https://developer.github.com/v3/users/blocking/#unblock-a-user",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Unblock a user",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/blocks/:username"
+    },
+    "unfollowUser": {
+      "description": "Unfollowing a user requires the user to be logged in and authenticated with basic auth or OAuth with the `user:follow` scope.",
+      "documentationUrl": "https://developer.github.com/v3/users/followers/#unfollow-a-user",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Unfollow a user",
+      "params": {
+        "0": {
+          "description": "",
+          "name": "username",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "/user/following/:username"
+    },
+    "update": {
+      "description": "**Note:** If your email is set to private and you send an `email` parameter as part of this request to update your profile, your privacy settings are still enforced: the email address will not be displayed on your public profile or via the API.",
+      "documentationUrl": "https://developer.github.com/v3/users/#update-the-authenticated-user",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "name": "Update the authenticated user",
+      "params": {
+        "0": {
+          "description": "The new name of the user.",
+          "name": "name",
+          "required": false,
+          "type": "string"
+        },
+        "1": {
+          "description": "The publicly visible email address of the user.",
+          "name": "email",
+          "required": false,
+          "type": "string"
+        },
+        "2": {
+          "description": "The new blog URL of the user.",
+          "name": "blog",
+          "required": false,
+          "type": "string"
+        },
+        "3": {
+          "description": "The new company of the user.",
+          "name": "company",
+          "required": false,
+          "type": "string"
+        },
+        "4": {
+          "description": "The new location of the user.",
+          "name": "location",
+          "required": false,
+          "type": "string"
+        },
+        "5": {
+          "description": "The new hiring availability of the user.",
+          "name": "hireable",
+          "required": false,
+          "type": "boolean"
+        },
+        "6": {
+          "description": "The new short biography of the user.",
+          "name": "bio",
+          "required": false,
+          "type": "string"
+        }
+      },
+      "path": "/user"
+    }
+  }
+}

--- a/scripts/routes-for-api-docs.json
+++ b/scripts/routes-for-api-docs.json
@@ -1,19 +1,20 @@
 {
   "activity": {
     "checkNotificationThreadSubscription": {
-      "description": "This checks to see if the current user is subscribed to a thread. You can also [get a Repository subscription](/v3/activity/watching/#get-a-repository-subscription).\n\nNote that subscriptions are only generated if a user is participating in a conversation--for example, they've replied to the thread, were **@mention**ed, or manually subscribe to a thread.",
+      "description": "This checks to see if the current user is subscribed to a thread. You can also [get a Repository subscription](https://developer.github.com/v3/activity/watching/#get-a-repository-subscription).\n\nNote that subscriptions are only generated if a user is participating in a conversation--for example, they've replied to the thread, were **@mention**ed, or manually subscribe to a thread.",
       "documentationUrl": "https://developer.github.com/v3/activity/notifications/#get-a-thread-subscription",
       "enabledForApps": false,
       "method": "GET",
       "name": "Get a Thread Subscription",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/notifications/threads/:id/subscription"
     },
     "checkStarringRepo": {
@@ -22,20 +23,22 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Check if you are starring a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/starred/:owner/:repo"
     },
     "deleteNotificationThreadSubscription": {
@@ -44,14 +47,15 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Delete a Thread Subscription",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/notifications/threads/:id/subscription"
     },
     "getEvents": {
@@ -60,22 +64,24 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List public events",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/events"
     },
     "getEventsForOrg": {
@@ -84,28 +90,31 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List public events for an organization",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/orgs/:org/events"
     },
     "getEventsForRepo": {
@@ -114,70 +123,78 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List repository events",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/events"
     },
     "getEventsForRepoIssues": {
-      "description": "Repository issue events have a different format than other events, as documented in the [Issue Events API](/v3/issues/events/).",
+      "description": "Repository issue events have a different format than other events, as documented in the [Issue Events API](https://developer.github.com/v3/issues/events/).",
       "documentationUrl": "https://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository",
       "enabledForApps": false,
       "method": "GET",
       "name": "List issue events for a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/events"
     },
     "getEventsForRepoNetwork": {
@@ -186,34 +203,38 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List public events for a network of repositories",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/networks/:owner/:repo/events"
     },
     "getEventsForUser": {
@@ -222,28 +243,31 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List events performed by a user",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/users/:username/events"
     },
     "getEventsForUserOrg": {
@@ -252,34 +276,38 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List events for an organization",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/users/:username/events/orgs/:org"
     },
     "getEventsForUserPublic": {
@@ -288,28 +316,31 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List public events performed by a user",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/users/:username/events/public"
     },
     "getEventsReceived": {
@@ -318,28 +349,31 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List events that a user has received",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/users/:username/received_events"
     },
     "getEventsReceivedPublic": {
@@ -348,37 +382,40 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List public events that a user has received",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/users/:username/received_events/public"
     },
     "getFeeds": {
-      "description": "GitHub provides several timeline resources in [Atom](http://en.wikipedia.org/wiki/Atom_(standard)) format. The Feeds API lists all the feeds available to the authenticated user:\n\n*   **Timeline**: The GitHub global public timeline\n*   **User**: The public timeline for any user, using [URI template](/v3/#hypermedia)\n*   **Current user public**: The public timeline for the authenticated user\n*   **Current user**: The private timeline for the authenticated user\n*   **Current user actor**: The private timeline for activity created by the authenticated user\n*   **Current user organizations**: The private timeline for the organizations the authenticated user is a member of.\n\n**Note**: Private feeds are only returned when [authenticating via Basic Auth](/v3/#basic-authentication) since current feed URIs use the older, non revocable auth tokens.",
+      "description": "GitHub provides several timeline resources in [Atom](http://en.wikipedia.org/wiki/Atom_(standard)) format. The Feeds API lists all the feeds available to the authenticated user:\n\n*   **Timeline**: The GitHub global public timeline\n*   **User**: The public timeline for any user, using [URI template](https://developer.github.com/v3/#hypermedia)\n*   **Current user public**: The public timeline for the authenticated user\n*   **Current user**: The private timeline for the authenticated user\n*   **Current user actor**: The private timeline for activity created by the authenticated user\n*   **Current user organizations**: The private timeline for the organizations the authenticated user is a member of.\n\n**Note**: Private feeds are only returned when [authenticating via Basic Auth](https://developer.github.com/v3/#basic-authentication) since current feed URIs use the older, non revocable auth tokens.",
       "documentationUrl": "https://developer.github.com/v3/activity/feeds/#list-feeds",
       "enabledForApps": true,
       "method": "GET",
       "name": "List Feeds",
-      "params": {},
+      "params": [],
       "path": "/feeds"
     },
     "getNotificationThread": {
@@ -387,14 +424,15 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "View a single thread",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/notifications/threads/:id"
     },
     "getNotifications": {
@@ -403,49 +441,55 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List your notifications",
-      "params": {
-        "0": {
-          "default": false,
-          "description": "If `true`, show notifications marked as read.",
+      "params": [
+        {
           "name": "all",
-          "required": false,
-          "type": "boolean"
-        },
-        "1": {
+          "type": "boolean",
+          "description": "If `true`, show notifications marked as read.",
           "default": false,
-          "description": "If `true`, only shows notifications in which the user is directly participating or mentioned.",
+          "required": false,
+          "location": "query"
+        },
+        {
           "name": "participating",
+          "type": "boolean",
+          "description": "If `true`, only shows notifications in which the user is directly participating or mentioned.",
+          "default": false,
           "required": false,
-          "type": "boolean"
+          "location": "query"
         },
-        "2": {
-          "default": "Time.now",
-          "description": "Only show notifications updated after the given time. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+        {
           "name": "since",
+          "type": "string",
+          "description": "Only show notifications updated after the given time. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "default": "<current date/time>",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "description": "Only show notifications updated before the given time. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+        {
           "name": "before",
+          "type": "string",
+          "description": "Only show notifications updated before the given time. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "4": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "5": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/notifications"
     },
     "getNotificationsForUser": {
@@ -454,61 +498,69 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List your notifications in a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": false,
-          "description": "If `true`, show notifications marked as read.",
+        {
           "name": "all",
-          "required": false,
-          "type": "boolean"
-        },
-        "3": {
+          "type": "boolean",
+          "description": "If `true`, show notifications marked as read.",
           "default": false,
-          "description": "If `true`, only shows notifications in which the user is directly participating or mentioned.",
+          "required": false,
+          "location": "query"
+        },
+        {
           "name": "participating",
+          "type": "boolean",
+          "description": "If `true`, only shows notifications in which the user is directly participating or mentioned.",
+          "default": false,
           "required": false,
-          "type": "boolean"
+          "location": "query"
         },
-        "4": {
-          "default": "Time.now",
-          "description": "Only show notifications updated after the given time. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+        {
           "name": "since",
+          "type": "string",
+          "description": "Only show notifications updated after the given time. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "default": "<current date/time>",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "5": {
-          "description": "Only show notifications updated before the given time. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+        {
           "name": "before",
+          "type": "string",
+          "description": "Only show notifications updated before the given time. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "6": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "7": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/notifications"
     },
     "getRepoSubscription": {
@@ -517,154 +569,169 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Get a Repository Subscription",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/subscription"
     },
     "getStargazersForRepo": {
-      "description": "You can also find out _when_ stars were created by passing the following custom [media type](/v3/media/) via the `Accept` header:",
+      "description": "You can also find out _when_ stars were created by passing the following custom [media type](https://developer.github.com/v3/media/) via the `Accept` header:",
       "documentationUrl": "https://developer.github.com/v3/activity/starring/#list-stargazers",
       "enabledForApps": true,
       "method": "GET",
       "name": "List Stargazers",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/stargazers"
     },
     "getStarredRepos": {
-      "description": "You can also find out _when_ stars were created by passing the following custom [media type](/v3/media/) via the `Accept` header:",
+      "description": "You can also find out _when_ stars were created by passing the following custom [media type](https://developer.github.com/v3/media/) via the `Accept` header:",
       "documentationUrl": "https://developer.github.com/v3/activity/starring/#list-repositories-being-starred",
       "enabledForApps": false,
       "method": "GET",
       "name": "List repositories being starred by the authenticated user",
-      "params": {
-        "0": {
-          "default": "created",
+      "params": [
+        {
+          "name": "sort",
+          "type": "string",
           "description": "One of `created` (when the repository was starred) or `updated` (when it was last pushed to).",
+          "default": "created",
+          "required": false,
           "enum": [
             "created",
             "updated"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "1": {
-          "default": "desc",
+        {
+          "name": "direction",
+          "type": "string",
           "description": "One of `asc` (ascending) or `desc` (descending).",
+          "default": "desc",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "direction",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/user/starred"
     },
     "getStarredReposForUser": {
-      "description": "You can also find out _when_ stars were created by passing the following custom [media type](/v3/media/) via the `Accept` header:",
+      "description": "You can also find out _when_ stars were created by passing the following custom [media type](https://developer.github.com/v3/media/) via the `Accept` header:",
       "documentationUrl": "https://developer.github.com/v3/activity/starring/#list-repositories-being-starred",
       "enabledForApps": false,
       "method": "GET",
       "name": "List repositories being starred by a user",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": "created",
+        {
+          "name": "sort",
+          "type": "string",
           "description": "One of `created` (when the repository was starred) or `updated` (when it was last pushed to).",
+          "default": "created",
+          "required": false,
           "enum": [
             "created",
             "updated"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
-          "default": "desc",
+        {
+          "name": "direction",
+          "type": "string",
           "description": "One of `asc` (ascending) or `desc` (descending).",
+          "default": "desc",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "direction",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/users/:username/starred"
     },
     "getWatchedRepos": {
@@ -673,22 +740,24 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List repositories being watched by the authenticated user",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/user/subscriptions"
     },
     "getWatchedReposForUser": {
@@ -697,28 +766,31 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List repositories being watched by a user",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/users/:username/subscriptions"
     },
     "getWatchersForRepo": {
@@ -727,34 +799,38 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List watchers",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/subscribers"
     },
     "markNotificationThreadAsRead": {
@@ -763,14 +839,15 @@
       "enabledForApps": false,
       "method": "PATCH",
       "name": "Mark a thread as read",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/notifications/threads/:id"
     },
     "markNotificationsAsRead": {
@@ -779,15 +856,16 @@
       "enabledForApps": false,
       "method": "PUT",
       "name": "Mark as read",
-      "params": {
-        "0": {
-          "default": "Time.now",
-          "description": "Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+      "params": [
+        {
           "name": "last_read_at",
+          "type": "string",
+          "description": "Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "default": "<current date/time>",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/notifications"
     },
     "markNotificationsAsReadForRepo": {
@@ -796,27 +874,30 @@
       "enabledForApps": false,
       "method": "PUT",
       "name": "Mark notifications as read in a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "repo",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "default": "Time.now",
-          "description": "Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
           "name": "last_read_at",
+          "type": "string",
+          "description": "Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+          "default": "<current date/time>",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/notifications"
     },
     "setNotificationThreadSubscription": {
@@ -825,26 +906,29 @@
       "enabledForApps": false,
       "method": "PUT",
       "name": "Set a Thread Subscription",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "description": "Determines if notifications should be received from this thread",
+        {
           "name": "subscribed",
+          "type": "boolean",
+          "description": "Determines if notifications should be received from this thread",
           "required": false,
-          "type": "boolean"
+          "location": "body"
         },
-        "2": {
-          "description": "Determines if all notifications should be blocked from this thread",
+        {
           "name": "ignored",
+          "type": "boolean",
+          "description": "Determines if all notifications should be blocked from this thread",
           "required": false,
-          "type": "boolean"
+          "location": "body"
         }
-      },
+      ],
       "path": "/notifications/threads/:id/subscription"
     },
     "setRepoSubscription": {
@@ -853,54 +937,60 @@
       "enabledForApps": false,
       "method": "PUT",
       "name": "Set a Repository Subscription",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "Determines if notifications should be received from this repository.",
+        {
           "name": "subscribed",
+          "type": "boolean",
+          "description": "Determines if notifications should be received from this repository.",
           "required": false,
-          "type": "boolean"
+          "location": "body"
         },
-        "3": {
-          "description": "Determines if all notifications should be blocked from this repository.",
+        {
           "name": "ignored",
+          "type": "boolean",
+          "description": "Determines if all notifications should be blocked from this repository.",
           "required": false,
-          "type": "boolean"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/subscription"
     },
     "starRepo": {
-      "description": "Requires for the user to be authenticated.\n\nNote that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](/v3/#http-verbs).\"",
+      "description": "Requires for the user to be authenticated.\n\nNote that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](https://developer.github.com/v3/#http-verbs).\"",
       "documentationUrl": "https://developer.github.com/v3/activity/starring/#star-a-repository",
       "enabledForApps": false,
       "method": "PUT",
       "name": "Star a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/starred/:owner/:repo"
     },
     "unstarRepo": {
@@ -909,20 +999,22 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Unstar a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/starred/:owner/:repo"
     },
     "unwatchRepo": {
@@ -931,20 +1023,22 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Delete a Repository Subscription",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/subscription"
     }
   },
@@ -955,20 +1049,22 @@
       "enabledForApps": false,
       "method": "PUT",
       "name": "Add repository to installation",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "installation_id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repository_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/installations/:installation_id/repositories/:repository_id"
     },
     "checkMarketplaceListingAccount": {
@@ -977,28 +1073,31 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Check if a GitHub account is associated with any Marketplace listing",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/marketplace_listing/accounts/:id"
     },
     "checkMarketplaceListingStubbedAccount": {
@@ -1007,28 +1106,31 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Check if a GitHub account is associated with any Marketplace listing (stubbed)",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/marketplace_listing/stubbed/accounts/:id"
     },
     "createInstallationToken": {
@@ -1037,23 +1139,24 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a new installation token",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "installation_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/installations/:installation_id/access_tokens"
     },
     "get": {
-      "description": "Returns the GitHub App associated with the [authentication credentials](/apps/building-github-apps/authentication-options-for-github-apps#authenticating-as-a-github-app) used.",
+      "description": "Returns the GitHub App associated with the [authentication credentials](https://developer.github.com/apps/building-github-apps/authentication-options-for-github-apps#authenticating-as-a-github-app) used.",
       "documentationUrl": "https://developer.github.com/v3/apps/#get-the-authenticated-github-app",
       "enabledForApps": true,
       "method": "GET",
       "name": "Get the authenticated GitHub App",
-      "params": {},
+      "params": [],
       "path": "/app"
     },
     "getForSlug": {
@@ -1062,14 +1165,15 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a single GitHub App",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "app_slug",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/apps/:app_slug"
     },
     "getInstallation": {
@@ -1078,14 +1182,15 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a single installation",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "installation_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/app/installations/:installation_id"
     },
     "getInstallationRepositories": {
@@ -1094,22 +1199,24 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List repositories",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/installation/repositories"
     },
     "getInstallations": {
@@ -1118,73 +1225,80 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Find installations",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/app/installations"
     },
     "getMarketplaceListingPlanAccounts": {
-      "description": "",
+      "description": "Returns any accounts associated with a plan, including free plans. For per-seat pricing, you see the list of accounts that have purchased the plan, including the number of seats purchased.",
       "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#list-all-github-accounts-user-or-organization-on-a-specific-plan",
       "enabledForApps": false,
       "method": "GET",
       "name": "List all GitHub accounts (user or organization) on a specific plan",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": "created",
+        {
+          "name": "sort",
+          "type": "string",
           "description": "Sorts the GitHub accounts by the date they were created or last updated. Can be one of `created` or `updated`.",
+          "default": "created",
+          "required": false,
           "enum": [
             "created",
             "updated"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
+        {
+          "name": "direction",
+          "type": "string",
           "description": "To return the oldest accounts first, set to `asc`. Can be one of `asc` or `desc`. Ignored without the `sort` parameter.",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "direction",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/marketplace_listing/plans/:id/accounts"
     },
     "getMarketplaceListingPlans": {
@@ -1193,73 +1307,80 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List all plans for your Marketplace listing",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/marketplace_listing/plans"
     },
     "getMarketplaceListingStubbedPlanAccounts": {
-      "description": "",
+      "description": "Returns any accounts associated with a plan, including free plans. For per-seat pricing, you see the list of accounts that have purchased the plan, including the number of seats purchased.",
       "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#list-all-github-accounts-user-or-organization-on-a-specific-plan",
       "enabledForApps": false,
       "method": "GET",
       "name": "List all GitHub accounts (user or organization) on a specific plan (stubbed)",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": "created",
+        {
+          "name": "sort",
+          "type": "string",
           "description": "Sorts the GitHub accounts by the date they were created or last updated. Can be one of `created` or `updated`.",
+          "default": "created",
+          "required": false,
           "enum": [
             "created",
             "updated"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
+        {
+          "name": "direction",
+          "type": "string",
           "description": "To return the oldest accounts first, set to `asc`. Can be one of `asc` or `desc`. Ignored without the `sort` parameter.",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "direction",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/marketplace_listing/stubbed/plans/:id/accounts"
     },
     "getMarketplaceListingStubbedPlans": {
@@ -1268,22 +1389,24 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List all plans for your Marketplace listing (stubbed)",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/marketplace_listing/stubbed/plans"
     },
     "removeRepoFromInstallation": {
@@ -1292,90 +1415,100 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Remove repository from installation",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "installation_id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repository_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/installations/:installation_id/repositories/:repository_id"
     }
   },
   "authorization": {
     "check": {
-      "description": "OAuth applications can use a special API method for checking OAuth token validity without running afoul of normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
+      "description": "OAuth applications can use a special API method for checking OAuth token validity without running afoul of normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
       "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#check-an-authorization",
       "enabledForApps": false,
       "method": "GET",
       "name": "Check an authorization",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "client_id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "access_token",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/applications/:client_id/tokens/:access_token"
     },
     "create": {
-      "description": "If you need a small number of personal access tokens, implementing the [web flow](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-authorization-options-for-oauth-apps/) can be cumbersome. Instead, tokens can be created using the OAuth Authorizations API using [Basic Authentication](/v3/auth#basic-authentication). To create personal access tokens for a particular OAuth application, you must provide its client ID and secret, found on the OAuth application settings page, linked from your [OAuth applications listing on GitHub](https://github.com/settings/developers).\n\nIf your OAuth application intends to create multiple tokens for one user, use `fingerprint` to differentiate between them.\n\nYou can also create OAuth tokens through the web UI via the [personal access tokens settings](https://github.com/settings/tokens). Read more about these tokens on the [GitHub Help site](https://help.github.com/articles/creating-an-access-token-for-command-line-use).\n\nOrganizations that enforce SAML SSO require personal access tokens to be whitelisted. Read more about whitelisting tokens on the [GitHub Help site](https://help.github.com/articles/about-identity-and-access-management-with-saml-single-sign-on).",
+      "description": "If you need a small number of personal access tokens, implementing the [web flow](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-authorization-options-for-oauth-apps/) can be cumbersome. Instead, tokens can be created using the OAuth Authorizations API using [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication). To create personal access tokens for a particular OAuth application, you must provide its client ID and secret, found on the OAuth application settings page, linked from your [OAuth applications listing on GitHub](https://github.com/settings/developers).\n\nIf your OAuth application intends to create multiple tokens for one user, use `fingerprint` to differentiate between them.\n\nYou can also create OAuth tokens through the web UI via the [personal access tokens settings](https://github.com/settings/tokens). Read more about these tokens on the [GitHub Help site](https://help.github.com/articles/creating-an-access-token-for-command-line-use).\n\nOrganizations that enforce SAML SSO require personal access tokens to be whitelisted. Read more about whitelisting tokens on the [GitHub Help site](https://help.github.com/articles/about-identity-and-access-management-with-saml-single-sign-on).",
       "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization",
       "enabledForApps": false,
       "method": "POST",
       "name": "Create a new authorization",
-      "params": {
-        "0": {
-          "description": "A list of scopes that this authorization is in.",
+      "params": [
+        {
           "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
           "required": false,
-          "type": "array"
+          "location": "body"
         },
-        "1": {
-          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
+        {
           "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "2": {
-          "description": "A URL to remind you what app the OAuth token is for.",
+        {
           "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "The 20 character OAuth app client key for which to create the token.",
+        {
           "name": "client_id",
+          "type": "string",
+          "description": "The 20 character OAuth app client key for which to create the token.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The 40 character OAuth app client secret for which to create the token.",
+        {
           "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret for which to create the token.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
+        {
           "name": "fingerprint",
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/authorizations"
     },
     "delete": {
@@ -1384,14 +1517,15 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Delete an authorization",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/authorizations/:id"
     },
     "deleteGrant": {
@@ -1400,14 +1534,15 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Delete a grant",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/applications/grants/:id"
     },
     "get": {
@@ -1416,14 +1551,15 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Get a single authorization",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/authorizations/:id"
     },
     "getAll": {
@@ -1432,22 +1568,24 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List your authorizations",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/authorizations"
     },
     "getGrant": {
@@ -1456,38 +1594,41 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Get a single grant",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/applications/grants/:id"
     },
     "getGrants": {
-      "description": "You can use this API to list the set of OAuth applications that have been granted access to your account. Unlike the [list your authorizations](/v3/oauth_authorizations/#list-your-authorizations) API, this API does not manage individual tokens. This API will return one entry for each OAuth application that has been granted access to your account, regardless of the number of tokens an application has generated for your user. The list of OAuth applications returned matches what is shown on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized). The `scopes` returned are the union of scopes authorized for the application. For example, if an application has one token with `repo` scope and another token with `user` scope, the grant will return `[\"repo\", \"user\"]`.",
+      "description": "You can use this API to list the set of OAuth applications that have been granted access to your account. Unlike the [list your authorizations](https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations) API, this API does not manage individual tokens. This API will return one entry for each OAuth application that has been granted access to your account, regardless of the number of tokens an application has generated for your user. The list of OAuth applications returned matches what is shown on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized). The `scopes` returned are the union of scopes authorized for the application. For example, if an application has one token with `repo` scope and another token with `user` scope, the grant will return `[\"repo\", \"user\"]`.",
       "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#list-your-grants",
       "enabledForApps": false,
       "method": "GET",
       "name": "List your grants",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/applications/grants"
     },
     "getOrCreateAuthorizationForApp": {
@@ -1496,44 +1637,50 @@
       "enabledForApps": false,
       "method": "PUT",
       "name": "Get-or-create an authorization for a specific app",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "client_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+        {
           "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "2": {
-          "description": "A list of scopes that this authorization is in.",
+        {
           "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
           "required": false,
-          "type": "array"
+          "location": "body"
         },
-        "3": {
-          "description": "A note to remind you what the OAuth token is for.",
+        {
           "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "A URL to remind you what app the OAuth token is for.",
+        {
           "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "A unique string to distinguish an authorization from others created for the same client and user. If provided, this API is functionally equivalent to [Get-or-create an authorization for a specific app and fingerprint](/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint).",
+        {
           "name": "fingerprint",
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client and user. If provided, this API is functionally equivalent to [Get-or-create an authorization for a specific app and fingerprint](https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint).",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/authorizations/clients/:client_id"
     },
     "getOrCreateAuthorizationForAppAndFingerprint": {
@@ -1542,110 +1689,122 @@
       "enabledForApps": false,
       "method": "PUT",
       "name": "Get-or-create an authorization for a specific app and fingerprint",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "client_id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "fingerprint",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+        {
           "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "A list of scopes that this authorization is in.",
+        {
           "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
           "required": false,
-          "type": "array"
+          "location": "body"
         },
-        "4": {
-          "description": "A note to remind you what the OAuth token is for.",
+        {
           "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "A URL to remind you what app the OAuth token is for.",
+        {
           "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/authorizations/clients/:client_id/:fingerprint"
     },
     "reset": {
-      "description": "OAuth applications can use this API method to reset a valid OAuth token without end user involvement. Applications must save the \"token\" property in the response, because changes take effect immediately. You must use [Basic Authentication](/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
+      "description": "OAuth applications can use this API method to reset a valid OAuth token without end user involvement. Applications must save the \"token\" property in the response, because changes take effect immediately. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
       "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#reset-an-authorization",
       "enabledForApps": false,
       "method": "POST",
       "name": "Reset an authorization",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "client_id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "access_token",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/applications/:client_id/tokens/:access_token"
     },
     "revoke": {
-      "description": "OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`.",
+      "description": "OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`.",
       "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#revoke-an-authorization-for-an-application",
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Revoke an authorization for an application",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "client_id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "access_token",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/applications/:client_id/tokens/:access_token"
     },
     "revokeGrant": {
-      "description": "OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`. You must also provide a valid token as `:token` and the grant for the token's owner will be deleted.\n\nDeleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
+      "description": "OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`. You must also provide a valid token as `:token` and the grant for the token's owner will be deleted.\n\nDeleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
       "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#revoke-a-grant-for-an-application",
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Revoke a grant for an application",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "client_id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "access_token",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/applications/:client_id/grants/:access_token"
     },
     "update": {
@@ -1654,50 +1813,57 @@
       "enabledForApps": false,
       "method": "PATCH",
       "name": "Update an existing authorization",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "description": "Replaces the authorization scopes with these.",
+        {
           "name": "scopes",
+          "type": "string[]",
+          "description": "Replaces the authorization scopes with these.",
           "required": false,
-          "type": "array"
+          "location": "body"
         },
-        "2": {
-          "description": "A list of scopes to add to this authorization.",
+        {
           "name": "add_scopes",
+          "type": "string[]",
+          "description": "A list of scopes to add to this authorization.",
           "required": false,
-          "type": "array"
+          "location": "body"
         },
-        "3": {
-          "description": "A list of scopes to remove from this authorization.",
+        {
           "name": "remove_scopes",
+          "type": "string[]",
+          "description": "A list of scopes to remove from this authorization.",
           "required": false,
-          "type": "array"
+          "location": "body"
         },
-        "4": {
-          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
+        {
           "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "A URL to remind you what app the OAuth token is for.",
+        {
           "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
+        {
           "name": "fingerprint",
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/authorizations/:id"
     }
   },
@@ -1708,14 +1874,15 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Check if a gist is starred",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/gists/:id/star"
     },
     "create": {
@@ -1724,27 +1891,30 @@
       "enabledForApps": false,
       "method": "POST",
       "name": "Create a gist",
-      "params": {
-        "0": {
-          "description": "Files that make up this gist.",
+      "params": [
+        {
           "name": "files",
+          "type": "object",
+          "description": "Files that make up this gist.",
           "required": true,
-          "type": "object"
+          "location": "body"
         },
-        "1": {
-          "description": "A description of the gist.",
+        {
           "name": "description",
+          "type": "string",
+          "description": "A description of the gist.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "2": {
-          "default": false,
-          "description": "Indicates whether the gist is public.",
+        {
           "name": "public",
+          "type": "boolean",
+          "description": "Indicates whether the gist is public.",
+          "default": false,
           "required": false,
-          "type": "boolean"
+          "location": "body"
         }
-      },
+      ],
       "path": "/gists"
     },
     "createComment": {
@@ -1753,20 +1923,22 @@
       "enabledForApps": false,
       "method": "POST",
       "name": "Create a comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "gist_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "description": "The comment text.",
+        {
           "name": "body",
+          "type": "string",
+          "description": "The comment text.",
           "required": true,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/gists/:gist_id/comments"
     },
     "delete": {
@@ -1775,14 +1947,15 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Delete a gist",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/gists/:id"
     },
     "deleteComment": {
@@ -1791,20 +1964,22 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Delete a comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "gist_id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/gists/:gist_id/comments/:id"
     },
     "edit": {
@@ -1813,38 +1988,43 @@
       "enabledForApps": false,
       "method": "PATCH",
       "name": "Edit a gist",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "description": "A description of the gist.",
+        {
           "name": "description",
+          "type": "string",
+          "description": "A description of the gist.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "2": {
-          "description": "Files that make up this gist.",
+        {
           "name": "files",
+          "type": "object",
+          "description": "Files that make up this gist.",
           "required": false,
-          "type": "object"
+          "location": "body"
         },
-        "3": {
-          "description": "Updated file contents.",
+        {
           "name": "content",
+          "type": "string",
+          "description": "Updated file contents.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "New name for this file.",
+        {
           "name": "filename",
+          "type": "string",
+          "description": "New name for this file.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/gists/:id"
     },
     "editComment": {
@@ -1853,26 +2033,29 @@
       "enabledForApps": false,
       "method": "PATCH",
       "name": "Edit a comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "gist_id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "id",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "description": "The comment text.",
-          "name": "body",
+        {
+          "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The comment text.",
+          "required": true,
+          "location": "body"
         }
-      },
+      ],
       "path": "/gists/:gist_id/comments/:id"
     },
     "fork": {
@@ -1881,14 +2064,15 @@
       "enabledForApps": false,
       "method": "POST",
       "name": "Fork a gist",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/gists/:id/forks"
     },
     "get": {
@@ -1897,14 +2081,15 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Get a single gist",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/gists/:id"
     },
     "getAll": {
@@ -1913,28 +2098,31 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List the authenticated user's gists or if called anonymously, this will return all public gists",
-      "params": {
-        "0": {
-          "description": "A timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Only gists updated at or after this time are returned.",
+      "params": [
+        {
           "name": "since",
+          "type": "string",
+          "description": "A timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Only gists updated at or after this time are returned.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/gists"
     },
     "getComment": {
@@ -1943,20 +2131,22 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Get a single comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "gist_id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/gists/:gist_id/comments/:id"
     },
     "getComments": {
@@ -1965,28 +2155,31 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List comments on a gist",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "gist_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/gists/:gist_id/comments"
     },
     "getCommits": {
@@ -1995,28 +2188,31 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List gist commits",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/gists/:id/commits"
     },
     "getForUser": {
@@ -2025,34 +2221,38 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List public gists for the specified user",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "description": "A timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Only gists updated at or after this time are returned.",
+        {
           "name": "since",
+          "type": "string",
+          "description": "A timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Only gists updated at or after this time are returned.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/users/:username/gists"
     },
     "getForks": {
@@ -2061,58 +2261,64 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List gist forks",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/gists/:id/forks"
     },
     "getPublic": {
-      "description": "List all public gists sorted by most recently updated to least recently updated.\n\nNote: With [pagination](/v3/#pagination), you can fetch up to 3000 gists. For example, you can fetch 100 pages with 30 gists per page or 30 pages with 100 gists per page.",
+      "description": "List all public gists sorted by most recently updated to least recently updated.\n\nNote: With [pagination](https://developer.github.com/v3/#pagination), you can fetch up to 3000 gists. For example, you can fetch 100 pages with 30 gists per page or 30 pages with 100 gists per page.",
       "documentationUrl": "https://developer.github.com/v3/gists/#list-all-public-gists",
       "enabledForApps": false,
       "method": "GET",
       "name": "List all public gists",
-      "params": {
-        "0": {
-          "description": "A timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Only gists updated at or after this time are returned.",
+      "params": [
+        {
           "name": "since",
+          "type": "string",
+          "description": "A timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Only gists updated at or after this time are returned.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/gists/public"
     },
     "getRevision": {
@@ -2121,20 +2327,22 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Get a specific revision of a gist",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "sha",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/gists/:id/:sha"
     },
     "getStarred": {
@@ -2143,44 +2351,48 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List starred gists",
-      "params": {
-        "0": {
-          "description": "A timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Only gists updated at or after this time are returned.",
+      "params": [
+        {
           "name": "since",
+          "type": "string",
+          "description": "A timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Only gists updated at or after this time are returned.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/gists/starred"
     },
     "star": {
-      "description": "Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](/v3/#http-verbs).\"",
+      "description": "Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](https://developer.github.com/v3/#http-verbs).\"",
       "documentationUrl": "https://developer.github.com/v3/gists/#star-a-gist",
       "enabledForApps": false,
       "method": "PUT",
       "name": "Star a gist",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/gists/:id/star"
     },
     "unstar": {
@@ -2189,14 +2401,15 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Unstar a gist",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/gists/:id/star"
     }
   },
@@ -2206,84 +2419,95 @@
       "documentationUrl": "https://developer.github.com/v3/git/blobs/#create-a-blob",
       "enabledForApps": true,
       "method": "POST",
-      "name": "Create a Blob",
-      "params": {
-        "0": {
-          "description": "",
+      "name": "Create a blob",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The new blob's content.",
+        {
           "name": "content",
+          "type": "string",
+          "description": "The new blob's content.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "default": "\"utf-8\"",
-          "description": "The encoding used for `content`. Currently, `\"utf-8\"` and `\"base64\"` are supported.",
+        {
           "name": "encoding",
+          "type": "string",
+          "description": "The encoding used for `content`. Currently, `\"utf-8\"` and `\"base64\"` are supported.",
+          "default": "\"utf-8\"",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/git/blobs"
     },
     "createCommit": {
-      "description": "The `committer` section is optional and will be filled with the `author` data if omitted. If the `author` section is omitted, it will be filled in with the authenticated user's information and the current date.\n\nBoth the `author` and `committer` parameters have the same keys:\n\n| name  | type   | description                                                                                                             |\n| ----- | ------ | ----------------------------------------------------------------------------------------------------------------------- |\n| name  | string | The name of the author (or committer) of the commit                                                                     |\n| email | string | The email of the author (or committer) of the commit                                                                    |\n| date  | string | Indicates when this commit was authored (or committed). This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. |\n\nYou can also provide an optional string `signature` parameter. This value will be added to the `gpgsig` header of the created commit. For a commit signature to be verifiable by Git or GitHub, it must be an ASCII-armored detached PGP signature over the string commit as it would be written to the object database.\n\n**Note**: To pass a `signature` parameter, you need to first manually create a valid PGP signature, which can be complicated. You may find it easier to [use the command line](https://git-scm.com/book/id/v2/Git-Tools-Signing-Your-Work) to create signed commits.\n\nIn this example, the payload that the signature is over would have been:\n\n",
+      "description": "Creates a new Git [commit object](https://git-scm.com/book/en/v1/Git-Internals-Git-Objects#Commit-Objects).\n\nThe `committer` section is optional and will be filled with the `author` data if omitted. If the `author` section is omitted, it will be filled in with the authenticated user's information and the current date.\n\nBoth the `author` and `committer` parameters have the same keys:\n\n| name  | type   | description                                                                                                             |\n| ----- | ------ | ----------------------------------------------------------------------------------------------------------------------- |\n| name  | string | The name of the author (or committer) of the commit                                                                     |\n| email | string | The email of the author (or committer) of the commit                                                                    |\n| date  | string | Indicates when this commit was authored (or committed). This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. |\n\nYou can also provide an optional string `signature` parameter. This value will be added to the `gpgsig` header of the created commit. For a commit signature to be verifiable by Git or GitHub, it must be an ASCII-armored detached PGP signature over the string commit as it would be written to the object database.\n\n**Note**: To pass a `signature` parameter, you need to first manually create a valid PGP signature, which can be complicated. You may find it easier to [use the command line](https://git-scm.com/book/id/v2/Git-Tools-Signing-Your-Work) to create signed commits.\n\nIn this example, the payload that the signature is over would have been:\n\n",
       "documentationUrl": "https://developer.github.com/v3/git/commits/#create-a-commit",
       "enabledForApps": true,
       "method": "POST",
-      "name": "Create a Commit",
-      "params": {
-        "0": {
-          "description": "",
+      "name": "Create a commit",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The commit message",
+        {
           "name": "message",
+          "type": "string",
+          "description": "The commit message",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "The SHA of the tree object this commit points to",
+        {
           "name": "tree",
+          "type": "string",
+          "description": "The SHA of the tree object this commit points to",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The SHAs of the commits that were the parents of this commit. If omitted or empty, the commit will be written as a root commit. For a single parent, an array of one SHA should be provided; for a merge commit, an array of more than one should be provided.",
+        {
           "name": "parents",
+          "type": "string[]",
+          "description": "The SHAs of the commits that were the parents of this commit. If omitted or empty, the commit will be written as a root commit. For a single parent, an array of one SHA should be provided; for a merge commit, an array of more than one should be provided.",
           "required": true,
-          "type": "array of strings"
+          "location": "body"
         },
-        "5": {
-          "description": "object containing information about the committer.",
+        {
           "name": "committer",
-          "type": "object"
+          "type": "object",
+          "description": "object containing information about the committer.",
+          "location": "body"
         },
-        "6": {
-          "description": "object containing information about the author.",
+        {
           "name": "author",
-          "type": "object"
+          "type": "object",
+          "description": "object containing information about the author.",
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/git/commits"
     },
     "createReference": {
@@ -2291,103 +2515,122 @@
       "documentationUrl": "https://developer.github.com/v3/git/refs/#create-a-reference",
       "enabledForApps": true,
       "method": "POST",
-      "name": "Create a Reference",
-      "params": {
-        "0": {
-          "description": "",
+      "name": "Create a reference",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The name of the fully qualified reference (ie: `refs/heads/master`). If it doesn't start with 'refs' and have at least two slashes, it will be rejected.",
+        {
           "name": "ref",
+          "type": "string",
+          "description": "The name of the fully qualified reference (ie: `refs/heads/master`). If it doesn't start with 'refs' and have at least two slashes, it will be rejected.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "The SHA1 value to set this reference to",
+        {
           "name": "sha",
+          "type": "string",
+          "description": "The SHA1 value to set this reference to",
           "required": true,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/git/refs"
     },
     "createTag": {
-      "description": "Note that creating a tag object does not create the reference that makes a tag in Git. If you want to create an annotated tag in Git, you have to do this call to create the tag object, and then [create](/v3/git/refs/#create-a-reference) the `refs/tags/[tag]` reference. If you want to create a lightweight tag, you only have to [create](/v3/git/refs/#create-a-reference) the tag reference - this call would be unnecessary.",
+      "description": "Note that creating a tag object does not create the reference that makes a tag in Git. If you want to create an annotated tag in Git, you have to do this call to create the tag object, and then [create](https://developer.github.com/v3/git/refs/#create-a-reference) the `refs/tags/[tag]` reference. If you want to create a lightweight tag, you only have to [create](https://developer.github.com/v3/git/refs/#create-a-reference) the tag reference - this call would be unnecessary.",
       "documentationUrl": "https://developer.github.com/v3/git/tags/#create-a-tag-object",
       "enabledForApps": true,
       "method": "POST",
-      "name": "Create a Tag Object",
-      "params": {
-        "0": {
-          "description": "",
+      "name": "Create a tag object",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The tag",
+        {
           "name": "tag",
-          "required": false,
-          "type": "string"
+          "type": "string",
+          "description": "The tag's name. This is typically a version (e.g., \"v0.0.1\").",
+          "required": true,
+          "location": "body"
         },
-        "3": {
-          "description": "The tag message",
+        {
           "name": "message",
-          "required": false,
-          "type": "string"
+          "type": "string",
+          "description": "The tag message.",
+          "required": true,
+          "location": "body"
         },
-        "4": {
-          "description": "The SHA of the git object this is tagging",
+        {
           "name": "object",
-          "required": false,
-          "type": "string"
+          "type": "string",
+          "description": "The SHA of the git object this is tagging.",
+          "required": true,
+          "location": "body"
         },
-        "5": {
-          "description": "The type of the object we're tagging. Normally this is a `commit` but it can also be a `tree` or a `blob`.",
+        {
           "name": "type",
-          "required": false,
-          "type": "string"
+          "type": "string",
+          "description": "The type of the object we're tagging. Normally this is a `commit` but it can also be a `tree` or a `blob`.",
+          "required": true,
+          "enum": [
+            "commit",
+            "tree",
+            "blob"
+          ],
+          "location": "body"
         },
-        "6": {
-          "description": "An object with information about the individual creating the tag.",
+        {
           "name": "tagger",
+          "type": "object",
+          "description": "An object with information about the individual creating the tag.",
           "required": false,
-          "type": "object"
+          "location": "body"
         },
-        "7": {
-          "description": "The name of the author of the tag",
+        {
           "name": "tagger.name",
+          "type": "string",
+          "description": "The name of the author of the tag",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "8": {
-          "description": "The email of the author of the tag",
+        {
           "name": "tagger.email",
+          "type": "string",
+          "description": "The email of the author of the tag",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "9": {
-          "description": "When this object was tagged. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+        {
           "name": "tagger.date",
+          "type": "string",
+          "description": "When this object was tagged. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/git/tags"
     },
     "createTree": {
@@ -2395,34 +2638,41 @@
       "documentationUrl": "https://developer.github.com/v3/git/trees/#create-a-tree",
       "enabledForApps": true,
       "method": "POST",
-      "name": "Create a Tree",
-      "params": {
-        "0": {
-          "description": "",
+      "name": "Create a tree",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "Objects (of `path`, `mode`, `type`, and `sha`) specifying a tree structure",
+        {
           "name": "tree",
+          "type": "object[]",
+          "description": "Objects (of `path`, `mode`, `type`, and `sha`) specifying a tree structure",
           "required": true,
-          "type": "array of objects"
+          "location": "body"
         },
-        "3": {
-          "description": "The file referenced in the tree",
+        {
           "name": "tree.path",
+          "type": "string",
+          "description": "The file referenced in the tree",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
+        {
+          "name": "tree.mode",
+          "type": "string",
           "description": "The file mode; one of `100644` for file (blob), `100755` for executable (blob), `040000` for subdirectory (tree), `160000` for submodule (commit), or `120000` for a blob that specifies the path of a symlink",
+          "required": false,
           "enum": [
             "100644",
             "100755",
@@ -2430,40 +2680,42 @@
             "160000",
             "120000"
           ],
-          "name": "tree.mode",
-          "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
+        {
+          "name": "tree.type",
+          "type": "string",
           "description": "Either `blob`, `tree`, or `commit`",
+          "required": false,
           "enum": [
             "blob",
             "tree",
             "commit"
           ],
-          "name": "tree.type",
-          "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "description": "The SHA1 checksum ID of the object in the tree",
+        {
           "name": "tree.sha",
+          "type": "string",
+          "description": "The SHA1 checksum ID of the object in the tree",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "7": {
-          "description": "The content you want this file to have. GitHub will write this blob out and use that SHA for this entry. Use either this, or `tree.sha`.",
+        {
           "name": "tree.content",
+          "type": "string",
+          "description": "The content you want this file to have. GitHub will write this blob out and use that SHA for this entry. Use either this, or `tree.sha`.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "8": {
-          "description": "The SHA1 of the tree you want to update with new data. If you don't set this, the commit will be created on top of everything; however, it will only contain your change, the rest of your files will show up as deleted.",
+        {
           "name": "base_tree",
+          "type": "string",
+          "description": "The SHA1 of the tree you want to update with new data. If you don't set this, the commit will be created on top of everything; however, it will only contain your change, the rest of your files will show up as deleted.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/git/trees"
     },
     "deleteReference": {
@@ -2471,27 +2723,30 @@
       "documentationUrl": "https://developer.github.com/v3/git/refs/#delete-a-reference",
       "enabledForApps": true,
       "method": "DELETE",
-      "name": "Delete a Reference",
-      "params": {
-        "0": {
-          "description": "",
+      "name": "Delete a reference",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "ref",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/git/refs/:ref"
     },
     "getBlob": {
@@ -2499,84 +2754,93 @@
       "documentationUrl": "https://developer.github.com/v3/git/blobs/#get-a-blob",
       "enabledForApps": true,
       "method": "GET",
-      "name": "Get a Blob",
-      "params": {
-        "0": {
-          "description": "",
+      "name": "Get a blob",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "sha",
+          "location": "url"
+        },
+        {
+          "name": "file_sha",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
-      "path": "/repos/:owner/:repo/git/blobs/:sha"
+      ],
+      "path": "/repos/:owner/:repo/git/blobs/:file_sha"
     },
     "getCommit": {
-      "description": "",
+      "description": "Gets a Git [commit object](https://git-scm.com/book/en/v1/Git-Internals-Git-Objects#Commit-Objects).",
       "documentationUrl": "https://developer.github.com/v3/git/commits/#get-a-commit",
       "enabledForApps": true,
       "method": "GET",
-      "name": "Get a Commit",
-      "params": {
-        "0": {
-          "description": "",
+      "name": "Get a commit",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "sha",
+          "location": "url"
+        },
+        {
+          "name": "commit_sha",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
-      "path": "/repos/:owner/:repo/git/commits/:sha"
+      ],
+      "path": "/repos/:owner/:repo/git/commits/:commit_sha"
     },
     "getCommitSignatureVerification": {
-      "description": "",
+      "description": "Gets a Git [commit object](https://git-scm.com/book/en/v1/Git-Internals-Git-Objects#Commit-Objects).",
       "documentationUrl": "https://developer.github.com/v3/git/commits/#get-a-commit",
       "enabledForApps": true,
       "method": "GET",
-      "name": "Get a Commit",
-      "params": {
-        "0": {
-          "description": "",
+      "name": "Get a commit",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "sha",
+          "location": "url"
+        },
+        {
+          "name": "commit_sha",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
-      "path": "/repos/:owner/:repo/git/commits/:sha"
+      ],
+      "path": "/repos/:owner/:repo/git/commits/:commit_sha"
     },
     "getReference": {
       "description": "Returns a branch or tag reference. Other than the [REST API](https://developer.github.com/v3/git/refs/#get-a-reference) it always returns a single reference. If the REST API returns with an array then the method responds with an error.",
@@ -2585,14 +2849,29 @@
       "isOverride": true,
       "method": "GET",
       "name": "Get a Reference",
-      "params": {
-        "0": {
-          "description": "Must be formatted as `heads/branch`, not just `branch`",
-          "name": "ref",
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "ref",
+          "type": "string",
+          "description": "Must be formatted as `heads/branch`, not just `branch`",
+          "required": true,
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/git/refs/:ref"
     },
     "getTag": {
@@ -2600,124 +2879,148 @@
       "documentationUrl": "https://developer.github.com/v3/git/tags/#get-a-tag",
       "enabledForApps": true,
       "method": "GET",
-      "name": "Get a Tag",
-      "params": {
-        "0": {
-          "description": "",
+      "name": "Get a tag",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "sha",
+          "location": "url"
+        },
+        {
+          "name": "tag_sha",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
-      "path": "/repos/:owner/:repo/git/tags/:sha"
+      ],
+      "path": "/repos/:owner/:repo/git/tags/:tag_sha"
     },
     "getTagSignatureVerification": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/git/tags/#get-a-tag",
       "enabledForApps": true,
       "method": "GET",
-      "name": "Get a Tag",
-      "params": {
-        "0": {
-          "description": "",
+      "name": "Get a tag",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "sha",
+          "location": "url"
+        },
+        {
+          "name": "tag_sha",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
-      "path": "/repos/:owner/:repo/git/tags/:sha"
+      ],
+      "path": "/repos/:owner/:repo/git/tags/:tag_sha"
     },
     "getTree": {
-      "description": "If `truncated` is `true`, the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
+      "description": "If `truncated` in the response is `true`, the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, omit the `recursive` parameter, and fetch one sub-tree at a time. If you need to fetch even more items, you can clone the repository and iterate over the Git data locally.",
       "documentationUrl": "https://developer.github.com/v3/git/trees/#get-a-tree",
       "enabledForApps": true,
+      "isOverride": true,
       "method": "GET",
-      "name": "Get a Tree",
-      "params": {
-        "0": {
-          "description": "",
+      "name": "Get a tree",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "sha",
+          "location": "url"
+        },
+        {
+          "name": "tree_sha",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "recursive",
+          "type": "integer",
+          "description": "",
+          "enum": [
+            1
+          ],
+          "location": "query"
         }
-      },
-      "path": "/repos/:owner/:repo/git/trees/:sha"
+      ],
+      "path": "/repos/:owner/:repo/git/trees/:tree_sha"
     },
     "updateReference": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/git/refs/#update-a-reference",
       "enabledForApps": true,
       "method": "PATCH",
-      "name": "Update a Reference",
-      "params": {
-        "0": {
-          "description": "",
+      "name": "Update a reference",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "ref",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "The SHA1 value to set this reference to",
+        {
           "name": "sha",
+          "type": "string",
+          "description": "The SHA1 value to set this reference to",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "default": false,
-          "description": "Indicates whether to force the update or to make sure the update is a fast-forward update. Leaving this out or setting it to `false` will make sure you're not overwriting work.",
+        {
           "name": "force",
+          "type": "boolean",
+          "description": "Indicates whether to force the update or to make sure the update is a fast-forward update. Leaving this out or setting it to `false` will make sure you're not overwriting work.",
+          "default": false,
           "required": false,
-          "type": "boolean"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/git/refs/:ref"
     }
   },
@@ -2728,32 +3031,36 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Add assignees to an issue",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "number",
-          "required": true,
-          "type": "integer"
+          "location": "url"
         },
-        "3": {
-          "description": "Usernames of people to assign this issue to. _NOTE: Only users with push access can add assignees to an issue. Assignees are silently ignored otherwise._",
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
           "name": "assignees",
+          "type": "string[]",
+          "description": "Usernames of people to assign this issue to. _NOTE: Only users with push access can add assignees to an issue. Assignees are silently ignored otherwise._",
           "required": false,
-          "type": "array of strings"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/:number/assignees"
     },
     "addLabels": {
@@ -2762,26 +3069,29 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Add labels to an issue",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/:number/labels"
     },
     "checkAssignee": {
@@ -2790,26 +3100,29 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Check assignee",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "assignee",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/assignees/:assignee"
     },
     "create": {
@@ -2818,56 +3131,64 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Create an issue",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The title of the issue.",
+        {
           "name": "title",
+          "type": "string",
+          "description": "The title of the issue.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "The contents of the issue.",
+        {
           "name": "body",
+          "type": "string",
+          "description": "The contents of the issue.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "Login for the user that this issue should be assigned to. _NOTE: Only users with push access can set the assignee for new issues. The assignee is silently dropped otherwise. **This field is deprecated.**_",
+        {
           "name": "assignee",
+          "type": "string",
+          "description": "Login for the user that this issue should be assigned to. _NOTE: Only users with push access can set the assignee for new issues. The assignee is silently dropped otherwise. **This field is deprecated.**_",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "The `number` of the milestone to associate this issue with. _NOTE: Only users with push access can set the milestone for new issues. The milestone is silently dropped otherwise._",
+        {
           "name": "milestone",
+          "type": "integer",
+          "description": "The `number` of the milestone to associate this issue with. _NOTE: Only users with push access can set the milestone for new issues. The milestone is silently dropped otherwise._",
           "required": false,
-          "type": "integer"
+          "location": "body"
         },
-        "6": {
-          "description": "Labels to associate with this issue. _NOTE: Only users with push access can set labels for new issues. Labels are silently dropped otherwise._",
+        {
           "name": "labels",
+          "type": "string[]",
+          "description": "Labels to associate with this issue. _NOTE: Only users with push access can set labels for new issues. Labels are silently dropped otherwise._",
           "required": false,
-          "type": "array of strings"
+          "location": "body"
         },
-        "7": {
-          "description": "Logins for Users to assign to this issue. _NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise._",
+        {
           "name": "assignees",
+          "type": "string[]",
+          "description": "Logins for Users to assign to this issue. _NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise._",
           "required": false,
-          "type": "array of strings"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues"
     },
     "createComment": {
@@ -2876,32 +3197,36 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "number",
-          "required": true,
-          "type": "integer"
+          "location": "url"
         },
-        "3": {
-          "description": "The contents of the comment.",
-          "name": "body",
+        {
+          "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The contents of the comment.",
+          "required": true,
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/:number/comments"
     },
     "createLabel": {
@@ -2910,38 +3235,43 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a label",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The name of the label. Emoji can be added to label names, using either native emoji or colon-style markup. For example, typing `:strawberry:` will render the emoji ![:strawberry:](https://a248.e.akamai.net/assets.github.com/images/icons/emoji/unicode/1f353.png \":strawberry:\"). For a full list of available emoji and codes, see [emoji-cheat-sheet.com](http://emoji-cheat-sheet.com/).",
+        {
           "name": "name",
+          "type": "string",
+          "description": "The name of the label. Emoji can be added to label names, using either native emoji or colon-style markup. For example, typing `:strawberry:` will render the emoji ![:strawberry:](https://a248.e.akamai.net/assets.github.com/images/icons/emoji/unicode/1f353.png \":strawberry:\"). For a full list of available emoji and codes, see [emoji-cheat-sheet.com](http://emoji-cheat-sheet.com/).",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "The [hexadecimal color code](http://www.color-hex.com/) for the label, without the leading `#`.",
+        {
           "name": "color",
+          "type": "string",
+          "description": "The [hexadecimal color code](http://www.color-hex.com/) for the label, without the leading `#`.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "A short description of the label.",
+        {
           "name": "description",
+          "type": "string",
+          "description": "A short description of the label.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/labels"
     },
     "createMilestone": {
@@ -2950,49 +3280,55 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a milestone",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The title of the milestone.",
+        {
           "name": "title",
+          "type": "string",
+          "description": "The title of the milestone.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "default": "open",
+        {
+          "name": "state",
+          "type": "string",
           "description": "The state of the milestone. Either `open` or `closed`.",
+          "default": "open",
+          "required": false,
           "enum": [
             "open",
             "closed"
           ],
-          "name": "state",
-          "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "A description of the milestone.",
+        {
           "name": "description",
+          "type": "string",
+          "description": "A description of the milestone.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "The milestone due date. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+        {
           "name": "due_on",
+          "type": "string",
+          "description": "The milestone due date. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/milestones"
     },
     "deleteComment": {
@@ -3001,26 +3337,29 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Delete a comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/comments/:id"
     },
     "deleteLabel": {
@@ -3029,26 +3368,29 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Delete a label",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "name",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/labels/:name"
     },
     "deleteMilestone": {
@@ -3057,26 +3399,29 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Delete a milestone",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/milestones/:number"
     },
     "edit": {
@@ -3085,73 +3430,83 @@
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Edit an issue",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "The title of the issue.",
+        {
           "name": "title",
+          "type": "string",
+          "description": "The title of the issue.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The contents of the issue.",
+        {
           "name": "body",
+          "type": "string",
+          "description": "The contents of the issue.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "Login for the user that this issue should be assigned to. **This field is deprecated.**",
+        {
           "name": "assignee",
+          "type": "string",
+          "description": "Login for the user that this issue should be assigned to. **This field is deprecated.**",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
+        {
+          "name": "state",
+          "type": "string",
           "description": "State of the issue. Either `open` or `closed`.",
+          "required": false,
           "enum": [
             "open",
             "closed"
           ],
-          "name": "state",
-          "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "7": {
-          "allowNull": true,
-          "description": "The `number` of the milestone to associate this issue with or `null` to remove current. _NOTE: Only users with push access can set the milestone for issues. The milestone is silently dropped otherwise._",
+        {
           "name": "milestone",
+          "type": "integer",
+          "description": "The `number` of the milestone to associate this issue with or `null` to remove current. _NOTE: Only users with push access can set the milestone for issues. The milestone is silently dropped otherwise._",
           "required": false,
-          "type": "integer"
+          "allowNull": true,
+          "location": "body"
         },
-        "8": {
-          "description": "Labels to associate with this issue. Pass one or more Labels to _replace_ the set of Labels on this Issue. Send an empty array (`[]`) to clear all Labels from the Issue. _NOTE: Only users with push access can set labels for issues. Labels are silently dropped otherwise._",
+        {
           "name": "labels",
+          "type": "string[]",
+          "description": "Labels to associate with this issue. Pass one or more Labels to _replace_ the set of Labels on this Issue. Send an empty array (`[]`) to clear all Labels from the Issue. _NOTE: Only users with push access can set labels for issues. Labels are silently dropped otherwise._",
           "required": false,
-          "type": "array of strings"
+          "location": "body"
         },
-        "9": {
-          "description": "Logins for Users to assign to this issue. Pass one or more user logins to _replace_ the set of assignees on this Issue. Send an empty array (`[]`) to clear all assignees from the Issue. _NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise._",
+        {
           "name": "assignees",
+          "type": "string[]",
+          "description": "Logins for Users to assign to this issue. Pass one or more user logins to _replace_ the set of assignees on this Issue. Send an empty array (`[]`) to clear all assignees from the Issue. _NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise._",
           "required": false,
-          "type": "array of strings"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/:number"
     },
     "editComment": {
@@ -3160,32 +3515,36 @@
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Edit a comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "id",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "3": {
-          "description": "The contents of the comment.",
-          "name": "body",
+        {
+          "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The contents of the comment.",
+          "required": true,
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/comments/:id"
     },
     "get": {
@@ -3194,26 +3553,29 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a single issue",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/:number"
     },
     "getAll": {
@@ -3222,10 +3584,13 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List all issues assigned to the authenticated user across all visible repositories including owned repositories, member repositories, and organization repositories",
-      "params": {
-        "0": {
-          "default": "assigned",
+      "params": [
+        {
+          "name": "filter",
+          "type": "string",
           "description": "Indicates which sorts of issues to return. Can be one of:  \n\\* `assigned`: Issues assigned to you  \n\\* `created`: Issues created by you  \n\\* `mentioned`: Issues mentioning you  \n\\* `subscribed`: Issues you're subscribed to updates for  \n\\* `all`: All issues the authenticated user can see, regardless of participation or creation",
+          "default": "assigned",
+          "required": false,
           "enum": [
             "assigned",
             "created",
@@ -3233,72 +3598,77 @@
             "subscribed",
             "all"
           ],
-          "name": "filter",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "1": {
-          "default": "open",
+        {
+          "name": "state",
+          "type": "string",
           "description": "Indicates the state of the issues to return. Can be either `open`, `closed`, or `all`.",
+          "default": "open",
+          "required": false,
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "name": "state",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
-          "description": "A list of comma separated label names. Example: `bug,ui,@high`",
+        {
           "name": "labels",
+          "type": "string",
+          "description": "A list of comma separated label names. Example: `bug,ui,@high`",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "default": "created",
+        {
+          "name": "sort",
+          "type": "string",
           "description": "What to sort results by. Can be either `created`, `updated`, `comments`.",
+          "default": "created",
+          "required": false,
           "enum": [
             "created",
             "updated",
             "comments"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "4": {
-          "default": "desc",
+        {
+          "name": "direction",
+          "type": "string",
           "description": "The direction of the sort. Can be either `asc` or `desc`.",
+          "default": "desc",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "direction",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "5": {
-          "description": "Only issues updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+        {
           "name": "since",
+          "type": "string",
+          "description": "Only issues updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "6": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "7": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/issues"
     },
     "getAssignees": {
@@ -3307,34 +3677,38 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List assignees",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/assignees"
     },
     "getComment": {
@@ -3343,40 +3717,45 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a single comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/comments/:id"
     },
     "getComments": {
@@ -3385,46 +3764,52 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List comments on an issue",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "Only comments updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+        {
           "name": "since",
+          "type": "string",
+          "description": "Only comments updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "4": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "5": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/:number/comments"
     },
     "getCommentsForRepo": {
@@ -3433,47 +3818,52 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List comments in a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "repo",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "default": "created",
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "sort",
+          "type": "string",
           "description": "Either `created` or `updated`.",
+          "default": "created",
+          "required": false,
           "enum": [
             "created",
             "updated"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
+        {
+          "name": "direction",
+          "type": "string",
           "description": "Either `asc` or `desc`. Ignored without the `sort` parameter.",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "direction",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "4": {
-          "description": "Only comments updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+        {
           "name": "since",
+          "type": "string",
+          "description": "Only comments updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
           "required": false,
-          "type": "string"
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/comments"
     },
     "getEvent": {
@@ -3482,26 +3872,29 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a single event",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/events/:id"
     },
     "getEvents": {
@@ -3510,40 +3903,45 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List events for an issue",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/:number/events"
     },
     "getEventsForRepo": {
@@ -3552,34 +3950,38 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List events for a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/events"
     },
     "getEventsTimeline": {
@@ -3588,40 +3990,45 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List events for an issue",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/:number/timeline"
     },
     "getForOrg": {
@@ -3630,16 +4037,20 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List all issues for a given organization assigned to the authenticated user",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": "assigned",
+        {
+          "name": "filter",
+          "type": "string",
           "description": "Indicates which sorts of issues to return. Can be one of:  \n\\* `assigned`: Issues assigned to you  \n\\* `created`: Issues created by you  \n\\* `mentioned`: Issues mentioning you  \n\\* `subscribed`: Issues you're subscribed to updates for  \n\\* `all`: All issues the authenticated user can see, regardless of participation or creation",
+          "default": "assigned",
+          "required": false,
           "enum": [
             "assigned",
             "created",
@@ -3647,72 +4058,77 @@
             "subscribed",
             "all"
           ],
-          "name": "filter",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
-          "default": "open",
+        {
+          "name": "state",
+          "type": "string",
           "description": "Indicates the state of the issues to return. Can be either `open`, `closed`, or `all`.",
+          "default": "open",
+          "required": false,
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "name": "state",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "description": "A list of comma separated label names. Example: `bug,ui,@high`",
+        {
           "name": "labels",
+          "type": "string",
+          "description": "A list of comma separated label names. Example: `bug,ui,@high`",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "4": {
-          "default": "created",
+        {
+          "name": "sort",
+          "type": "string",
           "description": "What to sort results by. Can be either `created`, `updated`, `comments`.",
+          "default": "created",
+          "required": false,
           "enum": [
             "created",
             "updated",
             "comments"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "5": {
-          "default": "desc",
+        {
+          "name": "direction",
+          "type": "string",
           "description": "The direction of the sort. Can be either `asc` or `desc`.",
+          "default": "desc",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "direction",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "6": {
-          "description": "Only issues updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+        {
           "name": "since",
+          "type": "string",
+          "description": "Only issues updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "7": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "8": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/orgs/:org/issues"
     },
     "getForRepo": {
@@ -3721,105 +4137,118 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List issues for a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "If an `integer` is passed, it should refer to a milestone by its `number` field. If the string `*` is passed, issues with any milestone are accepted. If the string `none` is passed, issues without milestones are returned.",
+        {
           "name": "milestone",
+          "type": "string",
+          "description": "If an `integer` is passed, it should refer to a milestone by its `number` field. If the string `*` is passed, issues with any milestone are accepted. If the string `none` is passed, issues without milestones are returned.",
           "required": false,
-          "type": "integer or string"
+          "location": "query"
         },
-        "3": {
-          "default": "open",
+        {
+          "name": "state",
+          "type": "string",
           "description": "Indicates the state of the issues to return. Can be either `open`, `closed`, or `all`.",
+          "default": "open",
+          "required": false,
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "name": "state",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "4": {
-          "description": "Can be the name of a user. Pass in `none` for issues with no assigned user, and `*` for issues assigned to any user.",
+        {
           "name": "assignee",
+          "type": "string",
+          "description": "Can be the name of a user. Pass in `none` for issues with no assigned user, and `*` for issues assigned to any user.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "5": {
-          "description": "The user that created the issue.",
+        {
           "name": "creator",
+          "type": "string",
+          "description": "The user that created the issue.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "6": {
-          "description": "A user that's mentioned in the issue.",
+        {
           "name": "mentioned",
+          "type": "string",
+          "description": "A user that's mentioned in the issue.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "7": {
-          "description": "A list of comma separated label names. Example: `bug,ui,@high`",
+        {
           "name": "labels",
+          "type": "string",
+          "description": "A list of comma separated label names. Example: `bug,ui,@high`",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "8": {
-          "default": "created",
+        {
+          "name": "sort",
+          "type": "string",
           "description": "What to sort results by. Can be either `created`, `updated`, `comments`.",
+          "default": "created",
+          "required": false,
           "enum": [
             "created",
             "updated",
             "comments"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "9": {
-          "default": "desc",
+        {
+          "name": "direction",
+          "type": "string",
           "description": "The direction of the sort. Can be either `asc` or `desc`.",
+          "default": "desc",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "direction",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "10": {
-          "description": "Only issues updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+        {
           "name": "since",
+          "type": "string",
+          "description": "Only issues updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "11": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "12": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues"
     },
     "getForUser": {
@@ -3828,10 +4257,13 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List all issues across owned and member repositories assigned to the authenticated user",
-      "params": {
-        "0": {
-          "default": "assigned",
+      "params": [
+        {
+          "name": "filter",
+          "type": "string",
           "description": "Indicates which sorts of issues to return. Can be one of:  \n\\* `assigned`: Issues assigned to you  \n\\* `created`: Issues created by you  \n\\* `mentioned`: Issues mentioning you  \n\\* `subscribed`: Issues you're subscribed to updates for  \n\\* `all`: All issues the authenticated user can see, regardless of participation or creation",
+          "default": "assigned",
+          "required": false,
           "enum": [
             "assigned",
             "created",
@@ -3839,72 +4271,77 @@
             "subscribed",
             "all"
           ],
-          "name": "filter",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "1": {
-          "default": "open",
+        {
+          "name": "state",
+          "type": "string",
           "description": "Indicates the state of the issues to return. Can be either `open`, `closed`, or `all`.",
+          "default": "open",
+          "required": false,
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "name": "state",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
-          "description": "A list of comma separated label names. Example: `bug,ui,@high`",
+        {
           "name": "labels",
+          "type": "string",
+          "description": "A list of comma separated label names. Example: `bug,ui,@high`",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "default": "created",
+        {
+          "name": "sort",
+          "type": "string",
           "description": "What to sort results by. Can be either `created`, `updated`, `comments`.",
+          "default": "created",
+          "required": false,
           "enum": [
             "created",
             "updated",
             "comments"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "4": {
-          "default": "desc",
+        {
+          "name": "direction",
+          "type": "string",
           "description": "The direction of the sort. Can be either `asc` or `desc`.",
+          "default": "desc",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "direction",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "5": {
-          "description": "Only issues updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+        {
           "name": "since",
+          "type": "string",
+          "description": "Only issues updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "6": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "7": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/user/issues"
     },
     "getIssueLabels": {
@@ -3913,40 +4350,45 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List labels on an issue",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/:number/labels"
     },
     "getLabel": {
@@ -3955,26 +4397,29 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a single label",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "name",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/labels/:name"
     },
     "getLabels": {
@@ -3983,34 +4428,38 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List all labels for this repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/labels"
     },
     "getMilestone": {
@@ -4019,26 +4468,29 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a single milestone",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/milestones/:number"
     },
     "getMilestoneLabels": {
@@ -4047,40 +4499,45 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get labels for every issue in a milestone",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/milestones/:number/labels"
     },
     "getMilestones": {
@@ -4089,108 +4546,119 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List milestones for a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "repo",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "default": "open",
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "state",
+          "type": "string",
           "description": "The state of the milestone. Either `open`, `closed`, or `all`.",
+          "default": "open",
+          "required": false,
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "name": "state",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "default": "due_on",
+        {
+          "name": "sort",
+          "type": "string",
           "description": "What to sort results by. Either `due_on` or `completeness`.",
+          "default": "due_on",
+          "required": false,
           "enum": [
             "due_on",
             "completeness"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "4": {
-          "default": "asc",
+        {
+          "name": "direction",
+          "type": "string",
           "description": "The direction of the sort. Either `asc` or `desc`.",
+          "default": "asc",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "direction",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "5": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "6": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/milestones"
     },
     "lock": {
-      "description": "Users with push access can lock an issue or pull request's conversation.\n\nNote that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](/v3/#http-verbs).\"",
+      "description": "Users with push access can lock an issue or pull request's conversation.\n\nNote that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](https://developer.github.com/v3/#http-verbs).\"",
       "documentationUrl": "https://developer.github.com/v3/issues/#lock-an-issue",
       "enabledForApps": true,
       "method": "PUT",
       "name": "Lock an issue",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "number",
-          "required": true,
-          "type": "integer"
+          "location": "url"
         },
-        "3": {
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "lock_reason",
+          "type": "string",
           "description": "The reason for locking the issue or pull request conversation. Lock will fail if you don't use one of these reasons:  \n\\* `off-topic`  \n\\* `too heated`  \n\\* `resolved`  \n\\* `spam`",
+          "required": false,
           "enum": [
             "off-topic",
             "too heated",
             "resolved",
             "spam"
           ],
-          "name": "lock_reason",
-          "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/:number/lock"
     },
     "removeAllLabels": {
@@ -4199,26 +4667,29 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Remove all labels from an issue",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/:number/labels"
     },
     "removeAssigneesFromIssue": {
@@ -4227,32 +4698,36 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Remove assignees from an issue",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "number",
-          "required": true,
-          "type": "integer"
+          "location": "url"
         },
-        "3": {
-          "description": "Usernames of assignees to remove from an issue. _NOTE: Only users with push access can remove assignees from an issue. Assignees are silently ignored otherwise._",
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
           "name": "assignees",
+          "type": "string[]",
+          "description": "Usernames of assignees to remove from an issue. _NOTE: Only users with push access can remove assignees from an issue. Assignees are silently ignored otherwise._",
           "required": false,
-          "type": "array of strings"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/:number/assignees"
     },
     "removeLabel": {
@@ -4261,32 +4736,36 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Remove a label from an issue",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
-        },
-        "3": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "name",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/:number/labels/:name"
     },
     "replaceAllLabels": {
@@ -4295,26 +4774,29 @@
       "enabledForApps": true,
       "method": "PUT",
       "name": "Replace all labels for an issue",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/:number/labels"
     },
     "unlock": {
@@ -4323,26 +4805,29 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Unlock an issue",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/:number/lock"
     },
     "updateLabel": {
@@ -4351,44 +4836,50 @@
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Update a label",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "oldname",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "The name of the label. Emoji can be added to label names, using either native emoji or colon-style markup. For example, typing `:strawberry:` will render the emoji ![:strawberry:](https://a248.e.akamai.net/assets.github.com/images/icons/emoji/unicode/1f353.png \":strawberry:\"). For a full list of available emoji and codes, see [emoji-cheat-sheet.com](http://emoji-cheat-sheet.com/).",
+        {
           "name": "name",
+          "type": "string",
+          "description": "The name of the label. Emoji can be added to label names, using either native emoji or colon-style markup. For example, typing `:strawberry:` will render the emoji ![:strawberry:](https://a248.e.akamai.net/assets.github.com/images/icons/emoji/unicode/1f353.png \":strawberry:\"). For a full list of available emoji and codes, see [emoji-cheat-sheet.com](http://emoji-cheat-sheet.com/).",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The [hexadecimal color code](http://www.color-hex.com/) for the label, without the leading `#`.",
+        {
           "name": "color",
+          "type": "string",
+          "description": "The [hexadecimal color code](http://www.color-hex.com/) for the label, without the leading `#`.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "A short description of the label.",
+        {
           "name": "description",
+          "type": "string",
+          "description": "A short description of the label.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/labels/:oldname"
     },
     "updateMilestone": {
@@ -4397,55 +4888,62 @@
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Update a milestone",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "The title of the milestone.",
+        {
           "name": "title",
+          "type": "string",
+          "description": "The title of the milestone.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "default": "open",
+        {
+          "name": "state",
+          "type": "string",
           "description": "The state of the milestone. Either `open` or `closed`.",
+          "default": "open",
+          "required": false,
           "enum": [
             "open",
             "closed"
           ],
-          "name": "state",
-          "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "A description of the milestone.",
+        {
           "name": "description",
+          "type": "string",
+          "description": "A description of the milestone.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "description": "The milestone due date. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+        {
           "name": "due_on",
+          "type": "string",
+          "description": "The milestone due date. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/milestones/:number"
     }
   },
@@ -4456,20 +4954,22 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Cancel an import",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/import"
     },
     "deleteMigrationArchive": {
@@ -4478,20 +4978,22 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Delete a migration archive",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/migrations/:id/archive"
     },
     "getImportCommitAuthors": {
@@ -4500,26 +5002,29 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get commit authors",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "repo",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "description": "Only authors found after this id are returned. Provide the highest author ID you've seen so far. New authors may be added to the list at any point while the importer is performing the `raw` step.",
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
           "name": "since",
+          "type": "string",
+          "description": "Only authors found after this id are returned. Provide the highest author ID you've seen so far. New authors may be added to the list at any point while the importer is performing the `raw` step.",
           "required": false,
-          "type": "string"
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/import/authors"
     },
     "getImportProgress": {
@@ -4528,20 +5033,22 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get import progress",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/import"
     },
     "getLargeImportFiles": {
@@ -4550,20 +5057,22 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get large files",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/import/large_files"
     },
     "getMigrationArchiveLink": {
@@ -4572,20 +5081,22 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Download a migration archive",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/migrations/:id/archive"
     },
     "getMigrationStatus": {
@@ -4594,20 +5105,22 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Get the status of a migration",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/migrations/:id"
     },
     "getMigrations": {
@@ -4616,28 +5129,31 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Get a list of migrations",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/orgs/:org/migrations"
     },
     "mapImportCommitAuthor": {
@@ -4646,38 +5162,43 @@
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Map a commit author",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "author_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "The new Git author email.",
+        {
           "name": "email",
+          "type": "string",
+          "description": "The new Git author email.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The new Git author name.",
+        {
           "name": "name",
+          "type": "string",
+          "description": "The new Git author name.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/import/authors/:author_id"
     },
     "setImportLfsPreference": {
@@ -4686,30 +5207,33 @@
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Set Git LFS preference",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "repo",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "use_lfs",
+          "type": "string",
           "description": "Can be one of `opt_in` (large files will be stored using Git LFS) or `opt_out` (large files will be removed during the import).",
+          "required": true,
           "enum": [
             "opt_in",
             "opt_out"
           ],
-          "name": "use_lfs",
-          "required": true,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/import/lfs"
     },
     "startImport": {
@@ -4718,56 +5242,63 @@
       "enabledForApps": true,
       "method": "PUT",
       "name": "Start an import",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The URL of the originating repository.",
+        {
           "name": "vcs_url",
+          "type": "string",
+          "description": "The URL of the originating repository.",
           "required": true,
-          "type": "url"
+          "location": "body"
         },
-        "3": {
+        {
+          "name": "vcs",
+          "type": "string",
           "description": "The originating VCS type. Can be one of `subversion`, `git`, `mercurial`, or `tfvc`. Please be aware that without this parameter, the import job will take additional time to detect the VCS type before beginning the import. This detection step will be reflected in the response.",
+          "required": false,
           "enum": [
             "subversion",
             "git",
             "mercurial",
             "tfvc"
           ],
-          "name": "vcs",
-          "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "If authentication is required, the username to provide to `vcs_url`.",
+        {
           "name": "vcs_username",
+          "type": "string",
+          "description": "If authentication is required, the username to provide to `vcs_url`.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "If authentication is required, the password to provide to `vcs_url`.",
+        {
           "name": "vcs_password",
+          "type": "string",
+          "description": "If authentication is required, the password to provide to `vcs_url`.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "description": "For a tfvc import, the name of the project that is being imported.",
+        {
           "name": "tfvc_project",
+          "type": "string",
+          "description": "For a tfvc import, the name of the project that is being imported.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/import"
     },
     "startMigration": {
@@ -4776,62 +5307,69 @@
       "enabledForApps": false,
       "method": "POST",
       "name": "Start a migration",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "description": "A list of arrays indicating which repositories should be migrated.",
+        {
           "name": "repositories",
+          "type": "string[]",
+          "description": "A list of arrays indicating which repositories should be migrated.",
           "required": true,
-          "type": "array of strings"
+          "location": "body"
         },
-        "2": {
-          "default": false,
-          "description": "Indicates whether repositories should be locked (to prevent manipulation) while migrating data.",
+        {
           "name": "lock_repositories",
-          "required": false,
-          "type": "boolean"
-        },
-        "3": {
+          "type": "boolean",
+          "description": "Indicates whether repositories should be locked (to prevent manipulation) while migrating data.",
           "default": false,
-          "description": "Indicates whether attachments should be excluded from the migration (to reduce migration archive file size).",
-          "name": "exclude_attachments",
           "required": false,
-          "type": "boolean"
+          "location": "body"
+        },
+        {
+          "name": "exclude_attachments",
+          "type": "boolean",
+          "description": "Indicates whether attachments should be excluded from the migration (to reduce migration archive file size).",
+          "default": false,
+          "required": false,
+          "location": "body"
         }
-      },
+      ],
       "path": "/orgs/:org/migrations"
     },
     "unlockRepoLockedForMigration": {
-      "description": "Unlocks a repository that was locked for migration. You should unlock each migrated repository and [delete them](/v3/repos/#delete-a-repository) when the migration is complete and you no longer need the source data.",
+      "description": "Unlocks a repository that was locked for migration. You should unlock each migrated repository and [delete them](https://developer.github.com/v3/repos/#delete-a-repository) when the migration is complete and you no longer need the source data.",
       "documentationUrl": "https://developer.github.com/v3/migration/migrations/#unlock-a-repository",
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Unlock a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo_name",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/migrations/:id/repos/:repo_name/lock"
     },
     "updateImport": {
@@ -4840,32 +5378,36 @@
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Update existing import",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The username to provide to the originating repository.",
+        {
           "name": "vcs_username",
+          "type": "string",
+          "description": "The username to provide to the originating repository.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "The password to provide to the originating repository.",
+        {
           "name": "vcs_password",
+          "type": "string",
+          "description": "The password to provide to the originating repository.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/import"
     }
   },
@@ -4876,14 +5418,15 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get an individual code of conduct",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "key",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/codes_of_conduct/:key"
     },
     "getCodesOfConduct": {
@@ -4892,32 +5435,33 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List all codes of conduct",
-      "params": {},
+      "params": [],
       "path": "/codes_of_conduct"
     },
     "getGitignoreTemplate": {
-      "description": "The API also allows fetching the source of a single template.\n\nUse the raw [media type](/v3/media/) to get the raw contents.\n\n",
+      "description": "The API also allows fetching the source of a single template.\n\nUse the raw [media type](https://developer.github.com/v3/media/) to get the raw contents.\n\n",
       "documentationUrl": "https://developer.github.com/v3/gitignore/#get-a-single-template",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "Get a single template",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "name",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/gitignore/templates/:name"
     },
     "getGitignoreTemplates": {
-      "description": "List all templates available to pass as an option when [creating a repository](/v3/repos/#create).",
+      "description": "List all templates available to pass as an option when [creating a repository](https://developer.github.com/v3/repos/#create).",
       "documentationUrl": "https://developer.github.com/v3/gitignore/#listing-available-templates",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "Listing available templates",
-      "params": {},
+      "params": [],
       "path": "/gitignore/templates"
     },
     "getLicense": {
@@ -4926,14 +5470,15 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get an individual license",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "license",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/licenses/:license"
     },
     "getLicenses": {
@@ -4942,60 +5487,64 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List all licenses",
-      "params": {},
+      "params": [],
       "path": "/licenses"
     },
     "getRateLimit": {
-      "description": "Note: Accessing this endpoint does not count against your rate limit.\n\n\n\n**Understanding Your Rate Limit Status**\n\nThe Search API has a [custom rate limit](/v3/search/#rate-limit), separate from the rate limit governing the rest of the API. For that reason, the response (shown above) categorizes your rate limit by resource. Within the `\"resources\"` object, the `\"search\"` object provides your rate limit status for the [Search API](/v3/search). The `\"core\"` object provides your rate limit status for all the _rest_ of the API.\n\nThe `\"rate\"` object (shown at the bottom of the response above) is deprecated.\n\nIf you're writing new API client code (or updating your existing code), you should use the `\"core\"` object instead of the `\"rate\"` object. The `\"core\"` object contains the same information that is present in the `\"rate\"` object.",
+      "description": "Note: Accessing this endpoint does not count against your rate limit.\n\n\n\n**Understanding Your Rate Limit Status**\n\nThe Search API has a [custom rate limit](https://developer.github.com/v3/search/#rate-limit), separate from the rate limit governing the rest of the API. For that reason, the response (shown above) categorizes your rate limit by resource. Within the `\"resources\"` object, the `\"search\"` object provides your rate limit status for the [Search API](https://developer.github.com/v3/search). The `\"core\"` object provides your rate limit status for all the _rest_ of the API.\n\nThe `\"rate\"` object (shown at the bottom of the response above) is deprecated.\n\nIf you're writing new API client code (or updating your existing code), you should use the `\"core\"` object instead of the `\"rate\"` object. The `\"core\"` object contains the same information that is present in the `\"rate\"` object.",
       "documentationUrl": "https://developer.github.com/v3/rate_limit/#get-your-current-rate-limit-status",
       "enabledForApps": true,
       "method": "GET",
       "name": "Get your current rate limit status",
-      "params": {},
+      "params": [],
       "path": "/rate_limit"
     },
     "getRepoCodeOfConduct": {
       "description": "This method returns the contents of the repository's code of conduct file, if one is detected.",
       "documentationUrl": "https://developer.github.com/v3/codes_of_conduct/#get-the-contents-of-a-repositorys-code-of-conduct",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "Get the contents of a repository's code of conduct",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/community/code_of_conduct"
     },
     "getRepoLicense": {
-      "description": "This method returns the contents of the repository's license file, if one is detected.\n\nSimilar to [the repository contents API](/v3/repos/contents/#get-contents), this method also supports [custom media types](/v3/repos/contents/#custom-media-types) for retrieving the raw license content or rendered license HTML.",
+      "description": "This method returns the contents of the repository's license file, if one is detected.\n\nSimilar to [the repository contents API](https://developer.github.com/v3/repos/contents/#get-contents), this method also supports [custom media types](https://developer.github.com/v3/repos/contents/#custom-media-types) for retrieving the raw license content or rendered license HTML.",
       "documentationUrl": "https://developer.github.com/v3/licenses/#get-the-contents-of-a-repositorys-license",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "Get the contents of a repository's license",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/license"
     },
     "renderMarkdown": {
@@ -5004,31 +5553,34 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Render an arbitrary Markdown document",
-      "params": {
-        "0": {
-          "description": "The Markdown text to render in HTML. Markdown content must be 400 KB or less.",
+      "params": [
+        {
           "name": "text",
+          "type": "string",
+          "description": "The Markdown text to render in HTML. Markdown content must be 400 KB or less.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "1": {
-          "default": "markdown",
+        {
+          "name": "mode",
+          "type": "string",
           "description": "The rendering mode. Can be either:  \n\\* `markdown` to render a document in plain Markdown, just like README.md files are rendered.  \n\\* `gfm` to render a document in [GitHub Flavored Markdown](https://github.github.com/gfm/), which creates links for user mentions as well as references to SHA-1 hashes, issues, and pull requests.",
+          "default": "markdown",
+          "required": false,
           "enum": [
             "markdown",
             "gfm"
           ],
-          "name": "mode",
-          "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "2": {
-          "description": "The repository context to use when creating references in `gfm` mode. Omit this parameter when using `markdown` mode.",
+        {
           "name": "context",
+          "type": "string",
+          "description": "The repository context to use when creating references in `gfm` mode. Omit this parameter when using `markdown` mode.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/markdown"
     },
     "renderMarkdownRaw": {
@@ -5037,7 +5589,7 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Render a Markdown document in raw mode",
-      "params": {},
+      "params": [],
       "path": "/markdown/raw"
     }
   },
@@ -5048,31 +5600,34 @@
       "enabledForApps": true,
       "method": "PUT",
       "name": "Add or update organization membership",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "username",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "default": "member",
+        {
+          "name": "username",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "role",
+          "type": "string",
           "description": "The role to give the user in the organization. Can be one of:  \n\\* `admin` \\- The user will become an owner of the organization.  \n\\* `member` \\- The user will become a non-owner member of the organization.",
+          "default": "member",
+          "required": false,
           "enum": [
             "admin",
             "member"
           ],
-          "name": "role",
-          "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/orgs/:org/memberships/:username"
     },
     "addTeamMembership": {
@@ -5081,71 +5636,78 @@
       "enabledForApps": true,
       "method": "PUT",
       "name": "Add or update team membership",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "username",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "default": "member",
+        {
+          "name": "username",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "role",
+          "type": "string",
           "description": "The role that this user should have in the team. Can be one of:  \n\\* `member` \\- a normal member of the team.  \n\\* `maintainer` \\- a team maintainer. Able to add/remove other team members, promote other team members to team maintainer, and edit the team's name and description.",
+          "default": "member",
+          "required": false,
           "enum": [
             "member",
             "maintainer"
           ],
-          "name": "role",
-          "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/teams/:id/memberships/:username"
     },
     "addTeamRepo": {
-      "description": "To add a repository to a team or update the team's permission on a repository, the authenticated user must have admin access to the repository, and must be able to see the team. Also, the repository must be owned by the organization, or a direct fork of a repository owned by the organization.\n\nNote that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](/v3/#http-verbs).\"\n\n",
+      "description": "To add a repository to a team or update the team's permission on a repository, the authenticated user must have admin access to the repository, and must be able to see the team. The repository must be owned by the organization, or a direct fork of a repository owned by the organization.\n\nIf you pass the `hellcat-preview` media type, you can modify repository permissions of child teams.\n\nNote that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](https://developer.github.com/v3/#http-verbs).\"\n\n",
       "documentationUrl": "https://developer.github.com/v3/teams/#add-or-update-team-repository",
       "enabledForApps": false,
       "method": "PUT",
       "name": "Add or update team repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "org",
+          "location": "url"
+        },
+        {
+          "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "3": {
+        {
+          "name": "permission",
+          "type": "string",
           "description": "The permission to grant the team on this repository. Can be one of:  \n\\* `pull` \\- team members can pull, but not push to or administer this repository.  \n\\* `push` \\- team members can pull and push, but not administer this repository.  \n\\* `admin` \\- team members can pull, push and administer this repository.  \n  \nIf no permission is specified, the team's `permission` attribute will be used to determine what permission to grant the team on this repository.  \n**Note**: If you pass the `hellcat-preview` media type, you can promote—but not demote—a `permission` attribute inherited through a parent team.",
+          "required": false,
           "enum": [
             "pull",
             "push",
             "admin"
           ],
-          "name": "permission",
-          "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
-      "path": "/teams/:id/repos/:org/:repo"
+      ],
+      "path": "/teams/:id/repos/:owner/:repo"
     },
     "blockUser": {
       "description": "",
@@ -5153,20 +5715,22 @@
       "enabledForApps": false,
       "method": "PUT",
       "name": "Block a user",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/blocks/:username"
     },
     "checkBlockedUser": {
@@ -5175,20 +5739,22 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Check whether a user is blocked from an organization",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/blocks/:username"
     },
     "checkMembership": {
@@ -5197,70 +5763,77 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Check membership",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/members/:username"
     },
     "checkPublicMembership": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/orgs/members/#check-public-membership",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "Check public membership",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/public_members/:username"
     },
     "checkTeamRepo": {
-      "description": "**Note**: If you pass the `hellcat-preview` media type, repositories inherited through a parent team will be checked as well.\n\nYou can also get information about the specified repository, including what permissions the team grants on it, by passing the following custom [media type](/v3/media/) via the `Accept` header:",
+      "description": "**Note**: If you pass the `hellcat-preview` media type, repositories inherited through a parent team will be checked.\n\nYou can also get information about the specified repository, including what permissions the team grants on it, by passing the following custom [media type](https://developer.github.com/v3/media/) via the `Accept` header:",
       "documentationUrl": "https://developer.github.com/v3/teams/#check-if-a-team-manages-a-repository",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "Check if a team manages a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/teams/:id/repos/:owner/:repo"
     },
     "concealMembership": {
@@ -5269,20 +5842,22 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Conceal a user's membership",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/public_members/:username"
     },
     "convertMemberToOutsideCollaborator": {
@@ -5291,20 +5866,22 @@
       "enabledForApps": true,
       "method": "PUT",
       "name": "Convert member to outside collaborator",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/outside_collaborators/:username"
     },
     "createHook": {
@@ -5313,129 +5890,150 @@
       "enabledForApps": false,
       "method": "POST",
       "name": "Create a hook",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "description": "Must be passed as \"web\".",
+        {
           "name": "name",
+          "type": "string",
+          "description": "Must be passed as \"web\".",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "2": {
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+        {
           "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
           "required": true,
-          "type": "object"
+          "location": "body"
         },
-        "3": {
-          "description": "The URL to which the payloads will be delivered.",
+        {
           "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        {
           "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/webhooks/#delivery-headers) header.",
+        {
           "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        {
           "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "7": {
-          "default": "[\"push\"]",
-          "description": "Determines what [events](/v3/activity/events/types/) the hook is triggered for.",
+        {
           "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for.",
+          "default": "[\"push\"]",
           "required": false,
-          "type": "array"
+          "location": "body"
         },
-        "8": {
-          "default": true,
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        {
           "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
           "required": false,
-          "type": "boolean"
+          "location": "body"
         }
-      },
+      ],
       "path": "/orgs/:org/hooks"
     },
     "createTeam": {
       "description": "To create a team, the authenticated user must be a member of `:org`.",
       "documentationUrl": "https://developer.github.com/v3/teams/#create-team",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "POST",
       "name": "Create team",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "description": "The name of the team.",
+        {
           "name": "name",
+          "type": "string",
+          "description": "The name of the team.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "2": {
-          "description": "The description of the team.",
+        {
           "name": "description",
+          "type": "string",
+          "description": "The description of the team.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "The logins of organization members to add as maintainers of the team.",
+        {
           "name": "maintainers",
+          "type": "string[]",
+          "description": "The logins of organization members to add as maintainers of the team.",
           "required": false,
-          "type": "array of strings"
+          "location": "body"
         },
-        "4": {
-          "description": "The full name (e.g., \"organization-name/repository-name\") of repositories to add the team to.",
+        {
           "name": "repo_names",
+          "type": "string[]",
+          "description": "The full name (e.g., \"organization-name/repository-name\") of repositories to add the team to.",
           "required": false,
-          "type": "array of strings"
+          "location": "body"
         },
-        "5": {
-          "default": "secret",
-          "description": "The level of privacy this team should have. The options are:  \n**For a non-nested team:**  \n\\* `secret` \\- only visible to organization owners and members of this team.  \n\\* `closed` \\- visible to all members of this organization.  \nDefault: `secret`  \n**For a parent or child team:**  \n\\* `closed` \\- visible to all members of this organization.  \nDefault for child team: `closed`  \n**Note**: You must pass the `hellcat-preview` media type to set privacy default to `closed` for child teams. **For a parent or child team:**  ",
+        {
           "name": "privacy",
+          "type": "string",
+          "description": "The level of privacy this team should have. The options are:  \n**For a non-nested team:**  \n\\* `secret` \\- only visible to organization owners and members of this team.  \n\\* `closed` \\- visible to all members of this organization.  \nDefault: `secret`  \n**For a parent or child team:**  \n\\* `closed` \\- visible to all members of this organization.  \nDefault for child team: `closed`  \n**Note**: You must pass the `hellcat-preview` media type to set privacy default to `closed` for child teams. **For a parent or child team:**  ",
+          "default": "secret",
           "required": false,
-          "type": "string"
+          "enum": [
+            "secret",
+            "closed"
+          ],
+          "location": "body"
         },
-        "6": {
-          "default": "pull",
+        {
+          "name": "permission",
+          "type": "string",
           "description": "**Deprecated**. The permission that new repositories will be added to the team with when none is specified. Can be one of:  \n\\* `pull` \\- team members can pull, but not push to or administer newly-added repositories.  \n\\* `push` \\- team members can pull and push, but not administer newly-added repositories.  \n\\* `admin` \\- team members can pull, push and administer newly-added repositories.",
+          "default": "pull",
+          "required": false,
           "enum": [
             "pull",
             "push",
             "admin"
           ],
-          "name": "permission",
-          "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "7": {
-          "description": "The ID of a team to set as the parent team. **Note**: You must pass the `hellcat-preview` media type to use this parameter.",
+        {
           "name": "parent_team_id",
+          "type": "integer",
+          "description": "The ID of a team to set as the parent team. **Note**: You must pass the `hellcat-preview` media type to use this parameter.",
           "required": false,
-          "type": "integer"
+          "location": "body"
         }
-      },
+      ],
       "path": "/orgs/:org/teams"
     },
     "deleteHook": {
@@ -5444,20 +6042,22 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Delete a hook",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/hooks/:id"
     },
     "deleteTeam": {
@@ -5466,14 +6066,15 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Delete team",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/teams/:id"
     },
     "deleteTeamRepo": {
@@ -5482,26 +6083,29 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Remove team repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/teams/:id/repos/:owner/:repo"
     },
     "editHook": {
@@ -5510,64 +6114,73 @@
       "enabledForApps": false,
       "method": "PATCH",
       "name": "Edit a hook",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
+        {
           "name": "config",
-          "required": true,
-          "type": "object"
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
+          "required": false,
+          "location": "body"
         },
-        "3": {
-          "description": "The URL to which the payloads will be delivered.",
+        {
           "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        {
           "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/webhooks/#delivery-headers) header.",
+        {
           "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        {
           "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "7": {
-          "default": "[\"push\"]",
-          "description": "Determines what [events](/v3/activity/events/types/) the hook is triggered for.",
+        {
           "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for.",
+          "default": "[\"push\"]",
           "required": false,
-          "type": "array"
+          "location": "body"
         },
-        "8": {
-          "default": true,
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        {
           "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
           "required": false,
-          "type": "boolean"
+          "location": "body"
         }
-      },
+      ],
       "path": "/orgs/:org/hooks/:id"
     },
     "editTeam": {
@@ -5576,96 +6189,106 @@
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Edit team",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "description": "The name of the team.",
+        {
           "name": "name",
+          "type": "string",
+          "description": "The name of the team.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "2": {
-          "description": "The description of the team.",
+        {
           "name": "description",
+          "type": "string",
+          "description": "The description of the team.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "The level of privacy this team should have. Editing teams without specifying this parameter leaves `privacy` intact. The options are:  \n**For a non-nested team:**  \n\\* `secret` \\- only visible to organization owners and members of this team.  \n\\* `closed` \\- visible to all members of this organization.  \n**For a parent or child team:**  \n\\* `closed` \\- visible to all members of this organization.",
+        {
           "name": "privacy",
+          "type": "string",
+          "description": "The level of privacy this team should have. Editing teams without specifying this parameter leaves `privacy` intact. The options are:  \n**For a non-nested team:**  \n\\* `secret` \\- only visible to organization owners and members of this team.  \n\\* `closed` \\- visible to all members of this organization.  \n**For a parent or child team:**  \n\\* `closed` \\- visible to all members of this organization.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "default": "pull",
+        {
+          "name": "permission",
+          "type": "string",
           "description": "**Deprecated**. The permission that new repositories will be added to the team with when none is specified. Can be one of:  \n\\* `pull` \\- team members can pull, but not push to or administer newly-added repositories.  \n\\* `push` \\- team members can pull and push, but not administer newly-added repositories.  \n\\* `admin` \\- team members can pull, push and administer newly-added repositories.",
+          "default": "pull",
+          "required": false,
           "enum": [
             "pull",
             "push",
             "admin"
           ],
-          "name": "permission",
-          "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "The ID of a team to set as the parent team. **Note**: You must pass the `hellcat-preview` media type to use this parameter.",
+        {
           "name": "parent_team_id",
+          "type": "integer",
+          "description": "The ID of a team to set as the parent team. **Note**: You must pass the `hellcat-preview` media type to use this parameter.",
           "required": false,
-          "type": "integer"
+          "location": "body"
         }
-      },
+      ],
       "path": "/teams/:id"
     },
     "get": {
-      "description": "**Note:** Many Organization response values require the user making the request to be authenticated, an organization owner, and have the admin:org scope authorized.",
+      "description": "To see many of the organization response values, you need to be an authenticated organization owner with the `admin:org` scope. When the value of `two_factor_requirement_enabled` is `true`, the organization requires all members, billing managers, and outside collaborators to enable [two-factor authentication](https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/).",
       "documentationUrl": "https://developer.github.com/v3/orgs/#get-an-organization",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "Get an organization",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org"
     },
     "getAll": {
-      "description": "Lists all organizations, in the order that they were created on GitHub.\n\n**Note:** Pagination is powered exclusively by the `since` parameter. Use the [Link header](/v3/#link-header) to get the URL for the next page of organizations.",
+      "description": "Lists all organizations, in the order that they were created on GitHub.\n\n**Note:** Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://developer.github.com/v3/#link-header) to get the URL for the next page of organizations.",
       "documentationUrl": "https://developer.github.com/v3/orgs/#list-all-organizations",
       "enabledForApps": true,
       "method": "GET",
       "name": "List all organizations",
-      "params": {
-        "0": {
-          "description": "The integer ID of the last Organization that you've seen.",
+      "params": [
+        {
           "name": "since",
+          "type": "string",
+          "description": "The integer ID of the last Organization that you've seen.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/organizations"
     },
     "getBlockedUsers": {
@@ -5674,14 +6297,15 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List blocked users",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/blocks"
     },
     "getChildTeams": {
@@ -5690,28 +6314,31 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List child teams",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/teams/:id/teams"
     },
     "getForUser": {
@@ -5720,28 +6347,31 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List user organizations",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/users/:username/orgs"
     },
     "getHook": {
@@ -5750,20 +6380,22 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Get single hook",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/hooks/:id"
     },
     "getHooks": {
@@ -5772,28 +6404,31 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List hooks",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/orgs/:org/hooks"
     },
     "getMembers": {
@@ -5802,51 +6437,56 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Members list",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": "all",
+        {
+          "name": "filter",
+          "type": "string",
           "description": "Filter members returned in the list. Can be one of:  \n\\* `2fa_disabled` \\- Members without [two-factor authentication](https://github.com/blog/1614-two-factor-authentication) enabled. Available for organization owners.  \n\\* `all` \\- All members the authenticated user can see.",
+          "default": "all",
+          "required": false,
           "enum": [
             "2fa_disabled",
             "all"
           ],
-          "name": "filter",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
-          "default": "all",
+        {
+          "name": "role",
+          "type": "string",
           "description": "Filter members returned by their role. Can be one of:  \n\\* `all` \\- All members of the organization, regardless of role.  \n\\* `admin` \\- Organization owners.  \n\\* `member` \\- Non-owner organization members.",
+          "default": "all",
+          "required": false,
           "enum": [
             "all",
             "admin",
             "member"
           ],
-          "name": "role",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/orgs/:org/members"
     },
     "getOrgMembership": {
@@ -5855,20 +6495,22 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get organization membership",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/memberships/:username"
     },
     "getOutsideCollaborators": {
@@ -5877,69 +6519,76 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List outside collaborators",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": "all",
+        {
+          "name": "filter",
+          "type": "string",
           "description": "Filter the list of outside collaborators. Can be one of:  \n\\* `2fa_disabled`: Outside collaborators without [two-factor authentication](https://github.com/blog/1614-two-factor-authentication) enabled.  \n\\* `all`: All outside collaborators.",
+          "default": "all",
+          "required": false,
           "enum": [
             "2fa_disabled",
             "all"
           ],
-          "name": "filter",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/orgs/:org/outside_collaborators"
     },
     "getPendingOrgInvites": {
       "description": "The return hash contains a `role` field which refers to the Organization Invitation role and will be one of the following values: `direct_member`, `admin`, `billing_manager`, `hiring_manager`, or `reinstate`. If the invitee is not a GitHub member, the `login` field in the return hash will be `null`.",
       "documentationUrl": "https://developer.github.com/v3/orgs/members/#list-pending-organization-invitations",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "List pending organization invitations",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/orgs/:org/invitations"
     },
     "getPendingTeamInvites": {
@@ -5948,58 +6597,64 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List pending team invitations",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/teams/:id/invitations"
     },
     "getPublicMembers": {
       "description": "Members of an organization can choose to have their membership publicized or not.",
       "documentationUrl": "https://developer.github.com/v3/orgs/members/#public-members-list",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "Public members list",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/orgs/:org/public_members"
     },
     "getTeam": {
@@ -6008,14 +6663,15 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get team",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/teams/:id"
     },
     "getTeamMembers": {
@@ -6024,62 +6680,68 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List team members",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": "all",
+        {
+          "name": "role",
+          "type": "string",
           "description": "Filters members returned by their role in the team. Can be one of:  \n\\* `member` \\- normal members of the team.  \n\\* `maintainer` \\- team maintainers.  \n\\* `all` \\- all members of the team.",
+          "default": "all",
+          "required": false,
           "enum": [
             "member",
             "maintainer",
             "all"
           ],
-          "name": "role",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/teams/:id/members"
     },
     "getTeamMembership": {
-      "description": "If you pass the `hellcat-preview` media type, team members will include the members of child teams.\n\nTo get a user's membership with a team, the team must be visible to the authenticated user.\n\n**Note:** The `role` for organization owners returns as `maintainer`. For more information about `maintainer` roles, see [Create team](/v3/teams#create-team).",
+      "description": "If you pass the `hellcat-preview` media type, team members will include the members of child teams.\n\nTo get a user's membership with a team, the team must be visible to the authenticated user.\n\n**Note:** The `role` for organization owners returns as `maintainer`. For more information about `maintainer` roles, see [Create team](https://developer.github.com/v3/teams#create-team).",
       "documentationUrl": "https://developer.github.com/v3/teams/members/#get-team-membership",
       "enabledForApps": true,
       "method": "GET",
       "name": "Get team membership",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/teams/:id/memberships/:username"
     },
     "getTeamRepos": {
@@ -6088,28 +6750,31 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List team repos",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/teams/:id/repos"
     },
     "getTeams": {
@@ -6118,72 +6783,79 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List teams",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/orgs/:org/teams"
     },
     "pingHook": {
-      "description": "This will trigger a [ping event](/webhooks/#ping-event) to be sent to the hook.",
+      "description": "This will trigger a [ping event](https://developer.github.com/webhooks/#ping-event) to be sent to the hook.",
       "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#ping-a-hook",
       "enabledForApps": false,
       "method": "POST",
       "name": "Ping a hook",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/hooks/:id/pings"
     },
     "publicizeMembership": {
-      "description": "The user can publicize their own membership. (A user cannot publicize the membership for another user.)\n\nNote that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](/v3/#http-verbs).\"",
+      "description": "The user can publicize their own membership. (A user cannot publicize the membership for another user.)\n\nNote that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](https://developer.github.com/v3/#http-verbs).\"",
       "documentationUrl": "https://developer.github.com/v3/orgs/members/#publicize-a-users-membership",
       "enabledForApps": false,
       "method": "PUT",
       "name": "Publicize a user's membership",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/public_members/:username"
     },
     "removeMember": {
@@ -6192,20 +6864,22 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Remove a member",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/members/:username"
     },
     "removeOrgMembership": {
@@ -6214,20 +6888,22 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Remove organization membership",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/memberships/:username"
     },
     "removeOutsideCollaborator": {
@@ -6236,20 +6912,22 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Remove outside collaborator",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/outside_collaborators/:username"
     },
     "removeTeamMembership": {
@@ -6258,20 +6936,22 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Remove team membership",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/teams/:id/memberships/:username"
     },
     "unblockUser": {
@@ -6280,20 +6960,22 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Unblock a user",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/orgs/:org/blocks/:username"
     },
     "update": {
@@ -6302,76 +6984,93 @@
       "enabledForApps": false,
       "method": "PATCH",
       "name": "Edit an organization",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "description": "Billing email address. This address is not publicized.",
+        {
           "name": "billing_email",
+          "type": "string",
+          "description": "Billing email address. This address is not publicized.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "2": {
-          "description": "The company name.",
+        {
           "name": "company",
+          "type": "string",
+          "description": "The company name.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "The publicly visible email address.",
+        {
           "name": "email",
+          "type": "string",
+          "description": "The publicly visible email address.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The location.",
+        {
           "name": "location",
+          "type": "string",
+          "description": "The location.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "The shorthand name of the company.",
+        {
           "name": "name",
+          "type": "string",
+          "description": "The shorthand name of the company.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "description": "The description of the company.",
+        {
           "name": "description",
+          "type": "string",
+          "description": "The description of the company.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "7": {
-          "description": "Toggles whether organization projects are enabled for the organization.",
+        {
           "name": "has_organization_projects",
+          "type": "boolean",
+          "description": "Toggles whether organization projects are enabled for the organization.",
           "required": false,
-          "type": "boolean"
+          "location": "body"
         },
-        "8": {
-          "description": "Toggles whether repository projects are enabled for repositories that belong to the organization.",
+        {
           "name": "has_repository_projects",
+          "type": "boolean",
+          "description": "Toggles whether repository projects are enabled for repositories that belong to the organization.",
           "required": false,
-          "type": "boolean"
+          "location": "body"
         },
-        "9": {
-          "default": "read",
-          "description": "Default permission level members have for organization repositories:  \n\\* `read` \\- can pull, but not push to or administer this repository.  \n\\* `write` \\- can pull and push, but not administer this repository.  \n\\* `admin` \\- can pull, push, and administer this repository.  \n\\* `none` \\- no permissions granted by default.",
+        {
           "name": "default_repository_permission",
+          "type": "string",
+          "description": "Default permission level members have for organization repositories:  \n\\* `read` \\- can pull, but not push to or administer this repository.  \n\\* `write` \\- can pull and push, but not administer this repository.  \n\\* `admin` \\- can pull, push, and administer this repository.  \n\\* `none` \\- no permissions granted by default.",
+          "default": "read",
           "required": false,
-          "type": "string"
+          "enum": [
+            "read",
+            "write",
+            "admin",
+            "none"
+          ],
+          "location": "body"
         },
-        "10": {
-          "default": true,
-          "description": "Toggles ability of non-admin organization members to create repositories  \n\\* `true` \\- all organization members can create repositories.  \n\\* `false` \\- only admin members can create repositories.",
+        {
           "name": "members_can_create_repositories",
+          "type": "boolean",
+          "description": "Toggles ability of non-admin organization members to create repositories  \n\\* `true` \\- all organization members can create repositories.  \n\\* `false` \\- only admin members can create repositories.",
+          "default": true,
           "required": false,
-          "type": "boolean"
+          "location": "body"
         }
-      },
+      ],
       "path": "/orgs/:org"
     }
   },
@@ -6382,40 +7081,45 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Create an organization project",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "description": "The name of the project.",
+        {
           "name": "name",
+          "type": "string",
+          "description": "The name of the project.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "2": {
-          "description": "The body of the project.",
+        {
           "name": "body",
+          "type": "string",
+          "description": "The body of the project.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/orgs/:org/projects"
     },
     "createProjectCard": {
@@ -6424,33 +7128,37 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a project card",
-      "params": {
-        "0": {
-          "description": "",
-          "name": "id",
+      "params": [
+        {
+          "name": "column_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "description": "The card's note content. Only valid for cards without another type of content, so this must be omitted if `content_id` and `content_type` are specified.",
+        {
           "name": "note",
+          "type": "string",
+          "description": "The card's note content. Only valid for cards without another type of content, so this must be omitted if `content_id` and `content_type` are specified.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "2": {
-          "description": "The id of the issue to associate with this card.",
+        {
           "name": "content_id",
+          "type": "integer",
+          "description": "The id of the issue to associate with this card.",
           "required": false,
-          "type": "integer"
+          "location": "body"
         },
-        "3": {
-          "description": "**Required if you specify a content_id**. The type of content to associate with this card. Can only be \"Issue\" at this time.",
+        {
           "name": "content_type",
+          "type": "string",
+          "description": "**Required if you specify a content_id**. The type of content to associate with this card. Can only be \"Issue\" at this time.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
-      "path": "/projects/columns/:id/cards"
+      ],
+      "path": "/projects/columns/:column_id/cards"
     },
     "createProjectColumn": {
       "description": "",
@@ -6458,21 +7166,23 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a project column",
-      "params": {
-        "0": {
+      "params": [
+        {
+          "name": "project_id",
+          "type": "string",
+          "required": true,
           "description": "",
-          "name": "id",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "1": {
-          "description": "The name of the column.",
+        {
           "name": "name",
+          "type": "string",
+          "description": "The name of the column.",
           "required": true,
-          "type": "string"
+          "location": "body"
         }
-      },
-      "path": "/projects/:id/columns"
+      ],
+      "path": "/projects/:project_id/columns"
     },
     "createRepoProject": {
       "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
@@ -6480,46 +7190,52 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a repository project",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The name of the project.",
+        {
           "name": "name",
+          "type": "string",
+          "description": "The name of the project.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "The body of the project.",
+        {
           "name": "body",
+          "type": "string",
+          "description": "The body of the project.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "5": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/projects"
     },
     "deleteProject": {
@@ -6528,15 +7244,16 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Delete a project",
-      "params": {
-        "0": {
-          "description": "",
-          "name": "id",
+      "params": [
+        {
+          "name": "project_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
-      "path": "/projects/:id"
+      ],
+      "path": "/projects/:project_id"
     },
     "deleteProjectCard": {
       "description": "",
@@ -6544,15 +7261,16 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Delete a project card",
-      "params": {
-        "0": {
-          "description": "",
-          "name": "id",
+      "params": [
+        {
+          "name": "card_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
-      "path": "/projects/columns/cards/:id"
+      ],
+      "path": "/projects/columns/cards/:card_id"
     },
     "deleteProjectColumn": {
       "description": "",
@@ -6560,15 +7278,16 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Delete a project column",
-      "params": {
-        "0": {
-          "description": "",
-          "name": "id",
+      "params": [
+        {
+          "name": "column_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
-      "path": "/projects/columns/:id"
+      ],
+      "path": "/projects/columns/:column_id"
     },
     "getOrgProjects": {
       "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
@@ -6576,40 +7295,44 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List organization projects",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": "open",
+        {
+          "name": "state",
+          "type": "string",
           "description": "Indicates the state of the projects to return. Can be either `open`, `closed`, or `all`.",
+          "default": "open",
+          "required": false,
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "name": "state",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/orgs/:org/projects"
     },
     "getProject": {
@@ -6618,29 +7341,32 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a project",
-      "params": {
-        "0": {
-          "description": "",
-          "name": "id",
+      "params": [
+        {
+          "name": "project_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
-      "path": "/projects/:id"
+      ],
+      "path": "/projects/:project_id"
     },
     "getProjectCard": {
       "description": "",
@@ -6648,15 +7374,16 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a project card",
-      "params": {
-        "0": {
-          "description": "",
-          "name": "id",
+      "params": [
+        {
+          "name": "card_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
-      "path": "/projects/columns/cards/:id"
+      ],
+      "path": "/projects/columns/cards/:card_id"
     },
     "getProjectCards": {
       "description": "",
@@ -6664,29 +7391,32 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List project cards",
-      "params": {
-        "0": {
-          "description": "",
-          "name": "id",
+      "params": [
+        {
+          "name": "column_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
-      "path": "/projects/columns/:id/cards"
+      ],
+      "path": "/projects/columns/:column_id/cards"
     },
     "getProjectColumn": {
       "description": "",
@@ -6694,45 +7424,49 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a project column",
-      "params": {
-        "0": {
-          "description": "",
-          "name": "id",
+      "params": [
+        {
+          "name": "column_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
-      "path": "/projects/columns/:id"
+      ],
+      "path": "/projects/columns/:column_id"
     },
     "getProjectColumns": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/projects/columns/#list-project-columns",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "List project columns",
-      "params": {
-        "0": {
-          "description": "",
-          "name": "id",
+      "params": [
+        {
+          "name": "project_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
-      "path": "/projects/:id/columns"
+      ],
+      "path": "/projects/:project_id/columns"
     },
     "getRepoProjects": {
       "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
@@ -6740,46 +7474,51 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List repository projects",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "repo",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "default": "open",
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "state",
+          "type": "string",
           "description": "Indicates the state of the projects to return. Can be either `open`, `closed`, or `all`.",
+          "default": "open",
+          "required": false,
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "name": "state",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/projects"
     },
     "moveProjectCard": {
@@ -6788,32 +7527,35 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Move a project card",
-      "params": {
-        "0": {
-          "description": "",
-          "name": "id",
+      "params": [
+        {
+          "name": "card_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
+        {
+          "name": "position",
+          "type": "string",
           "description": "Can be one of `top`, `bottom`, or `after:<card_id>`, where `<card_id>` is the `id` value of a card in the same column, or in the new column specified by `column_id`.",
+          "required": true,
           "enum": [
             "top",
             "bottom",
             "after:<card_id>"
           ],
-          "name": "position",
-          "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "2": {
-          "description": "The `id` value of a column in the same project.",
+        {
           "name": "column_id",
+          "type": "integer",
+          "description": "The `id` value of a column in the same project.",
           "required": false,
-          "type": "integer"
+          "location": "body"
         }
-      },
-      "path": "/projects/columns/cards/:id/moves"
+      ],
+      "path": "/projects/columns/cards/:card_id/moves"
     },
     "moveProjectColumn": {
       "description": "",
@@ -6821,26 +7563,28 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Move a project column",
-      "params": {
-        "0": {
-          "description": "",
-          "name": "id",
+      "params": [
+        {
+          "name": "column_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
+        {
+          "name": "position",
+          "type": "string",
           "description": "Can be one of `first`, `last`, or `after:<column_id>`, where `<column_id>` is the `id` value of a column in the same project.",
+          "required": true,
           "enum": [
             "first",
             "last",
             "after:<column_id>"
           ],
-          "name": "position",
-          "required": true,
-          "type": "string"
+          "location": "body"
         }
-      },
-      "path": "/projects/columns/:id/moves"
+      ],
+      "path": "/projects/columns/:column_id/moves"
     },
     "updateProject": {
       "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
@@ -6848,63 +7592,71 @@
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Update a project",
-      "params": {
-        "0": {
-          "description": "",
-          "name": "id",
+      "params": [
+        {
+          "name": "project_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "description": "The name of the project.",
+        {
           "name": "name",
+          "type": "string",
+          "description": "The name of the project.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "2": {
-          "description": "The body of the project.",
+        {
           "name": "body",
+          "type": "string",
+          "description": "The body of the project.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
+        {
+          "name": "state",
+          "type": "string",
           "description": "State of the project. Either `open` or `closed`.",
+          "required": false,
           "enum": [
             "open",
             "closed"
           ],
-          "name": "state",
-          "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The permission level that all members of the project's organization will have on this project. If an organization member belongs to a team with a higher level of access or is a collaborator with a higher level of access, their permission level is not lowered by `organization_permission`. Updating a project's organization permission requires `admin` access to the project. Setting the organization permission is only available for organization projects.",
+        {
           "name": "organization_permission",
+          "type": "string",
+          "description": "The permission level that all members of the project's organization will have on this project. If an organization member belongs to a team with a higher level of access or is a collaborator with a higher level of access, their permission level is not lowered by `organization_permission`. Updating a project's organization permission requires `admin` access to the project. Setting the organization permission is only available for organization projects.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "Sets visibility of the project within the organization. Updating a project's visibility requires `admin` access to the project. Setting visibility is only available for organization projects. Can be one of:  \n\\* `true` \\- Anyone that can view the organization can see the project.  \n\\* `false` \\- The project must be an organization project to set project visibility.",
+        {
           "name": "public",
+          "type": "boolean",
+          "description": "Sets visibility of the project within the organization. Updating a project's visibility requires `admin` access to the project. Setting visibility is only available for organization projects. Can be one of:  \n\\* `true` \\- Anyone that can view the organization can see the project.  \n\\* `false` \\- The project must be an organization project to set project visibility.",
           "required": false,
-          "type": "boolean"
+          "location": "body"
         },
-        "6": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "7": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
-      "path": "/projects/:id"
+      ],
+      "path": "/projects/:project_id"
     },
     "updateProjectCard": {
       "description": "",
@@ -6912,21 +7664,23 @@
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Update a project card",
-      "params": {
-        "0": {
-          "description": "",
-          "name": "id",
+      "params": [
+        {
+          "name": "card_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "description": "The card's note content. Only valid for cards without another type of content, so this cannot be specified if the card already has a `content_id` and `content_type`.",
+        {
           "name": "note",
+          "type": "string",
+          "description": "The card's note content. Only valid for cards without another type of content, so this cannot be specified if the card already has a `content_id` and `content_type`.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
-      "path": "/projects/columns/cards/:id"
+      ],
+      "path": "/projects/columns/cards/:card_id"
     },
     "updateProjectColumn": {
       "description": "",
@@ -6934,21 +7688,23 @@
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Update a project column",
-      "params": {
-        "0": {
+      "params": [
+        {
+          "name": "column_id",
+          "type": "string",
+          "required": true,
           "description": "",
-          "name": "id",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "1": {
-          "description": "The new name of the column.",
+        {
           "name": "name",
+          "type": "string",
+          "description": "The new name of the column.",
           "required": true,
-          "type": "string"
+          "location": "body"
         }
-      },
-      "path": "/projects/columns/:id"
+      ],
+      "path": "/projects/columns/:column_id"
     }
   },
   "pullRequests": {
@@ -6958,349 +7714,381 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get if a pull request has been merged",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number/merge"
     },
     "create": {
-      "description": "",
+      "description": "**Note:** To open a pull request in a public repository, you must have write access to the head or the source branch. For organization-owned repositories, you must be a member of the organization that owns the repository to open a pull request.",
       "documentationUrl": "https://developer.github.com/v3/pulls/#create-a-pull-request",
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a pull request",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The title of the pull request.",
+        {
           "name": "title",
+          "type": "string",
+          "description": "The title of the pull request.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "The name of the branch where your changes are implemented. For cross-repository pull requests in the same network, namespace `head` with a user like this: `username:branch`.",
+        {
           "name": "head",
+          "type": "string",
+          "description": "The name of the branch where your changes are implemented. For cross-repository pull requests in the same network, namespace `head` with a user like this: `username:branch`.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The name of the branch you want the changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repository that requests a merge to a base of another repository.",
+        {
           "name": "base",
+          "type": "string",
+          "description": "The name of the branch you want the changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repository that requests a merge to a base of another repository.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "The contents of the pull request.",
+        {
           "name": "body",
+          "type": "string",
+          "description": "The contents of the pull request.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "description": "Indicates whether [maintainers can modify](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) the pull request.",
+        {
           "name": "maintainer_can_modify",
+          "type": "boolean",
+          "description": "Indicates whether [maintainers can modify](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) the pull request.",
           "required": false,
-          "type": "boolean"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls"
     },
     "createComment": {
-      "description": "**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
+      "description": "**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](https://developer.github.com/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
       "documentationUrl": "https://developer.github.com/v3/pulls/comments/#create-a-comment",
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "The text of the comment.",
+        {
           "name": "body",
+          "type": "string",
+          "description": "The text of the comment.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The SHA of the commit needing a comment. Not using the latest commit SHA may render your comment outdated if a subsequent commit modifies the line you specify as the `position`.",
+        {
           "name": "commit_id",
+          "type": "string",
+          "description": "The SHA of the commit needing a comment. Not using the latest commit SHA may render your comment outdated if a subsequent commit modifies the line you specify as the `position`.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "The relative path to the file that necessitates a comment.",
+        {
           "name": "path",
+          "type": "string",
+          "description": "The relative path to the file that necessitates a comment.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
+        {
           "name": "position",
+          "type": "integer",
+          "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
           "required": true,
-          "type": "integer"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number/comments"
     },
     "createCommentReply": {
-      "description": "**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
+      "description": "**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](https://developer.github.com/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
       "documentationUrl": "https://developer.github.com/v3/pulls/comments/#create-a-comment",
       "enabledForApps": true,
       "method": "POST",
-      "name": "Create a comment",
-      "params": {
-        "0": {
-          "description": "",
+      "name": "Create a comment (alternative)",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "The text of the comment.",
+        {
           "name": "body",
+          "type": "string",
+          "description": "The text of the comment.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The SHA of the commit needing a comment. Not using the latest commit SHA may render your comment outdated if a subsequent commit modifies the line you specify as the `position`.",
-          "name": "commit_id",
+        {
+          "name": "in_reply_to",
+          "type": "integer",
+          "description": "The comment ID to reply to. **Note**: This must be the ID of a _top-level comment_, not a reply to that comment. Replies to replies are not supported.",
           "required": true,
-          "type": "string"
-        },
-        "5": {
-          "description": "The relative path to the file that necessitates a comment.",
-          "name": "path",
-          "required": true,
-          "type": "string"
-        },
-        "6": {
-          "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
-          "name": "position",
-          "required": true,
-          "type": "integer"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number/comments"
     },
     "createFromIssue": {
-      "description": "",
+      "description": "**Note:** To open a pull request in a public repository, you must have write access to the head or the source branch. For organization-owned repositories, you must be a member of the organization that owns the repository to open a pull request.",
       "documentationUrl": "https://developer.github.com/v3/pulls/#create-a-pull-request",
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a pull request",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The title of the pull request.",
+        {
           "name": "title",
+          "type": "string",
+          "description": "The title of the pull request.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "The name of the branch where your changes are implemented. For cross-repository pull requests in the same network, namespace `head` with a user like this: `username:branch`.",
+        {
           "name": "head",
+          "type": "string",
+          "description": "The name of the branch where your changes are implemented. For cross-repository pull requests in the same network, namespace `head` with a user like this: `username:branch`.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The name of the branch you want the changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repository that requests a merge to a base of another repository.",
+        {
           "name": "base",
+          "type": "string",
+          "description": "The name of the branch you want the changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repository that requests a merge to a base of another repository.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "The contents of the pull request.",
+        {
           "name": "body",
+          "type": "string",
+          "description": "The contents of the pull request.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "description": "Indicates whether [maintainers can modify](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) the pull request.",
+        {
           "name": "maintainer_can_modify",
+          "type": "boolean",
+          "description": "Indicates whether [maintainers can modify](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) the pull request.",
           "required": false,
-          "type": "boolean"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls"
     },
     "createReview": {
-      "description": "**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
+      "description": "**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](https://developer.github.com/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
       "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review",
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a pull request review",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
+        {
           "name": "commit_id",
+          "type": "string",
+          "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
+        {
           "name": "body",
+          "type": "string",
+          "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
+        {
+          "name": "event",
+          "type": "string",
+          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
+          "required": false,
           "enum": [
             "APPROVE",
             "REQUEST_CHANGES",
             "COMMENT"
           ],
-          "name": "event",
-          "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
+        {
           "name": "comments",
+          "type": "object[]",
+          "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
           "required": false,
-          "type": "array of draft review comment objects"
+          "location": "body"
         },
-        "7": {
-          "description": "**Required.** The relative path to the file that necessitates a review comment.",
+        {
           "name": "comments.path",
+          "type": "string",
+          "description": "**Required.** The relative path to the file that necessitates a review comment.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "8": {
-          "description": "**Required.** The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
+        {
           "name": "comments.position",
+          "type": "integer",
+          "description": "**Required.** The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
           "required": false,
-          "type": "integer"
+          "location": "body"
         },
-        "9": {
-          "description": "**Required.** Text of the review comment.",
+        {
           "name": "comments.body",
+          "type": "string",
+          "description": "**Required.** Text of the review comment.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number/reviews"
     },
     "createReviewRequest": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/pulls/review_requests/#create-a-review-request",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "POST",
       "name": "Create a review request",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "An array of user `login`s that will be requested.",
+        {
           "name": "reviewers",
+          "type": "string[]",
+          "description": "An array of user `login`s that will be requested.",
           "required": false,
-          "type": "array of strings"
+          "location": "body"
         },
-        "4": {
-          "description": "An array of team `slug`s that will be requested.",
+        {
           "name": "team_reviewers",
+          "type": "string[]",
+          "description": "An array of team `slug`s that will be requested.",
           "required": false,
-          "type": "array of strings"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number/requested_reviewers"
     },
     "deleteComment": {
@@ -7309,140 +8097,157 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Delete a comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/comments/:id"
     },
     "deletePendingReview": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#delete-a-pending-review",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "DELETE",
       "name": "Delete a pending review",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
-        },
-        "3": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number/reviews/:id"
     },
     "deleteReviewRequest": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/pulls/review_requests/#delete-a-review-request",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "DELETE",
       "name": "Delete a review request",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "An array of user `login`s that will be removed.",
+        {
           "name": "reviewers",
+          "type": "string[]",
+          "description": "An array of user `login`s that will be removed.",
           "required": false,
-          "type": "array of strings"
+          "location": "body"
         },
-        "4": {
-          "description": "An array of team `slug`s that will be removed.",
+        {
           "name": "team_reviewers",
+          "type": "string[]",
+          "description": "An array of team `slug`s that will be removed.",
           "required": false,
-          "type": "array of strings"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number/requested_reviewers"
     },
     "dismissReview": {
-      "description": "**Note:** To dismiss a pull request review on a [protected branch](/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
+      "description": "**Note:** To dismiss a pull request review on a [protected branch](https://developer.github.com/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
       "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#dismiss-a-pull-request-review",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "PUT",
       "name": "Dismiss a pull request review",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
-        },
-        "3": {
           "description": "",
-          "name": "id",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "4": {
-          "description": "**Required.** The message for the pull request review dismissal",
+        {
+          "name": "id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
           "name": "message",
+          "type": "string",
+          "description": "**Required.** The message for the pull request review dismissal",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number/reviews/:id/dismissals"
     },
     "editComment": {
@@ -7451,60 +8256,67 @@
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Edit a comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "id",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "3": {
-          "description": "The text of the comment.",
-          "name": "body",
+        {
+          "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The text of the comment.",
+          "required": true,
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/comments/:id"
     },
     "get": {
-      "description": "Each time the pull request receives new commits, GitHub creates a merge commit to _test_ whether the pull request can be automatically merged into the base branch. (This _test_ commit is not added to the base branch or the head branch.)\n\nThe value of the `merge_commit_sha` attribute changes depending on the state of the pull request. Before a pull request is merged, the `merge_commit_sha` attribute holds the SHA of the _test_ merge commit. After a pull request is merged, the attribute changes depending on how the pull request was merged:\n\n*   If the pull request was merged as a merge commit, the attribute represents the SHA of the merge commit.\n*   If the pull request was merged via a squash, the attribute represents the SHA of the squashed commit on the base branch.\n*   If the pull request was rebased, the attribute represents the commit that the base branch was updated to.\n\nThe value of the `mergeable` attribute can be `true`, `false`, or `null`. If the value is `null`, this means that the mergeability hasn't been computed yet, and a background job was started to compute it. Give the job a few moments to complete, and then submit the request again. When the job is complete, the response will include a non-`null` value for the `mergeable` attribute.\n\nPass the appropriate [media type](/v3/media/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.",
+      "description": "Each time the pull request receives new commits, GitHub creates a merge commit to _test_ whether the pull request can be automatically merged into the base branch. (This _test_ commit is not added to the base branch or the head branch.)\n\nThe value of the `merge_commit_sha` attribute changes depending on the state of the pull request. Before a pull request is merged, the `merge_commit_sha` attribute holds the SHA of the _test_ merge commit. After a pull request is merged, the attribute changes depending on how the pull request was merged:\n\n*   If the pull request was merged as a merge commit, the attribute represents the SHA of the merge commit.\n*   If the pull request was merged via a squash, the attribute represents the SHA of the squashed commit on the base branch.\n*   If the pull request was rebased, the attribute represents the commit that the base branch was updated to.\n\nThe value of the `mergeable` attribute can be `true`, `false`, or `null`. If the value is `null`, this means that the mergeability hasn't been computed yet, and a background job was started to compute it. Give the job a few moments to complete, and then submit the request again. When the job is complete, the response will include a non-`null` value for the `mergeable` attribute.\n\nPass the appropriate [media type](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.",
       "documentationUrl": "https://developer.github.com/v3/pulls/#get-a-single-pull-request",
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a single pull request",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number"
     },
     "getAll": {
@@ -7513,82 +8325,91 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List pull requests",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "repo",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "default": "open",
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "state",
+          "type": "string",
           "description": "Either `open`, `closed`, or `all` to filter by state.",
+          "default": "open",
+          "required": false,
           "enum": [
             "open",
             "closed",
             "all"
           ],
-          "name": "state",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "description": "Filter pulls by head user and branch name in the format of `user:ref-name`. Example: `github:new-script-format`.",
+        {
           "name": "head",
+          "type": "string",
+          "description": "Filter pulls by head user and branch name in the format of `user:ref-name`. Example: `github:new-script-format`.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "4": {
-          "description": "Filter pulls by base branch name. Example: `gh-pages`.",
+        {
           "name": "base",
+          "type": "string",
+          "description": "Filter pulls by base branch name. Example: `gh-pages`.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "5": {
-          "default": "created",
+        {
+          "name": "sort",
+          "type": "string",
           "description": "What to sort results by. Can be either `created`, `updated`, `popularity` (comment count) or `long-running` (age, filtering by pulls updated in the last month).",
+          "default": "created",
+          "required": false,
           "enum": [
             "created",
             "updated",
             "popularity",
             "long-running"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "6": {
-          "default": "`desc` when sort is `created` or sort is not specified, otherwise `asc`",
+        {
+          "name": "direction",
+          "type": "string",
           "description": "The direction of the sort. Can be either `asc` or `desc`.",
+          "default": "`desc` when sort is `created` or sort is not specified, otherwise `asc`",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "direction",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "7": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "8": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls"
     },
     "getComment": {
@@ -7597,26 +8418,29 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a single comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/comments/:id"
     },
     "getComments": {
@@ -7625,67 +8449,75 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List comments on a pull request",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "number",
-          "required": true,
-          "type": "integer"
+          "location": "url"
         },
-        "3": {
-          "default": "created",
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "sort",
+          "type": "string",
           "description": "Can be either `created` or `updated` comments.",
+          "default": "created",
+          "required": false,
           "enum": [
             "created",
             "updated"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "4": {
+        {
+          "name": "direction",
+          "type": "string",
           "description": "Can be either `asc` or `desc`. Ignored without `sort` parameter.",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "direction",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "5": {
-          "description": "This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Only returns comments `updated` at or after this time.",
+        {
           "name": "since",
+          "type": "string",
+          "description": "This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Only returns comments `updated` at or after this time.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "6": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "7": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number/comments"
     },
     "getCommentsForRepo": {
@@ -7694,103 +8526,115 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List comments in a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "repo",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "default": "created",
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "sort",
+          "type": "string",
           "description": "Can be either `created` or `updated` comments.",
+          "default": "created",
+          "required": false,
           "enum": [
             "created",
             "updated"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
+        {
+          "name": "direction",
+          "type": "string",
           "description": "Can be either `asc` or `desc`. Ignored without `sort` parameter.",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "direction",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "4": {
-          "description": "This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Only returns comments `updated` at or after this time.",
+        {
           "name": "since",
+          "type": "string",
+          "description": "This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Only returns comments `updated` at or after this time.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "5": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "6": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/comments"
     },
     "getCommits": {
-      "description": "**Note:** The response includes a maximum of 250 commits. To receive a complete commit list for pull requests with more than 250 commits, use the [Commit List API](/v3/repos/commits/#list-commits-on-a-repository).",
+      "description": "**Note:** The response includes a maximum of 250 commits. To receive a complete commit list for pull requests with more than 250 commits, use the [Commit List API](https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository).",
       "documentationUrl": "https://developer.github.com/v3/pulls/#list-commits-on-a-pull-request",
       "enabledForApps": true,
       "method": "GET",
       "name": "List commits on a pull request",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number/commits"
     },
     "getFiles": {
@@ -7799,40 +8643,45 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List pull requests files",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number/files"
     },
     "getReview": {
@@ -7841,32 +8690,36 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a single review",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
-        },
-        "3": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number/reviews/:id"
     },
     "getReviewComments": {
@@ -7875,688 +8728,834 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get comments for a single review",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
-        },
-        "3": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "4": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "5": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number/reviews/:id/comments"
     },
     "getReviewRequests": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/pulls/review_requests/#list-review-requests",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "List review requests",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number/requested_reviewers"
     },
     "getReviews": {
       "description": "The list of reviews returns in chronological order.",
       "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "List reviews on a pull request",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number/reviews"
     },
     "merge": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "PUT",
       "name": "Merge a pull request (Merge Button)",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "Title for the automatic commit message.",
+        {
           "name": "commit_title",
+          "type": "string",
+          "description": "Title for the automatic commit message.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "Extra detail to append to automatic commit message.",
+        {
           "name": "commit_message",
+          "type": "string",
+          "description": "Extra detail to append to automatic commit message.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "SHA that pull request head must match to allow merge.",
+        {
           "name": "sha",
+          "type": "string",
+          "description": "SHA that pull request head must match to allow merge.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
+        {
+          "name": "merge_method",
+          "type": "string",
           "description": "Merge method to use. Possible values are `merge`, `squash` or `rebase`. Default is `merge`.",
+          "required": false,
           "enum": [
             "merge",
             "squash",
             "rebase"
           ],
-          "name": "merge_method",
-          "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number/merge"
     },
     "submitReview": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "POST",
       "name": "Submit a pull request review",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
-        },
-        "3": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "4": {
-          "description": "The body text of the pull request review",
+        {
           "name": "body",
+          "type": "string",
+          "description": "The body text of the pull request review",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
+        {
+          "name": "event",
+          "type": "string",
           "description": "**Required.** The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
+          "required": false,
           "enum": [
             "APPROVE",
             "REQUEST_CHANGES",
             "COMMENT"
           ],
-          "name": "event",
-          "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number/reviews/:id/events"
     },
     "update": {
-      "description": "",
+      "description": "**Note:** To open a pull request in a public repository, you must have write access to the head or the source branch. For organization-owned repositories, you must be a member of the organization that owns the repository to open a pull request.",
       "documentationUrl": "https://developer.github.com/v3/pulls/#update-a-pull-request",
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Update a pull request",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "The title of the pull request.",
+        {
           "name": "title",
+          "type": "string",
+          "description": "The title of the pull request.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The contents of the pull request.",
+        {
           "name": "body",
+          "type": "string",
+          "description": "The contents of the pull request.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
+        {
+          "name": "state",
+          "type": "string",
           "description": "State of this Pull Request. Either `open` or `closed`.",
+          "required": false,
           "enum": [
             "open",
             "closed"
           ],
-          "name": "state",
-          "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "description": "The name of the branch you want your changes pulled into. This should be an existing branch on the current repository. You cannot update the base branch on a pull request to point to another repository.",
+        {
           "name": "base",
+          "type": "string",
+          "description": "The name of the branch you want your changes pulled into. This should be an existing branch on the current repository. You cannot update the base branch on a pull request to point to another repository.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "7": {
-          "description": "Indicates whether [maintainers can modify](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) the pull request.",
+        {
           "name": "maintainer_can_modify",
+          "type": "boolean",
+          "description": "Indicates whether [maintainers can modify](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) the pull request.",
           "required": false,
-          "type": "boolean"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/:number"
     }
   },
   "reactions": {
     "createForCommitComment": {
-      "description": "Create a reaction to a [commit comment](/v3/repos/comments/). A response with a `Status: 200 OK` means that you already added the reaction type to this commit comment.",
+      "description": "Create a reaction to a [commit comment](https://developer.github.com/v3/repos/comments/). A response with a `Status: 200 OK` means that you already added the reaction type to this commit comment.",
       "documentationUrl": "https://developer.github.com/v3/reactions/#create-reaction-for-a-commit-comment",
       "enabledForApps": false,
       "method": "POST",
       "name": "Create reaction for a commit comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "id",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "3": {
-          "description": "The [reaction type](/v3/reactions/#reaction-types) to add to the commit comment.",
-          "name": "content",
+        {
+          "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "content",
+          "type": "string",
+          "description": "The [reaction type](https://developer.github.com/v3/reactions/#reaction-types) to add to the commit comment.",
+          "required": true,
+          "enum": [
+            "+1",
+            "-1",
+            "laugh",
+            "confused",
+            "heart",
+            "hooray"
+          ],
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/comments/:id/reactions"
     },
     "createForIssue": {
-      "description": "Create a reaction to an [issue](/v3/issues/). A response with a `Status: 200 OK` means that you already added the reaction type to this issue.",
+      "description": "Create a reaction to an [issue](https://developer.github.com/v3/issues/). A response with a `Status: 200 OK` means that you already added the reaction type to this issue.",
       "documentationUrl": "https://developer.github.com/v3/reactions/#create-reaction-for-an-issue",
       "enabledForApps": false,
       "method": "POST",
       "name": "Create reaction for an issue",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "number",
-          "required": true,
-          "type": "integer"
+          "location": "url"
         },
-        "3": {
-          "description": "The [reaction type](/v3/reactions/#reaction-types) to add to the issue.",
-          "name": "content",
+        {
+          "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "content",
+          "type": "string",
+          "description": "The [reaction type](https://developer.github.com/v3/reactions/#reaction-types) to add to the issue.",
+          "required": true,
+          "enum": [
+            "+1",
+            "-1",
+            "laugh",
+            "confused",
+            "heart",
+            "hooray"
+          ],
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/:number/reactions"
     },
     "createForIssueComment": {
-      "description": "Create a reaction to an [issue comment](/v3/issues/comments/). A response with a `Status: 200 OK` means that you already added the reaction type to this issue comment.",
+      "description": "Create a reaction to an [issue comment](https://developer.github.com/v3/issues/comments/). A response with a `Status: 200 OK` means that you already added the reaction type to this issue comment.",
       "documentationUrl": "https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment",
       "enabledForApps": false,
       "method": "POST",
       "name": "Create reaction for an issue comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "id",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "3": {
-          "description": "The [reaction type](/v3/reactions/#reaction-types) to add to the issue comment.",
-          "name": "content",
+        {
+          "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "content",
+          "type": "string",
+          "description": "The [reaction type](https://developer.github.com/v3/reactions/#reaction-types) to add to the issue comment.",
+          "required": true,
+          "enum": [
+            "+1",
+            "-1",
+            "laugh",
+            "confused",
+            "heart",
+            "hooray"
+          ],
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/comments/:id/reactions"
     },
     "createForPullRequestReviewComment": {
-      "description": "Create a reaction to a [pull request review comment](/v3/pulls/comments/). A response with a `Status: 200 OK` means that you already added the reaction type to this pull request review comment.",
+      "description": "Create a reaction to a [pull request review comment](https://developer.github.com/v3/pulls/comments/). A response with a `Status: 200 OK` means that you already added the reaction type to this pull request review comment.",
       "documentationUrl": "https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-review-comment",
       "enabledForApps": false,
       "method": "POST",
       "name": "Create reaction for a pull request review comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "id",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "3": {
-          "description": "The [reaction type](/v3/reactions/#reaction-types) to add to the pull request review comment.",
-          "name": "content",
+        {
+          "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "content",
+          "type": "string",
+          "description": "The [reaction type](https://developer.github.com/v3/reactions/#reaction-types) to add to the pull request review comment.",
+          "required": true,
+          "enum": [
+            "+1",
+            "-1",
+            "laugh",
+            "confused",
+            "heart",
+            "hooray"
+          ],
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/comments/:id/reactions"
     },
     "delete": {
-      "description": "OAuth access tokens require the `read:discussion` [scope](/apps/building-oauth-apps/scopes-for-oauth-apps/), when deleting a [team discussion](/v3/teams/discussions/) or [team discussion comment](/v3/teams/discussion_comments/).",
+      "description": "OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/scopes-for-oauth-apps/), when deleting a [team discussion](https://developer.github.com/v3/teams/discussions/) or [team discussion comment](https://developer.github.com/v3/teams/discussion_comments/).",
       "documentationUrl": "https://developer.github.com/v3/reactions/#delete-a-reaction",
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Delete a reaction",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/reactions/:id"
     },
     "getForCommitComment": {
-      "description": "List the reactions to a [commit comment](/v3/repos/comments/).",
+      "description": "List the reactions to a [commit comment](https://developer.github.com/v3/repos/comments/).",
       "documentationUrl": "https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment",
       "enabledForApps": true,
       "method": "GET",
       "name": "List reactions for a commit comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "Returns a single [reaction type](/v3/reactions/#reaction-types). Omit this parameter to list all reactions to a commit comment.",
+        {
           "name": "content",
+          "type": "string",
+          "description": "Returns a single [reaction type](https://developer.github.com/v3/reactions/#reaction-types). Omit this parameter to list all reactions to a commit comment.",
           "required": false,
-          "type": "string"
+          "enum": [
+            "+1",
+            "-1",
+            "laugh",
+            "confused",
+            "heart",
+            "hooray"
+          ],
+          "location": "query"
         },
-        "4": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "5": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/comments/:id/reactions"
     },
     "getForIssue": {
-      "description": "List the reactions to an [issue](/v3/issues/).",
+      "description": "List the reactions to an [issue](https://developer.github.com/v3/issues/).",
       "documentationUrl": "https://developer.github.com/v3/reactions/#list-reactions-for-an-issue",
       "enabledForApps": true,
       "method": "GET",
       "name": "List reactions for an issue",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "number",
+          "type": "integer",
           "required": true,
-          "type": "integer"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "Returns a single [reaction type](/v3/reactions/#reaction-types). Omit this parameter to list all reactions to an issue.",
+        {
           "name": "content",
+          "type": "string",
+          "description": "Returns a single [reaction type](https://developer.github.com/v3/reactions/#reaction-types). Omit this parameter to list all reactions to an issue.",
           "required": false,
-          "type": "string"
+          "enum": [
+            "+1",
+            "-1",
+            "laugh",
+            "confused",
+            "heart",
+            "hooray"
+          ],
+          "location": "query"
         },
-        "4": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "5": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/:number/reactions"
     },
     "getForIssueComment": {
-      "description": "List the reactions to an [issue comment](/v3/issues/comments/).",
+      "description": "List the reactions to an [issue comment](https://developer.github.com/v3/issues/comments/).",
       "documentationUrl": "https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment",
       "enabledForApps": true,
       "method": "GET",
       "name": "List reactions for an issue comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "Returns a single [reaction type](/v3/reactions/#reaction-types). Omit this parameter to list all reactions to an issue comment.",
+        {
           "name": "content",
+          "type": "string",
+          "description": "Returns a single [reaction type](https://developer.github.com/v3/reactions/#reaction-types). Omit this parameter to list all reactions to an issue comment.",
           "required": false,
-          "type": "string"
+          "enum": [
+            "+1",
+            "-1",
+            "laugh",
+            "confused",
+            "heart",
+            "hooray"
+          ],
+          "location": "query"
         },
-        "4": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "5": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/issues/comments/:id/reactions"
     },
     "getForPullRequestReviewComment": {
-      "description": "List the reactions to a [pull request review comment](/v3/pulls/comments/).",
+      "description": "List the reactions to a [pull request review comment](https://developer.github.com/v3/pulls/comments/).",
       "documentationUrl": "https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment",
       "enabledForApps": true,
       "method": "GET",
       "name": "List reactions for a pull request review comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "Returns a single [reaction type](/v3/reactions/#reaction-types). Omit this parameter to list all reactions to a pull request review comment.",
+        {
           "name": "content",
+          "type": "string",
+          "description": "Returns a single [reaction type](https://developer.github.com/v3/reactions/#reaction-types). Omit this parameter to list all reactions to a pull request review comment.",
           "required": false,
-          "type": "string"
+          "enum": [
+            "+1",
+            "-1",
+            "laugh",
+            "confused",
+            "heart",
+            "hooray"
+          ],
+          "location": "query"
         },
-        "4": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "5": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pulls/comments/:id/reactions"
     }
   },
   "repos": {
     "addCollaborator": {
-      "description": "Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](/v3/#http-verbs).\"\n\nThe invitee will receive a notification that they have been invited to the repository, which they must accept or decline. They may do this via the notifications page, the email they receive, or by using the [repository invitations API endpoints](/v3/repos/invitations/).\n\n**Rate limits**\n\nTo prevent abuse, you are limited to sending 50 invitations to a repository per 24 hour period. Note there is no limit if you are inviting organization members to an organization repository.",
+      "description": "Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](https://developer.github.com/v3/#http-verbs).\"\n\nThe invitee will receive a notification that they have been invited to the repository, which they must accept or decline. They may do this via the notifications page, the email they receive, or by using the [repository invitations API endpoints](https://developer.github.com/v3/repos/invitations/).\n\n**Rate limits**\n\nTo prevent abuse, you are limited to sending 50 invitations to a repository per 24 hour period. Note there is no limit if you are inviting organization members to an organization repository.",
       "documentationUrl": "https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator",
       "enabledForApps": true,
       "method": "PUT",
       "name": "Add user as a collaborator",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "username",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "3": {
-          "default": "push",
+        {
+          "name": "username",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "permission",
+          "type": "string",
           "description": "The permission to grant the collaborator. **Only valid on organization-owned repositories.** Can be one of:  \n\\* `pull` \\- can pull, but not push to or administer this repository.  \n\\* `push` \\- can pull and push, but not administer this repository.  \n\\* `admin` \\- can pull, push and administer this repository.",
+          "default": "push",
+          "required": false,
           "enum": [
             "pull",
             "push",
             "admin"
           ],
-          "name": "permission",
-          "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/collaborators/:username"
     },
     "addDeployKey": {
@@ -8565,38 +9564,43 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Add a new deploy key",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "A name for the key.",
+        {
           "name": "title",
+          "type": "string",
+          "description": "A name for the key.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "The contents of the key.",
+        {
           "name": "key",
-          "required": false,
-          "type": "string"
+          "type": "string",
+          "description": "The contents of the key.",
+          "required": true,
+          "location": "body"
         },
-        "4": {
-          "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.",
+        {
           "name": "read_only",
+          "type": "boolean",
+          "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.",
           "required": false,
-          "type": "boolean"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/keys"
     },
     "addProtectedBranchAdminEnforcement": {
@@ -8605,26 +9609,29 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Add admin enforcement of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins"
     },
     "addProtectedBranchRequiredStatusChecksContexts": {
@@ -8633,82 +9640,91 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Add required status checks contexts of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
     },
     "addProtectedBranchTeamRestrictions": {
-      "description": "Pass the list of team `slug`s with push access.\n\n**Note**: The list of users and teams in total is limited to 100 items.",
+      "description": "Grants the specified teams push access for this branch. If you pass the `hellcat-preview` media type, you can also give push access to child teams.\n\n| Type    | Description                                                                                                                         |\n| ------- | ----------------------------------------------------------------------------------------------------------------------------------- |\n| `array` | The teams that can have push access. Use the team's `slug`. **Note**: The list of users and teams in total is limited to 100 items. |",
       "documentationUrl": "https://developer.github.com/v3/repos/branches/#add-team-restrictions-of-protected-branch",
       "enabledForApps": true,
       "method": "POST",
       "name": "Add team restrictions of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
     },
     "addProtectedBranchUserRestrictions": {
-      "description": "Pass the list of user `login`s with push access.\n\n**Note**: The list of users and teams in total is limited to 100 items.",
+      "description": "Grants the specified people push access for this branch.\n\n| Type    | Description                                                                                                            |\n| ------- | ---------------------------------------------------------------------------------------------------------------------- |\n| `array` | Usernames for people who can have push access. **Note**: The list of users and teams in total is limited to 100 items. |",
       "documentationUrl": "https://developer.github.com/v3/repos/branches/#add-user-restrictions-of-protected-branch",
       "enabledForApps": true,
       "method": "POST",
       "name": "Add user restrictions of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
     },
     "checkCollaborator": {
@@ -8717,162 +9733,183 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Check if a user is a collaborator",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/collaborators/:username"
     },
     "compareCommits": {
-      "description": "Both `:base` and `:head` must be branch names in `:repo`. To compare branches across other repositories in the same network as `:repo`, use the format `<USERNAME>:branch`. For example:\n\n```\nGET /repos/:owner/:repo/compare/hubot:branchname...octocat:branchname\n```\n\nThe response from the API is equivalent to running the `git log base..head` command; however, commits are returned in reverse chronological order.\n\nPass the appropriate [media type](/v3/media/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.\n\n**Working with large comparisons**\n\nThe response will include a comparison of up to 250 commits. If you are working with a larger commit range, you can use the [Commit List API](/v3/repos/commits/#list-commits-on-a-repository) to enumerate all commits in the range.\n\nFor comparisons with extremely large diffs, you may receive an error response indicating that the diff took too long to generate. You can typically resolve this error by using a smaller commit range.",
+      "description": "Both `:base` and `:head` must be branch names in `:repo`. To compare branches across other repositories in the same network as `:repo`, use the format `<USERNAME>:branch`. For example:\n\n```\nGET /repos/:owner/:repo/compare/hubot:branchname...octocat:branchname\n```\n\nThe response from the API is equivalent to running the `git log base..head` command; however, commits are returned in reverse chronological order.\n\nPass the appropriate [media type](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.\n\n**Working with large comparisons**\n\nThe response will include a comparison of up to 250 commits. If you are working with a larger commit range, you can use the [Commit List API](https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository) to enumerate all commits in the range.\n\nFor comparisons with extremely large diffs, you may receive an error response indicating that the diff took too long to generate. You can typically resolve this error by using a smaller commit range.",
       "documentationUrl": "https://developer.github.com/v3/repos/commits/#compare-two-commits",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "Compare two commits",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "base",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "3": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "head",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/compare/:base...:head"
     },
     "create": {
-      "description": "**Note**: There are two endpoints for creating a repository: one to create a repository on a user account, and one to create a repository in an organization. The organization endpoint is fully enabled for [GitHub Apps](/v3/apps/available-endpoints/), whereas the user endpoint is enabled only for [user-to-server requests](/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#user-to-server-requests).\n\n**OAuth scope requirements**\n\nWhen using [OAuth](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/), authorizations must include:\n\n*   `public_repo` scope or `repo` scope to create a public repository\n*   `repo` scope to create a private repository",
+      "description": "**Note**: There are two endpoints for creating a repository: one to create a repository on a user account, and one to create a repository in an organization. The organization endpoint is fully enabled for [GitHub Apps](https://developer.github.com/v3/apps/available-endpoints/), whereas the user endpoint is enabled only for [user-to-server requests](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#user-to-server-requests).\n\n**OAuth scope requirements**\n\nWhen using [OAuth](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/), authorizations must include:\n\n*   `public_repo` scope or `repo` scope to create a public repository\n*   `repo` scope to create a private repository",
       "documentationUrl": "https://developer.github.com/v3/repos/#create",
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a new repository for the authenticated user",
-      "params": {
-        "0": {
-          "description": "The name of the repository.",
+      "params": [
+        {
           "name": "name",
+          "type": "string",
+          "description": "The name of the repository.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "1": {
-          "description": "A short description of the repository.",
+        {
           "name": "description",
+          "type": "string",
+          "description": "A short description of the repository.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "2": {
-          "description": "A URL with more information about the repository.",
+        {
           "name": "homepage",
+          "type": "string",
+          "description": "A URL with more information about the repository.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "default": false,
-          "description": "Either `true` to create a private repository or `false` to create a public one. Creating private repositories requires a paid GitHub account.",
+        {
           "name": "private",
-          "required": false,
-          "type": "boolean"
-        },
-        "4": {
-          "default": true,
-          "description": "Either `true` to enable issues for this repository or `false` to disable them.",
-          "name": "has_issues",
-          "required": false,
-          "type": "boolean"
-        },
-        "5": {
-          "default": true,
-          "description": "Either `true` to enable projects for this repository or `false` to disable them. **Note:** If you're creating a repository in an organization that has disabled repository projects, the default is `false`, and if you pass `true`, the API returns an error.",
-          "name": "has_projects",
-          "required": false,
-          "type": "boolean"
-        },
-        "6": {
-          "default": true,
-          "description": "Either `true` to enable the wiki for this repository or `false` to disable it.",
-          "name": "has_wiki",
-          "required": false,
-          "type": "boolean"
-        },
-        "7": {
-          "description": "The id of the team that will be granted access to this repository. This is only valid when creating a repository in an organization.",
-          "name": "team_id",
-          "required": false,
-          "type": "integer"
-        },
-        "8": {
+          "type": "boolean",
+          "description": "Either `true` to create a private repository or `false` to create a public one. Creating private repositories requires a paid GitHub account.",
           "default": false,
-          "description": "Pass `true` to create an initial commit with empty README.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "has_issues",
+          "type": "boolean",
+          "description": "Either `true` to enable issues for this repository or `false` to disable them.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "has_projects",
+          "type": "boolean",
+          "description": "Either `true` to enable projects for this repository or `false` to disable them. **Note:** If you're creating a repository in an organization that has disabled repository projects, the default is `false`, and if you pass `true`, the API returns an error.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "has_wiki",
+          "type": "boolean",
+          "description": "Either `true` to enable the wiki for this repository or `false` to disable it.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "team_id",
+          "type": "integer",
+          "description": "The id of the team that will be granted access to this repository. This is only valid when creating a repository in an organization.",
+          "required": false,
+          "location": "body"
+        },
+        {
           "name": "auto_init",
+          "type": "boolean",
+          "description": "Pass `true` to create an initial commit with empty README.",
+          "default": false,
           "required": false,
-          "type": "boolean"
+          "location": "body"
         },
-        "9": {
-          "description": "Desired language or platform [.gitignore template](https://github.com/github/gitignore) to apply. Use the name of the template without the extension. For example, \"Haskell\".",
+        {
           "name": "gitignore_template",
+          "type": "string",
+          "description": "Desired language or platform [.gitignore template](https://github.com/github/gitignore) to apply. Use the name of the template without the extension. For example, \"Haskell\".",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "10": {
-          "description": "Choose an [open source license template](https://choosealicense.com/) that best suits your needs, and then use the [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type) as the `license_template` string. For example, \"mit\" or \"mpl-2.0\".",
+        {
           "name": "license_template",
+          "type": "string",
+          "description": "Choose an [open source license template](https://choosealicense.com/) that best suits your needs, and then use the [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type) as the `license_template` string. For example, \"mit\" or \"mpl-2.0\".",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "11": {
-          "default": true,
-          "description": "Either `true` to allow squash-merging pull requests, or `false` to prevent squash-merging.",
+        {
           "name": "allow_squash_merge",
-          "required": false,
-          "type": "boolean"
-        },
-        "12": {
+          "type": "boolean",
+          "description": "Either `true` to allow squash-merging pull requests, or `false` to prevent squash-merging.",
           "default": true,
-          "description": "Either `true` to allow merging pull requests with a merge commit, or `false` to prevent merging pull requests with merge commits.",
+          "required": false,
+          "location": "body"
+        },
+        {
           "name": "allow_merge_commit",
-          "required": false,
-          "type": "boolean"
-        },
-        "13": {
+          "type": "boolean",
+          "description": "Either `true` to allow merging pull requests with a merge commit, or `false` to prevent merging pull requests with merge commits.",
           "default": true,
-          "description": "Either `true` to allow rebase-merging pull requests, or `false` to prevent rebase-merging.",
-          "name": "allow_rebase_merge",
           "required": false,
-          "type": "boolean"
+          "location": "body"
+        },
+        {
+          "name": "allow_rebase_merge",
+          "type": "boolean",
+          "description": "Either `true` to allow rebase-merging pull requests, or `false` to prevent rebase-merging.",
+          "default": true,
+          "required": false,
+          "location": "body"
         }
-      },
+      ],
       "path": "/user/repos"
     },
     "createCommitComment": {
@@ -8881,133 +9918,151 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a commit comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "sha",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "The contents of the comment.",
+        {
           "name": "body",
+          "type": "string",
+          "description": "The contents of the comment.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "Relative path of the file to comment on.",
+        {
           "name": "path",
+          "type": "string",
+          "description": "Relative path of the file to comment on.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "Line index in the diff to comment on.",
+        {
           "name": "position",
+          "type": "integer",
+          "description": "Line index in the diff to comment on.",
           "required": false,
-          "type": "integer"
+          "location": "body"
         },
-        "6": {
-          "description": "**Deprecated**. Use **position** parameter instead. Line number in the file to comment on.",
+        {
           "name": "line",
+          "type": "integer",
+          "description": "**Deprecated**. Use **position** parameter instead. Line number in the file to comment on.",
           "required": false,
-          "type": "integer"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/commits/:sha/comments"
     },
     "createDeployment": {
-      "description": "Deployments offer a few configurable parameters with sane defaults.\n\nThe `ref` parameter can be any named branch, tag, or SHA. At GitHub we often deploy branches and verify them before we merge a pull request.\n\nThe `environment` parameter allows deployments to be issued to different runtime environments. Teams often have multiple environments for verifying their applications, such as `production`, `staging`, and `qa`. This allows for easy tracking of which environments had deployments requested. The default environment is `production`.\n\nThe `auto_merge` parameter is used to ensure that the requested ref is not behind the repository's default branch. If the ref _is_ behind the default branch for the repository, we will attempt to merge it for you. If the merge succeeds, the API will return a successful merge commit. If merge conflicts prevent the merge from succeeding, the API will return a failure response.\n\nBy default, [commit statuses](/v3/repos/statuses) for every submitted context must be in a `success` state. The `required_contexts` parameter allows you to specify a subset of contexts that must be `success`, or to specify contexts that have not yet been submitted. You are not required to use commit statuses to deploy. If you do not require any contexts or create any commit statuses, the deployment will always succeed.\n\nThe `payload` parameter is available for any extra information that a deployment system might need. It is a JSON text field that will be passed on when a deployment event is dispatched.\n\nThe `task` parameter is used by the deployment system to allow different execution paths. In the web world this might be `deploy:migrations` to run schema changes on the system. In the compiled world this could be a flag to compile an application with debugging enabled.\n\nUsers with `repo` or `repo_deployment` scopes can create a deployment for a given ref:\n\nA simple example putting the user and room into the payload to notify back to chat networks.\n\nA more advanced example specifying required commit statuses and bypassing auto-merging.\n\nThis error happens when the `auto_merge` option is enabled and when the default branch (in this case `master`), can't be merged into the branch that's being deployed (in this case `topic-branch`), due to merge conflicts.\n\nThis error happens when the `required_contexts` parameter indicates that one or more contexts need to have a `success` status for the commit to be deployed, but one or more of the required contexts do not have a state of `success`.",
+      "description": "Deployments offer a few configurable parameters with sane defaults.\n\nThe `ref` parameter can be any named branch, tag, or SHA. At GitHub we often deploy branches and verify them before we merge a pull request.\n\nThe `environment` parameter allows deployments to be issued to different runtime environments. Teams often have multiple environments for verifying their applications, such as `production`, `staging`, and `qa`. This allows for easy tracking of which environments had deployments requested. The default environment is `production`.\n\nThe `auto_merge` parameter is used to ensure that the requested ref is not behind the repository's default branch. If the ref _is_ behind the default branch for the repository, we will attempt to merge it for you. If the merge succeeds, the API will return a successful merge commit. If merge conflicts prevent the merge from succeeding, the API will return a failure response.\n\nBy default, [commit statuses](https://developer.github.com/v3/repos/statuses) for every submitted context must be in a `success` state. The `required_contexts` parameter allows you to specify a subset of contexts that must be `success`, or to specify contexts that have not yet been submitted. You are not required to use commit statuses to deploy. If you do not require any contexts or create any commit statuses, the deployment will always succeed.\n\nThe `payload` parameter is available for any extra information that a deployment system might need. It is a JSON text field that will be passed on when a deployment event is dispatched.\n\nThe `task` parameter is used by the deployment system to allow different execution paths. In the web world this might be `deploy:migrations` to run schema changes on the system. In the compiled world this could be a flag to compile an application with debugging enabled.\n\nUsers with `repo` or `repo_deployment` scopes can create a deployment for a given ref:\n\nA simple example putting the user and room into the payload to notify back to chat networks.\n\nA more advanced example specifying required commit statuses and bypassing auto-merging.\n\nThis error happens when the `auto_merge` option is enabled and when the default branch (in this case `master`), can't be merged into the branch that's being deployed (in this case `topic-branch`), due to merge conflicts.\n\nThis error happens when the `required_contexts` parameter indicates that one or more contexts need to have a `success` status for the commit to be deployed, but one or more of the required contexts do not have a state of `success`.",
       "documentationUrl": "https://developer.github.com/v3/repos/deployments/#create-a-deployment",
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a deployment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The ref to deploy. This can be a branch, tag, or SHA.",
+        {
           "name": "ref",
+          "type": "string",
+          "description": "The ref to deploy. This can be a branch, tag, or SHA.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "default": "deploy",
-          "description": "Specifies a task to execute (e.g., `deploy` or `deploy:migrations`).",
+        {
           "name": "task",
+          "type": "string",
+          "description": "Specifies a task to execute (e.g., `deploy` or `deploy:migrations`).",
+          "default": "deploy",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "default": true,
-          "description": "Attempts to automatically merge the default branch into the requested ref, if it is behind the default branch.",
+        {
           "name": "auto_merge",
+          "type": "boolean",
+          "description": "Attempts to automatically merge the default branch into the requested ref, if it is behind the default branch.",
+          "default": true,
           "required": false,
-          "type": "boolean"
+          "location": "body"
         },
-        "5": {
-          "description": "The status contexts to verify against commit status checks. If this parameter is omitted, then all unique contexts will be verified before a deployment is created. To bypass checking entirely pass an empty array. Defaults to all unique contexts.",
+        {
           "name": "required_contexts",
+          "type": "string[]",
+          "description": "The status contexts to verify against commit status checks. If this parameter is omitted, then all unique contexts will be verified before a deployment is created. To bypass checking entirely pass an empty array. Defaults to all unique contexts.",
           "required": false,
-          "type": "array"
+          "location": "body"
         },
-        "6": {
-          "default": "\"\"",
-          "description": "JSON payload with extra information about the deployment.",
+        {
           "name": "payload",
-          "required": false,
-          "type": "string"
-        },
-        "7": {
-          "default": "production",
-          "description": "Name for the target deployment environment (e.g., `production`, `staging`, `qa`).",
-          "name": "environment",
-          "required": false,
-          "type": "string"
-        },
-        "8": {
+          "type": "string",
+          "description": "JSON payload with extra information about the deployment.",
           "default": "\"\"",
-          "description": "Short description of the deployment.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "environment",
+          "type": "string",
+          "description": "Name for the target deployment environment (e.g., `production`, `staging`, `qa`).",
+          "default": "production",
+          "required": false,
+          "location": "body"
+        },
+        {
           "name": "description",
+          "type": "string",
+          "description": "Short description of the deployment.",
+          "default": "\"\"",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "9": {
-          "default": false,
-          "description": "Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future. **This parameter requires a custom media type to be specified. Please see more in the alert below.**",
+        {
           "name": "transient_environment",
+          "type": "boolean",
+          "description": "Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future. **This parameter requires a custom media type to be specified. Please see more in the alert below.**",
+          "default": false,
           "required": false,
-          "type": "boolean"
+          "location": "body"
         },
-        "10": {
-          "default": "`true` when `environment` is `production` and `false` otherwise",
-          "description": "Specifies if the given environment is one that end-users directly interact with. **This parameter requires a custom media type to be specified. Please see more in the alert below.**",
+        {
           "name": "production_environment",
+          "type": "boolean",
+          "description": "Specifies if the given environment is one that end-users directly interact with. **This parameter requires a custom media type to be specified. Please see more in the alert below.**",
+          "default": "`true` when `environment` is `production` and `false` otherwise",
           "required": false,
-          "type": "boolean"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/deployments"
     },
     "createDeploymentStatus": {
@@ -9016,27 +10071,33 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a deployment status",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "id",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "3": {
+        {
+          "name": "id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "state",
+          "type": "string",
           "description": "The state of the status. Can be one of `error`, `failure`, `inactive`, `pending`, or `success`. **The `inactive` state requires a custom media type to be specified. Please see more in the alert below.**",
+          "required": true,
           "enum": [
             "error",
             "failure",
@@ -9044,46 +10105,49 @@
             "pending",
             "success"
           ],
-          "name": "state",
-          "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "default": "\"\"",
-          "description": "The target URL to associate with this status. This URL should contain output to keep the user updated while the task is running or serve as historical information for what happened in the deployment.",
+        {
           "name": "target_url",
-          "required": false,
-          "type": "string"
-        },
-        "5": {
+          "type": "string",
+          "description": "The target URL to associate with this status. This URL should contain output to keep the user updated while the task is running or serve as historical information for what happened in the deployment.",
           "default": "\"\"",
-          "description": "This is functionally equivalent to `target_url`. We will continue accept `target_url` to support legacy uses, but we recommend modifying this to the new name to avoid confusion. **This parameter requires a custom media type to be specified. Please see more in the alert below.**",
+          "required": false,
+          "location": "body"
+        },
+        {
           "name": "log_url",
-          "required": false,
-          "type": "string"
-        },
-        "6": {
+          "type": "string",
+          "description": "This is functionally equivalent to `target_url`. We will continue accept `target_url` to support legacy uses, but we recommend modifying this to the new name to avoid confusion. **This parameter requires a custom media type to be specified. Please see more in the alert below.**",
           "default": "\"\"",
-          "description": "A short description of the status. Maximum length of 140 characters.",
+          "required": false,
+          "location": "body"
+        },
+        {
           "name": "description",
-          "required": false,
-          "type": "string"
-        },
-        "7": {
+          "type": "string",
+          "description": "A short description of the status. Maximum length of 140 characters.",
           "default": "\"\"",
-          "description": "Sets the URL for accessing your environment. **This parameter requires a custom media type to be specified. Please see more in the alert below.**",
-          "name": "environment_url",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "8": {
-          "default": true,
-          "description": "Adds a new `inactive` status to all non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment. **This parameter requires a custom media type to be specified. Please see more in the alert below.**",
-          "name": "auto_inactive",
+        {
+          "name": "environment_url",
+          "type": "string",
+          "description": "Sets the URL for accessing your environment. **This parameter requires a custom media type to be specified. Please see more in the alert below.**",
+          "default": "\"\"",
           "required": false,
-          "type": "boolean"
+          "location": "body"
+        },
+        {
+          "name": "auto_inactive",
+          "type": "boolean",
+          "description": "Adds a new `inactive` status to all non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment. **This parameter requires a custom media type to be specified. Please see more in the alert below.**",
+          "default": true,
+          "required": false,
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/deployments/:id/statuses"
     },
     "createFile": {
@@ -9092,163 +10156,186 @@
       "enabledForApps": true,
       "method": "PUT",
       "name": "Create a file",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The content path.",
+        {
           "name": "path",
+          "type": "string",
+          "description": "The content path.",
           "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "3": {
-          "description": "The commit message.",
+        {
           "name": "message",
+          "type": "string",
+          "description": "The commit message.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The new file content, Base64 encoded.",
+        {
           "name": "content",
+          "type": "string",
+          "description": "The new file content, Base64 encoded.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "default": "the repository’s default branch (usually `master`)",
-          "description": "The branch name.",
+        {
           "name": "branch",
+          "type": "string",
+          "description": "The branch name.",
+          "default": "the repository’s default branch (usually `master`)",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "description": "object containing information about the committer.",
+        {
           "name": "committer",
-          "type": "object"
+          "type": "object",
+          "description": "object containing information about the committer.",
+          "location": "body"
         },
-        "7": {
-          "description": "object containing information about the author.",
+        {
           "name": "author",
-          "type": "object"
+          "type": "object",
+          "description": "object containing information about the author.",
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/contents/:path"
     },
     "createForOrg": {
-      "description": "**Note**: There are two endpoints for creating a repository: one to create a repository on a user account, and one to create a repository in an organization. The organization endpoint is fully enabled for [GitHub Apps](/v3/apps/available-endpoints/), whereas the user endpoint is enabled only for [user-to-server requests](/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#user-to-server-requests).\n\n**OAuth scope requirements**\n\nWhen using [OAuth](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/), authorizations must include:\n\n*   `public_repo` scope or `repo` scope to create a public repository\n*   `repo` scope to create a private repository",
+      "description": "**Note**: There are two endpoints for creating a repository: one to create a repository on a user account, and one to create a repository in an organization. The organization endpoint is fully enabled for [GitHub Apps](https://developer.github.com/v3/apps/available-endpoints/), whereas the user endpoint is enabled only for [user-to-server requests](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#user-to-server-requests).\n\n**OAuth scope requirements**\n\nWhen using [OAuth](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/), authorizations must include:\n\n*   `public_repo` scope or `repo` scope to create a public repository\n*   `repo` scope to create a private repository",
       "documentationUrl": "https://developer.github.com/v3/repos/#create",
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a new repository in this organization",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "description": "The name of the repository.",
+        {
           "name": "name",
+          "type": "string",
+          "description": "The name of the repository.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "2": {
-          "description": "A short description of the repository.",
+        {
           "name": "description",
+          "type": "string",
+          "description": "A short description of the repository.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "A URL with more information about the repository.",
+        {
           "name": "homepage",
+          "type": "string",
+          "description": "A URL with more information about the repository.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "default": false,
-          "description": "Either `true` to create a private repository or `false` to create a public one. Creating private repositories requires a paid GitHub account.",
+        {
           "name": "private",
-          "required": false,
-          "type": "boolean"
-        },
-        "5": {
-          "default": true,
-          "description": "Either `true` to enable issues for this repository or `false` to disable them.",
-          "name": "has_issues",
-          "required": false,
-          "type": "boolean"
-        },
-        "6": {
-          "default": true,
-          "description": "Either `true` to enable projects for this repository or `false` to disable them. **Note:** If you're creating a repository in an organization that has disabled repository projects, the default is `false`, and if you pass `true`, the API returns an error.",
-          "name": "has_projects",
-          "required": false,
-          "type": "boolean"
-        },
-        "7": {
-          "default": true,
-          "description": "Either `true` to enable the wiki for this repository or `false` to disable it.",
-          "name": "has_wiki",
-          "required": false,
-          "type": "boolean"
-        },
-        "8": {
-          "description": "The id of the team that will be granted access to this repository. This is only valid when creating a repository in an organization.",
-          "name": "team_id",
-          "required": false,
-          "type": "integer"
-        },
-        "9": {
+          "type": "boolean",
+          "description": "Either `true` to create a private repository or `false` to create a public one. Creating private repositories requires a paid GitHub account.",
           "default": false,
-          "description": "Pass `true` to create an initial commit with empty README.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "has_issues",
+          "type": "boolean",
+          "description": "Either `true` to enable issues for this repository or `false` to disable them.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "has_projects",
+          "type": "boolean",
+          "description": "Either `true` to enable projects for this repository or `false` to disable them. **Note:** If you're creating a repository in an organization that has disabled repository projects, the default is `false`, and if you pass `true`, the API returns an error.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "has_wiki",
+          "type": "boolean",
+          "description": "Either `true` to enable the wiki for this repository or `false` to disable it.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "team_id",
+          "type": "integer",
+          "description": "The id of the team that will be granted access to this repository. This is only valid when creating a repository in an organization.",
+          "required": false,
+          "location": "body"
+        },
+        {
           "name": "auto_init",
+          "type": "boolean",
+          "description": "Pass `true` to create an initial commit with empty README.",
+          "default": false,
           "required": false,
-          "type": "boolean"
+          "location": "body"
         },
-        "10": {
-          "description": "Desired language or platform [.gitignore template](https://github.com/github/gitignore) to apply. Use the name of the template without the extension. For example, \"Haskell\".",
+        {
           "name": "gitignore_template",
+          "type": "string",
+          "description": "Desired language or platform [.gitignore template](https://github.com/github/gitignore) to apply. Use the name of the template without the extension. For example, \"Haskell\".",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "11": {
-          "description": "Choose an [open source license template](https://choosealicense.com/) that best suits your needs, and then use the [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type) as the `license_template` string. For example, \"mit\" or \"mpl-2.0\".",
+        {
           "name": "license_template",
+          "type": "string",
+          "description": "Choose an [open source license template](https://choosealicense.com/) that best suits your needs, and then use the [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type) as the `license_template` string. For example, \"mit\" or \"mpl-2.0\".",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "12": {
-          "default": true,
-          "description": "Either `true` to allow squash-merging pull requests, or `false` to prevent squash-merging.",
+        {
           "name": "allow_squash_merge",
-          "required": false,
-          "type": "boolean"
-        },
-        "13": {
+          "type": "boolean",
+          "description": "Either `true` to allow squash-merging pull requests, or `false` to prevent squash-merging.",
           "default": true,
-          "description": "Either `true` to allow merging pull requests with a merge commit, or `false` to prevent merging pull requests with merge commits.",
+          "required": false,
+          "location": "body"
+        },
+        {
           "name": "allow_merge_commit",
-          "required": false,
-          "type": "boolean"
-        },
-        "14": {
+          "type": "boolean",
+          "description": "Either `true` to allow merging pull requests with a merge commit, or `false` to prevent merging pull requests with merge commits.",
           "default": true,
-          "description": "Either `true` to allow rebase-merging pull requests, or `false` to prevent rebase-merging.",
-          "name": "allow_rebase_merge",
           "required": false,
-          "type": "boolean"
+          "location": "body"
+        },
+        {
+          "name": "allow_rebase_merge",
+          "type": "boolean",
+          "description": "Either `true` to allow rebase-merging pull requests, or `false` to prevent rebase-merging.",
+          "default": true,
+          "required": false,
+          "location": "body"
         }
-      },
+      ],
       "path": "/orgs/:org/repos"
     },
     "createHook": {
@@ -9257,70 +10344,80 @@
       "enabledForApps": false,
       "method": "POST",
       "name": "Create a hook",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "Must be passed as \"web\".",
+        {
           "name": "name",
+          "type": "string",
+          "description": "Must be passed as \"web\".",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+        {
           "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
           "required": true,
-          "type": "object"
+          "location": "body"
         },
-        "4": {
-          "description": "The URL to which the payloads will be delivered.",
+        {
           "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        {
           "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/webhooks/#delivery-headers) header.",
+        {
           "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "7": {
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        {
           "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "8": {
-          "default": "[\"push\"]",
-          "description": "Determines what [events](/v3/activity/events/types/) the hook is triggered for.",
+        {
           "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for.",
+          "default": "[\"push\"]",
           "required": false,
-          "type": "array"
+          "location": "body"
         },
-        "9": {
-          "default": true,
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        {
           "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
           "required": false,
-          "type": "boolean"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/hooks"
     },
     "createRelease": {
@@ -9329,118 +10426,133 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a release",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The name of the tag.",
+        {
           "name": "tag_name",
+          "type": "string",
+          "description": "The name of the tag.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "default": "the repository's default branch (usually `master`).",
-          "description": "Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists.",
+        {
           "name": "target_commitish",
+          "type": "string",
+          "description": "Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists.",
+          "default": "the repository's default branch (usually `master`).",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The name of the release.",
+        {
           "name": "name",
+          "type": "string",
+          "description": "The name of the release.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "Text describing the contents of the tag.",
+        {
           "name": "body",
+          "type": "string",
+          "description": "Text describing the contents of the tag.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "default": false,
-          "description": "`true` to create a draft (unpublished) release, `false` to create a published one.",
+        {
           "name": "draft",
-          "required": false,
-          "type": "boolean"
-        },
-        "7": {
+          "type": "boolean",
+          "description": "`true` to create a draft (unpublished) release, `false` to create a published one.",
           "default": false,
-          "description": "`true` to identify the release as a prerelease. `false` to identify the release as a full release.",
-          "name": "prerelease",
           "required": false,
-          "type": "boolean"
+          "location": "body"
+        },
+        {
+          "name": "prerelease",
+          "type": "boolean",
+          "description": "`true` to identify the release as a prerelease. `false` to identify the release as a full release.",
+          "default": false,
+          "required": false,
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/releases"
     },
     "createStatus": {
-      "description": "Users with push access can create commit statuses for a given ref:\n\nNote: there is a limit of 1000 statuses per `sha` and `context` within a repository. Attempts to create more than 1000 statuses will result in a validation error.",
+      "description": "Users with push access in a repository can create commit statuses for a given SHA.\n\nNote: there is a limit of 1000 statuses per `sha` and `context` within a repository. Attempts to create more than 1000 statuses will result in a validation error.",
       "documentationUrl": "https://developer.github.com/v3/repos/statuses/#create-a-status",
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a status",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "sha",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "3": {
+        {
+          "name": "sha",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "state",
+          "type": "string",
           "description": "The state of the status. Can be one of `error`, `failure`, `pending`, or `success`.",
+          "required": true,
           "enum": [
             "error",
             "failure",
             "pending",
             "success"
           ],
-          "name": "state",
-          "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The target URL to associate with this status. This URL will be linked from the GitHub UI to allow users to easily see the source of the status.  \nFor example, if your continuous integration system is posting build status, you would want to provide the deep link for the build output for this specific SHA:  \n`http://ci.example.com/user/repo/build/sha`",
+        {
           "name": "target_url",
+          "type": "string",
+          "description": "The target URL to associate with this status. This URL will be linked from the GitHub UI to allow users to easily see the source of the status.  \nFor example, if your continuous integration system is posting build status, you would want to provide the deep link for the build output for this specific SHA:  \n`http://ci.example.com/user/repo/build/sha`",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "A short description of the status.",
+        {
           "name": "description",
+          "type": "string",
+          "description": "A short description of the status.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "default": "default",
-          "description": "A string label to differentiate this status from the status of other systems.",
+        {
           "name": "context",
+          "type": "string",
+          "description": "A string label to differentiate this status from the status of other systems.",
+          "default": "default",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/statuses/:sha"
     },
     "delete": {
@@ -9449,20 +10561,22 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Delete a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo"
     },
     "deleteAsset": {
@@ -9471,26 +10585,29 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Delete a release asset",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/releases/assets/:id"
     },
     "deleteCommitComment": {
@@ -9499,26 +10616,29 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Delete a commit comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/comments/:id"
     },
     "deleteDeployKey": {
@@ -9527,26 +10647,29 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Remove a deploy key",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/keys/:id"
     },
     "deleteDownload": {
@@ -9555,26 +10678,29 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Delete a download",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/downloads/:id"
     },
     "deleteFile": {
@@ -9583,55 +10709,63 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Delete a file",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The content path.",
+        {
           "name": "path",
+          "type": "string",
+          "description": "The content path.",
           "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "3": {
-          "description": "The commit message.",
+        {
           "name": "message",
+          "type": "string",
+          "description": "The commit message.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The blob SHA of the file being replaced.",
+        {
           "name": "sha",
+          "type": "string",
+          "description": "The blob SHA of the file being replaced.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "default": "the repository’s default branch (usually `master`)",
-          "description": "The branch name.",
+        {
           "name": "branch",
+          "type": "string",
+          "description": "The branch name.",
+          "default": "the repository’s default branch (usually `master`)",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "description": "object containing information about the committer.",
+        {
           "name": "committer",
-          "type": "object"
+          "type": "object",
+          "description": "object containing information about the committer.",
+          "location": "body"
         },
-        "7": {
-          "description": "object containing information about the author.",
+        {
           "name": "author",
-          "type": "object"
+          "type": "object",
+          "description": "object containing information about the author.",
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/contents/:path"
     },
     "deleteHook": {
@@ -9640,54 +10774,60 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Delete a hook",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/hooks/:id"
     },
     "deleteInvite": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/repos/invitations/#delete-a-repository-invitation",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "DELETE",
       "name": "Delete a repository invitation",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "invitation_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/invitations/:invitation_id"
     },
     "deleteRelease": {
@@ -9696,26 +10836,29 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Delete a release",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/releases/:id"
     },
     "edit": {
@@ -9724,100 +10867,114 @@
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Edit",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The name of the repository.",
+        {
           "name": "name",
+          "type": "string",
+          "description": "The name of the repository.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "A short description of the repository.",
+        {
           "name": "description",
+          "type": "string",
+          "description": "A short description of the repository.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "A URL with more information about the repository.",
+        {
           "name": "homepage",
+          "type": "string",
+          "description": "A URL with more information about the repository.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "default": false,
-          "description": "Either `true` to make the repository private or `false` to make it public. Creating private repositories requires a paid GitHub account. Default: `false`.  \n**Note**: You will get a `422` error if the organization restricts [changing repository visibility](https://help.github.com/articles/repository-permission-levels-for-an-organization#changing-the-visibility-of-repositories) to organization owners and a non-owner tries to change the value of private. **Note**: You will get a `422` error if the organization restricts [changing repository visibility](https://help.github.com/articles/repository-permission-levels-for-an-organization#changing-the-visibility-of-repositories) to organization owners and a non-owner tries to change the value of private.",
+        {
           "name": "private",
-          "required": false,
-          "type": "boolean"
-        },
-        "6": {
-          "default": true,
-          "description": "Either `true` to enable issues for this repository or `false` to disable them.",
-          "name": "has_issues",
-          "required": false,
-          "type": "boolean"
-        },
-        "7": {
-          "default": true,
-          "description": "Either `true` to enable projects for this repository or `false` to disable them. **Note:** If you're creating a repository in an organization that has disabled repository projects, the default is `false`, and if you pass `true`, the API returns an error.",
-          "name": "has_projects",
-          "required": false,
-          "type": "boolean"
-        },
-        "8": {
-          "default": true,
-          "description": "Either `true` to enable the wiki for this repository or `false` to disable it.",
-          "name": "has_wiki",
-          "required": false,
-          "type": "boolean"
-        },
-        "9": {
-          "description": "Updates the default branch for this repository.",
-          "name": "default_branch",
-          "required": false,
-          "type": "string"
-        },
-        "10": {
-          "default": true,
-          "description": "Either `true` to allow squash-merging pull requests, or `false` to prevent squash-merging.",
-          "name": "allow_squash_merge",
-          "required": false,
-          "type": "boolean"
-        },
-        "11": {
-          "default": true,
-          "description": "Either `true` to allow merging pull requests with a merge commit, or `false` to prevent merging pull requests with merge commits.",
-          "name": "allow_merge_commit",
-          "required": false,
-          "type": "boolean"
-        },
-        "12": {
-          "default": true,
-          "description": "Either `true` to allow rebase-merging pull requests, or `false` to prevent rebase-merging.",
-          "name": "allow_rebase_merge",
-          "required": false,
-          "type": "boolean"
-        },
-        "13": {
+          "type": "boolean",
+          "description": "Either `true` to make the repository private or `false` to make it public. Creating private repositories requires a paid GitHub account. Default: `false`.  \n**Note**: You will get a `422` error if the organization restricts [changing repository visibility](https://help.github.com/articles/repository-permission-levels-for-an-organization#changing-the-visibility-of-repositories) to organization owners and a non-owner tries to change the value of private. **Note**: You will get a `422` error if the organization restricts [changing repository visibility](https://help.github.com/articles/repository-permission-levels-for-an-organization#changing-the-visibility-of-repositories) to organization owners and a non-owner tries to change the value of private.",
           "default": false,
-          "description": "`true` to archive this repository. **Note**: You cannot unarchive repositories through the API.",
-          "name": "archived",
           "required": false,
-          "type": "boolean"
+          "location": "body"
+        },
+        {
+          "name": "has_issues",
+          "type": "boolean",
+          "description": "Either `true` to enable issues for this repository or `false` to disable them.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "has_projects",
+          "type": "boolean",
+          "description": "Either `true` to enable projects for this repository or `false` to disable them. **Note:** If you're creating a repository in an organization that has disabled repository projects, the default is `false`, and if you pass `true`, the API returns an error.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "has_wiki",
+          "type": "boolean",
+          "description": "Either `true` to enable the wiki for this repository or `false` to disable it.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "default_branch",
+          "type": "string",
+          "description": "Updates the default branch for this repository.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "allow_squash_merge",
+          "type": "boolean",
+          "description": "Either `true` to allow squash-merging pull requests, or `false` to prevent squash-merging.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "allow_merge_commit",
+          "type": "boolean",
+          "description": "Either `true` to allow merging pull requests with a merge commit, or `false` to prevent merging pull requests with merge commits.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "allow_rebase_merge",
+          "type": "boolean",
+          "description": "Either `true` to allow rebase-merging pull requests, or `false` to prevent rebase-merging.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "archived",
+          "type": "boolean",
+          "description": "`true` to archive this repository. **Note**: You cannot unarchive repositories through the API.",
+          "default": false,
+          "required": false,
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo"
     },
     "editAsset": {
@@ -9826,38 +10983,43 @@
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Edit a release asset",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "The file name of the asset.",
+        {
           "name": "name",
+          "type": "string",
+          "description": "The file name of the asset.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "An alternate short description of the asset. Used in place of the filename.",
+        {
           "name": "label",
+          "type": "string",
+          "description": "An alternate short description of the asset. Used in place of the filename.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/releases/assets/:id"
     },
     "editHook": {
@@ -9866,82 +11028,94 @@
       "enabledForApps": false,
       "method": "PATCH",
       "name": "Edit a hook",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+        {
           "name": "config",
-          "required": true,
-          "type": "object"
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "required": false,
+          "location": "body"
         },
-        "4": {
-          "description": "The URL to which the payloads will be delivered.",
+        {
           "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        {
           "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/webhooks/#delivery-headers) header.",
+        {
           "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "7": {
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        {
           "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "8": {
-          "default": "[\"push\"]",
-          "description": "Determines what [events](/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
+        {
           "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
+          "default": "[\"push\"]",
           "required": false,
-          "type": "array"
+          "location": "body"
         },
-        "9": {
-          "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
+        {
           "name": "add_events",
+          "type": "string[]",
+          "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
           "required": false,
-          "type": "array"
+          "location": "body"
         },
-        "10": {
-          "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
+        {
           "name": "remove_events",
+          "type": "string[]",
+          "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
           "required": false,
-          "type": "array"
+          "location": "body"
         },
-        "11": {
-          "default": true,
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        {
           "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
           "required": false,
-          "type": "boolean"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/hooks/:id"
     },
     "editRelease": {
@@ -9950,63 +11124,72 @@
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Edit a release",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "The name of the tag.",
+        {
           "name": "tag_name",
+          "type": "string",
+          "description": "The name of the tag.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "default": "the repository's default branch (usually `master`).",
-          "description": "Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists.",
+        {
           "name": "target_commitish",
+          "type": "string",
+          "description": "Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists.",
+          "default": "the repository's default branch (usually `master`).",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "The name of the release.",
+        {
           "name": "name",
+          "type": "string",
+          "description": "The name of the release.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "description": "Text describing the contents of the tag.",
+        {
           "name": "body",
+          "type": "string",
+          "description": "Text describing the contents of the tag.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "7": {
-          "description": "`true` makes the release a draft, and `false` publishes the release.",
+        {
           "name": "draft",
+          "type": "boolean",
+          "description": "`true` makes the release a draft, and `false` publishes the release.",
           "required": false,
-          "type": "boolean"
+          "location": "body"
         },
-        "8": {
-          "description": "`true` to identify the release as a prerelease, `false` to identify the release as a full release.",
+        {
           "name": "prerelease",
+          "type": "boolean",
+          "description": "`true` to identify the release as a prerelease, `false` to identify the release as a full release.",
           "required": false,
-          "type": "boolean"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/releases/:id"
     },
     "fork": {
@@ -10015,26 +11198,29 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Create a fork",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "repo",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "description": "Optional parameter to specify the organization name if forking into an organization.",
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
           "name": "organization",
+          "type": "string",
+          "description": "Optional parameter to specify the organization name if forking into an organization.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/forks"
     },
     "get": {
@@ -10043,20 +11229,22 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo"
     },
     "getAll": {
@@ -10065,34 +11253,39 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List your repositories",
-      "params": {
-        "0": {
-          "default": "all",
+      "params": [
+        {
+          "name": "visibility",
+          "type": "string",
           "description": "Can be one of `all`, `public`, or `private`.",
+          "default": "all",
+          "required": false,
           "enum": [
             "all",
             "public",
             "private"
           ],
-          "name": "visibility",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "1": {
-          "default": "owner,collaborator,organization_member",
+        {
+          "name": "affiliation",
+          "type": "string",
           "description": "Comma-separated list of values. Can include:  \n\\* `owner`: Repositories that are owned by the authenticated user.  \n\\* `collaborator`: Repositories that the user has been added to as a collaborator.  \n\\* `organization_member`: Repositories that the user has access to through being a member of an organization. This includes every repository on every team that the user is on.",
+          "default": "owner,collaborator,organization_member",
+          "required": false,
           "enum": [
             "owner",
             "collaborator",
             "organization_member"
           ],
-          "name": "affiliation",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
-          "default": "all",
+        {
+          "name": "type",
+          "type": "string",
           "description": "Can be one of `all`, `owner`, `public`, `private`, `member`. Default: `all`  \n  \nWill cause a `422` error if used in the same request as **visibility** or **affiliation**. Will cause a `422` error if used in the same request as **visibility** or **affiliation**.",
+          "default": "all",
+          "required": false,
           "enum": [
             "all",
             "owner",
@@ -10100,85 +11293,91 @@
             "private",
             "member"
           ],
-          "name": "type",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "default": "full_name",
+        {
+          "name": "sort",
+          "type": "string",
           "description": "Can be one of `created`, `updated`, `pushed`, `full_name`.",
+          "default": "full_name",
+          "required": false,
           "enum": [
             "created",
             "updated",
             "pushed",
             "full_name"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "4": {
-          "default": "when using `full_name`: `asc`; otherwise `desc`",
+        {
+          "name": "direction",
+          "type": "string",
           "description": "Can be one of `asc` or `desc`.",
+          "default": "when using `full_name`: `asc`; otherwise `desc`",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "direction",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "5": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "6": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/user/repos"
     },
     "getAllCommitComments": {
-      "description": "Commit Comments use [these custom media types](#custom-media-types). You can read more about the use of media types in the API [here](/v3/media/).\n\nComments are ordered by ascending ID.",
+      "description": "Commit Comments use [these custom media types](#custom-media-types). You can read more about the use of media types in the API [here](https://developer.github.com/v3/media/).\n\nComments are ordered by ascending ID.",
       "documentationUrl": "https://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository",
       "enabledForApps": true,
       "method": "GET",
       "name": "List commit comments for a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/comments"
     },
     "getArchiveLink": {
@@ -10187,66 +11386,73 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get archive link",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "repo",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "default": "tarball",
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "archive_format",
+          "type": "string",
           "description": "Can be either `tarball` or `zipball`.",
+          "default": "tarball",
+          "required": true,
           "enum": [
             "tarball",
             "zipball"
           ],
-          "name": "archive_format",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "3": {
-          "default": "the repository’s default branch (usually `master`)",
-          "description": "A valid Git reference.",
+        {
           "name": "ref",
+          "type": "string",
+          "description": "A valid Git reference.",
+          "default": "the repository’s default branch (usually `master`)",
           "required": true,
-          "type": "string"
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/:archive_format/:ref"
     },
     "getAsset": {
-      "description": "To download the asset's binary content, set the `Accept` header of the request to [`application/octet-stream`](/v3/media/#media-types). The API will either redirect the client to the location, or stream it directly if possible. API clients should handle both a `200` or `302` response.",
+      "description": "To download the asset's binary content, set the `Accept` header of the request to [`application/octet-stream`](https://developer.github.com/v3/media/#media-types). The API will either redirect the client to the location, or stream it directly if possible. API clients should handle both a `200` or `302` response.",
       "documentationUrl": "https://developer.github.com/v3/repos/releases/#get-a-single-release-asset",
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a single release asset",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/releases/assets/:id"
     },
     "getAssets": {
@@ -10255,40 +11461,45 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List assets for a release",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/releases/:id/assets"
     },
     "getBranch": {
@@ -10297,26 +11508,29 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch"
     },
     "getBranchProtection": {
@@ -10325,26 +11539,29 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get branch protection",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection"
     },
     "getBranches": {
@@ -10353,73 +11570,81 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List branches",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "Setting to `true` returns only protected branches.",
+        {
           "name": "protected",
+          "type": "boolean",
+          "description": "Setting to `true` returns only protected branches.",
           "required": false,
-          "type": "boolean"
+          "location": "query"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches"
     },
     "getClones": {
       "description": "Get the total number of clones and breakdown per day or week for the last 14 days. Timestamps are aligned to UTC midnight of the beginning of the day or week. Week begins on Monday.",
       "documentationUrl": "https://developer.github.com/v3/repos/traffic/#clones",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "Clones",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "repo",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "default": "day",
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per",
+          "type": "string",
           "description": "Must be one of: `day`, `week`.",
+          "default": "day",
+          "required": false,
           "enum": [
             "day",
             "week"
           ],
-          "name": "per",
-          "required": false,
-          "type": "string"
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/traffic/clones"
     },
     "getCollaborators": {
@@ -10428,102 +11653,113 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List collaborators",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "repo",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "default": "all",
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "affiliation",
+          "type": "string",
           "description": "Filter collaborators returned by their affiliation. Can be one of:  \n\\* `outside`: All outside collaborators of an organization-owned repository.  \n\\* `direct`: All collaborators with permissions to an organization-owned repository, regardless of organization membership status.  \n\\* `all`: All collaborators the authenticated user can see.",
+          "default": "all",
+          "required": false,
           "enum": [
             "outside",
             "direct",
             "all"
           ],
-          "name": "affiliation",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/collaborators"
     },
     "getCombinedStatusForRef": {
-      "description": "Users with pull access can access a combined view of commit statuses for a given ref.\n\nThe most recent status for each context is returned, up to 100. This field [paginates](/v3/#pagination) if there are over 100 contexts.\n\nAdditionally, a combined `state` is returned. The `state` is one of:\n\n*   **failure** if any of the contexts report as `error` or `failure`\n*   **pending** if there are no statuses or a context is `pending`\n*   **success** if the latest status for all contexts is `success`",
+      "description": "Users with pull access in a repository can access a combined view of commit statuses for a given ref. The ref can be a SHA, a branch name, or a tag name.\n\nThe most recent status for each context is returned, up to 100. This field [paginates](https://developer.github.com/v3/#pagination) if there are over 100 contexts.\n\nAdditionally, a combined `state` is returned. The `state` is one of:\n\n*   **failure** if any of the contexts report as `error` or `failure`\n*   **pending** if there are no statuses or a context is `pending`\n*   **success** if the latest status for all contexts is `success`",
       "documentationUrl": "https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref",
       "enabledForApps": true,
       "method": "GET",
       "name": "Get the combined status for a specific ref",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "repo",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "description": "Ref to fetch the status for. It can be a SHA, a branch name, or a tag name.",
-          "name": "ref",
+        {
+          "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "ref",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/commits/:ref/status"
     },
     "getCommit": {
-      "description": "Diffs with binary data will have no 'patch' property. Pass the appropriate [media type](/v3/media/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.",
+      "description": "Diffs with binary data will have no 'patch' property. Pass the appropriate [media type](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.",
       "documentationUrl": "https://developer.github.com/v3/repos/commits/#get-a-single-commit",
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a single commit",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "sha",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/commits/:sha"
     },
     "getCommitComment": {
@@ -10532,26 +11768,29 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a single commit comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/comments/:id"
     },
     "getCommitComments": {
@@ -10560,40 +11799,45 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List comments for a single commit",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "ref",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/commits/:ref/comments"
     },
     "getCommits": {
@@ -10602,65 +11846,74 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List commits on a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": "the repository’s default branch (usually `master`).",
-          "description": "SHA or branch to start listing commits from.",
+        {
           "name": "sha",
+          "type": "string",
+          "description": "SHA or branch to start listing commits from.",
+          "default": "the repository’s default branch (usually `master`).",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "description": "Only commits containing this file path will be returned.",
+        {
           "name": "path",
+          "type": "string",
+          "description": "Only commits containing this file path will be returned.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "4": {
-          "description": "GitHub login or email address by which to filter by commit author.",
+        {
           "name": "author",
+          "type": "string",
+          "description": "GitHub login or email address by which to filter by commit author.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "5": {
-          "description": "Only commits after this date will be returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+        {
           "name": "since",
+          "type": "string",
+          "description": "Only commits after this date will be returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "6": {
-          "description": "Only commits before this date will be returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
+        {
           "name": "until",
+          "type": "string",
+          "description": "Only commits before this date will be returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "7": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "8": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/commits"
     },
     "getCommunityProfileMetrics": {
@@ -10669,55 +11922,61 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Retrieve community profile metrics",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "name",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:name/community/profile"
     },
     "getContent": {
-      "description": "This method returns the contents of a file or directory in a repository.\n\nFiles and symlinks support [a custom media type](#custom-media-types) for retrieving the raw content or rendered HTML (when supported). All content types support [a custom media type](#custom-media-types) to ensure the content is returned in a consistent object format.\n\n**Note**:\n\n*   To get a repository's contents recursively, you can [recursively get the tree](/v3/git/trees/).\n*   This API has an upper limit of 1,000 files for a directory. If you need to retrieve more files, use the [Git Trees API](/v3/git/trees/#get-a-tree).\n*   This API supports files up to 1 megabyte in size.\n\nThe response will be an array of objects, one object for each item in the directory.\n\nWhen listing the contents of a directory, submodules have their \"type\" specified as \"file\". Logically, the value _should_ be \"submodule\". This behavior exists in API v3 [for backwards compatibility purposes](https://git.io/v1YCW). In the next major version of the API, the type will be returned as \"submodule\".\n\nIf the requested `:path` points to a symlink, and the symlink's target is a normal file in the repository, then the API responds with the content of the file (in the [format shown above](#response-if-content-is-a-file)).\n\nOtherwise, the API responds with an object describing the symlink itself:\n\nThe `submodule_git_url` identifies the location of the submodule repository, and the `sha` identifies a specific commit within the submodule repository. Git uses the given URL when cloning the submodule repository, and checks out the submodule at that specific commit.\n\nIf the submodule repository is not hosted on github.com, the Git URLs (`git_url` and `_links[\"git\"]`) and the github.com URLs (`html_url` and `_links[\"html\"]`) will have null values.",
+      "description": "This method returns the contents of a file or directory in a repository.\n\nFiles and symlinks support [a custom media type](#custom-media-types) for retrieving the raw content or rendered HTML (when supported). All content types support [a custom media type](#custom-media-types) to ensure the content is returned in a consistent object format.\n\n**Note**:\n\n*   To get a repository's contents recursively, you can [recursively get the tree](https://developer.github.com/v3/git/trees/).\n*   This API has an upper limit of 1,000 files for a directory. If you need to retrieve more files, use the [Git Trees API](https://developer.github.com/v3/git/trees/#get-a-tree).\n*   This API supports files up to 1 megabyte in size.\n\nThe response will be an array of objects, one object for each item in the directory.\n\nWhen listing the contents of a directory, submodules have their \"type\" specified as \"file\". Logically, the value _should_ be \"submodule\". This behavior exists in API v3 [for backwards compatibility purposes](https://git.io/v1YCW). In the next major version of the API, the type will be returned as \"submodule\".\n\nIf the requested `:path` points to a symlink, and the symlink's target is a normal file in the repository, then the API responds with the content of the file (in the [format shown above](#response-if-content-is-a-file)).\n\nOtherwise, the API responds with an object describing the symlink itself:\n\nThe `submodule_git_url` identifies the location of the submodule repository, and the `sha` identifies a specific commit within the submodule repository. Git uses the given URL when cloning the submodule repository, and checks out the submodule at that specific commit.\n\nIf the submodule repository is not hosted on github.com, the Git URLs (`git_url` and `_links[\"git\"]`) and the github.com URLs (`html_url` and `_links[\"html\"]`) will have null values.",
       "documentationUrl": "https://developer.github.com/v3/repos/contents/#get-contents",
       "enabledForApps": true,
       "method": "GET",
       "name": "Get contents",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The content path.",
+        {
           "name": "path",
+          "type": "string",
+          "description": "The content path.",
           "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "3": {
-          "default": "the repository’s default branch (usually `master`)",
-          "description": "The name of the commit/branch/tag.",
+        {
           "name": "ref",
+          "type": "string",
+          "description": "The name of the commit/branch/tag.",
+          "default": "the repository’s default branch (usually `master`)",
           "required": false,
-          "type": "string"
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/contents/:path"
     },
     "getContributors": {
@@ -10726,40 +11985,45 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List contributors",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "Set to `1` or `true` to include anonymous contributors in results.",
+        {
           "name": "anon",
+          "type": "string",
+          "description": "Set to `1` or `true` to include anonymous contributors in results.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/contributors"
     },
     "getDeployKey": {
@@ -10768,26 +12032,29 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a deploy key",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/keys/:id"
     },
     "getDeployKeys": {
@@ -10796,34 +12063,38 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List deploy keys",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/keys"
     },
     "getDeployment": {
@@ -10832,26 +12103,29 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a single deployment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/deployments/:id"
     },
     "getDeploymentStatus": {
@@ -10860,32 +12134,36 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a single deployment status",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The deployment ID to list the statuses from.",
+        {
           "name": "id",
+          "type": "integer",
+          "description": "The deployment ID to list the statuses from.",
           "required": true,
-          "type": "integer"
+          "location": "url"
         },
-        "3": {
-          "description": "The deployment status ID.",
+        {
           "name": "status_id",
+          "type": "integer",
+          "description": "The deployment status ID.",
           "required": true,
-          "type": "integer"
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/deployments/:id/statuses/:status_id"
     },
     "getDeploymentStatuses": {
@@ -10894,40 +12172,45 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List deployment statuses",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The deployment ID to list the statuses from.",
+        {
           "name": "id",
+          "type": "integer",
+          "description": "The deployment ID to list the statuses from.",
           "required": true,
-          "type": "integer"
+          "location": "url"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/deployments/:id/statuses"
     },
     "getDeployments": {
@@ -10936,62 +12219,70 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List deployments",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": "none",
-          "description": "The SHA that was recorded at creation time.",
+        {
           "name": "sha",
-          "required": false,
-          "type": "string"
-        },
-        "3": {
+          "type": "string",
+          "description": "The SHA that was recorded at creation time.",
           "default": "none",
-          "description": "The name of the ref. This can be a branch, tag, or SHA.",
+          "required": false,
+          "location": "query"
+        },
+        {
           "name": "ref",
-          "required": false,
-          "type": "string"
-        },
-        "4": {
+          "type": "string",
+          "description": "The name of the ref. This can be a branch, tag, or SHA.",
           "default": "none",
-          "description": "The name of the task for the deployment (e.g., `deploy` or `deploy:migrations`).",
+          "required": false,
+          "location": "query"
+        },
+        {
           "name": "task",
-          "required": false,
-          "type": "string"
-        },
-        "5": {
+          "type": "string",
+          "description": "The name of the task for the deployment (e.g., `deploy` or `deploy:migrations`).",
           "default": "none",
-          "description": "The name of the environment that was deployed to (e.g., `staging` or `production`).",
+          "required": false,
+          "location": "query"
+        },
+        {
           "name": "environment",
+          "type": "string",
+          "description": "The name of the environment that was deployed to (e.g., `staging` or `production`).",
+          "default": "none",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "6": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "7": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/deployments"
     },
     "getDownload": {
@@ -11000,80 +12291,91 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Get a single download",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/downloads/:id"
     },
     "getDownloads": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/repos/downloads/#list-downloads-for-a-repository",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "List downloads for a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/downloads"
     },
     "getForOrg": {
       "description": "List repositories for the specified org.",
       "documentationUrl": "https://developer.github.com/v3/repos/#list-organization-repositories",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "List organization repositories",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": "all",
+        {
+          "name": "type",
+          "type": "string",
           "description": "Can be one of `all`, `public`, `private`, `forks`, `sources`, `member`.",
+          "default": "all",
+          "required": false,
           "enum": [
             "all",
             "public",
@@ -11082,25 +12384,25 @@
             "sources",
             "member"
           ],
-          "name": "type",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/orgs/:org/repos"
     },
     "getForUser": {
@@ -11109,64 +12411,70 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List user repositories",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": "owner",
+        {
+          "name": "type",
+          "type": "string",
           "description": "Can be one of `all`, `owner`, `member`.",
+          "default": "owner",
+          "required": false,
           "enum": [
             "all",
             "owner",
             "member"
           ],
-          "name": "type",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
-          "default": "full_name",
+        {
+          "name": "sort",
+          "type": "string",
           "description": "Can be one of `created`, `updated`, `pushed`, `full_name`.",
+          "default": "full_name",
+          "required": false,
           "enum": [
             "created",
             "updated",
             "pushed",
             "full_name"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "default": "when using `full_name`: `asc`, otherwise `desc`",
+        {
+          "name": "direction",
+          "type": "string",
           "description": "Can be one of `asc` or `desc`.",
+          "default": "when using `full_name`: `asc`, otherwise `desc`",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "direction",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "4": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "5": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/users/:username/repos"
     },
     "getForks": {
@@ -11175,46 +12483,51 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List forks",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "repo",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "default": "newest",
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "sort",
+          "type": "string",
           "description": "The sort order. Can be either `newest`, `oldest`, or `stargazers`.",
+          "default": "newest",
+          "required": false,
           "enum": [
             "newest",
             "oldest",
             "stargazers"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/forks"
     },
     "getHook": {
@@ -11223,26 +12536,29 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Get single hook",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/hooks/:id"
     },
     "getHooks": {
@@ -11251,70 +12567,78 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List hooks",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/hooks"
     },
     "getInvites": {
       "description": "When authenticating as a user with admin rights to a repository, this endpoint will list all currently open repository invitations.\n\n",
       "documentationUrl": "https://developer.github.com/v3/repos/invitations/#list-invitations-for-a-repository",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "List invitations for a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/invitations"
     },
     "getLanguages": {
@@ -11323,42 +12647,46 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List languages",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/languages"
     },
     "getLatestPagesBuild": {
       "description": "",
-      "documentationUrl": "https://developer.github.com/v3/repos/pages/#list-latest-pages-build",
+      "documentationUrl": "https://developer.github.com/v3/repos/pages/#get-latest-pages-build",
       "enabledForApps": true,
       "method": "GET",
-      "name": "List latest Pages build",
-      "params": {
-        "0": {
-          "description": "",
+      "name": "Get latest Pages build",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pages/builds/latest"
     },
     "getLatestRelease": {
@@ -11367,20 +12695,22 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get the latest release",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/releases/latest"
     },
     "getPages": {
@@ -11389,48 +12719,53 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get information about a Pages site",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pages"
     },
     "getPagesBuild": {
       "description": "",
-      "documentationUrl": "https://developer.github.com/v3/repos/pages/#list-a-specific-pages-build",
+      "documentationUrl": "https://developer.github.com/v3/repos/pages/#get-a-specific-pages-build",
       "enabledForApps": true,
       "method": "GET",
-      "name": "List a specific Pages build",
-      "params": {
-        "0": {
-          "description": "",
+      "name": "Get a specific Pages build",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pages/builds/:id"
     },
     "getPagesBuilds": {
@@ -11439,56 +12774,62 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List Pages builds",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pages/builds"
     },
     "getPaths": {
       "description": "Get the top 10 popular contents over the last 14 days.",
       "documentationUrl": "https://developer.github.com/v3/repos/traffic/#list-paths",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "List paths",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/traffic/popular/paths"
     },
     "getProtectedBranchAdminEnforcement": {
@@ -11497,26 +12838,29 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get admin enforcement of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins"
     },
     "getProtectedBranchPullRequestReviewEnforcement": {
@@ -11525,26 +12869,29 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get pull request review enforcement of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews"
     },
     "getProtectedBranchRequiredStatusChecks": {
@@ -11553,26 +12900,29 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get required status checks of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks"
     },
     "getProtectedBranchRequiredStatusChecksContexts": {
@@ -11581,26 +12931,29 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List required status checks contexts of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
     },
     "getProtectedBranchRestrictions": {
@@ -11609,112 +12962,124 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get restrictions of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions"
     },
     "getProtectedBranchTeamRestrictions": {
-      "description": "",
+      "description": "Lists the teams who have push access to this branch. If you pass the `hellcat-preview` media type, the list includes child teams.",
       "documentationUrl": "https://developer.github.com/v3/repos/branches/#list-team-restrictions-of-protected-branch",
       "enabledForApps": true,
       "method": "GET",
       "name": "List team restrictions of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
     },
     "getProtectedBranchUserRestrictions": {
-      "description": "",
+      "description": "Lists the people who have push access to this branch.",
       "documentationUrl": "https://developer.github.com/v3/repos/branches/#list-user-restrictions-of-protected-branch",
       "enabledForApps": true,
       "method": "GET",
       "name": "List user restrictions of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
     },
     "getPublic": {
-      "description": "This provides a dump of every public repository, in the order that they were created.\n\nNote: Pagination is powered exclusively by the `since` parameter. Use the [Link header](/v3/#link-header) to get the URL for the next page of repositories.",
+      "description": "This provides a dump of every public repository, in the order that they were created.\n\nNote: Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://developer.github.com/v3/#link-header) to get the URL for the next page of repositories.",
       "documentationUrl": "https://developer.github.com/v3/repos/#list-all-public-repositories",
       "enabledForApps": true,
       "method": "GET",
       "name": "List all public repositories",
-      "params": {
-        "0": {
-          "description": "The integer ID of the last Repository that you've seen.",
+      "params": [
+        {
           "name": "since",
+          "type": "string",
+          "description": "The integer ID of the last Repository that you've seen.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repositories"
     },
     "getReadme": {
@@ -11723,77 +13088,85 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get the README",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "repo",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "default": "the repository’s default branch (usually `master`)",
-          "description": "The name of the commit/branch/tag.",
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
           "name": "ref",
+          "type": "string",
+          "description": "The name of the commit/branch/tag.",
+          "default": "the repository’s default branch (usually `master`)",
           "required": false,
-          "type": "string"
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/readme"
     },
     "getReferrers": {
       "description": "Get the top 10 referrers over the last 14 days.",
       "documentationUrl": "https://developer.github.com/v3/repos/traffic/#list-referrers",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "List referrers",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/traffic/popular/referrers"
     },
     "getRelease": {
-      "description": "**Note:** This returns an `upload_url` key corresponding to the endpoint for uploading release assets. This key is a [hypermedia resource](/v3/#hypermedia).",
+      "description": "**Note:** This returns an `upload_url` key corresponding to the endpoint for uploading release assets. This key is a [hypermedia resource](https://developer.github.com/v3/#hypermedia).",
       "documentationUrl": "https://developer.github.com/v3/repos/releases/#get-a-single-release",
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a single release",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/releases/:id"
     },
     "getReleaseByTag": {
@@ -11802,90 +13175,100 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a release by tag name",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "tag",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/releases/tags/:tag"
     },
     "getReleases": {
-      "description": "This returns a list of releases, which does not include regular Git tags that have not been associated with a release. To get a list of Git tags, use the [Repository Tags API](/v3/repos/#list-tags).\n\nInformation about published releases are available to everyone. Only users with push access will receive listings for draft releases.",
+      "description": "This returns a list of releases, which does not include regular Git tags that have not been associated with a release. To get a list of Git tags, use the [Repository Tags API](https://developer.github.com/v3/repos/#list-tags).\n\nInformation about published releases are available to everyone. Only users with push access will receive listings for draft releases.",
       "documentationUrl": "https://developer.github.com/v3/repos/releases/#list-releases-for-a-repository",
       "enabledForApps": true,
       "method": "GET",
       "name": "List releases for a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/releases"
     },
     "getShaOfCommitRef": {
-      "description": "Users with read access can get the SHA-1 of a commit reference:\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n\n\nTo check if a remote reference's SHA-1 is the same as your local reference's SHA-1, make a `GET` request and provide the current SHA-1 for the local reference as the ETag.\n\nThe SHA-1 of the commit reference.\n\n",
+      "description": "Users with read access can get the SHA-1 of a commit reference:\n\nTo access the API you must provide a custom [media type](https://developer.github.com/v3/media) in the `Accept` header:\n\n\n\nTo check if a remote reference's SHA-1 is the same as your local reference's SHA-1, make a `GET` request and provide the current SHA-1 for the local reference as the ETag.\n\nThe SHA-1 of the commit reference.\n\n",
       "documentationUrl": "https://developer.github.com/v3/repos/commits/#get-the-sha-1-of-a-commit-reference",
       "enabledForApps": true,
       "method": "GET",
       "name": "Get the SHA-1 of a commit reference",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "ref",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/commits/:ref"
     },
     "getStatsCodeFrequency": {
@@ -11894,20 +13277,22 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get the number of additions and deletions per week",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/stats/code_frequency"
     },
     "getStatsCommitActivity": {
@@ -11916,20 +13301,22 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get the last year of commit activity data",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/stats/commit_activity"
     },
     "getStatsContributors": {
@@ -11938,20 +13325,22 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get contributors list with additions, deletions, and commit counts",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/stats/contributors"
     },
     "getStatsParticipation": {
@@ -11960,20 +13349,22 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get the weekly commit count for the repository owner and everyone else",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/stats/participation"
     },
     "getStatsPunchCard": {
@@ -11982,62 +13373,69 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Get the number of commits per hour in each day",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/stats/punch_card"
     },
     "getStatuses": {
-      "description": "Users with pull access can view commit statuses for a given ref:\n\nThis resource is also available via a legacy route: `GET /repos/:owner/:repo/statuses/:ref`.\n\nStatuses are returned in reverse chronological order. The first status in the list will be the latest one.",
+      "description": "Users with pull access in a repository can view commit statuses for a given ref. The ref can be a SHA, a branch name, or a tag name. Statuses are returned in reverse chronological order. The first status in the list will be the latest one.\n\nThis resource is also available via a legacy route: `GET /repos/:owner/:repo/statuses/:ref`.",
       "documentationUrl": "https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref",
       "enabledForApps": true,
       "method": "GET",
       "name": "List statuses for a specific ref",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "Ref to list the statuses from. It can be a SHA, a branch name, or a tag name.",
+        {
           "name": "ref",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/commits/:ref/statuses"
     },
     "getTags": {
@@ -12046,34 +13444,38 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List tags",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/tags"
     },
     "getTeams": {
@@ -12082,34 +13484,38 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List teams",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "3": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/teams"
     },
     "getTopics": {
@@ -12118,53 +13524,58 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List all topics for a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/topics"
     },
     "getViews": {
       "description": "Get the total number of views and breakdown per day or week for the last 14 days. Timestamps are aligned to UTC midnight of the beginning of the day or week. Week begins on Monday.",
       "documentationUrl": "https://developer.github.com/v3/repos/traffic/#views",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "Views",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "repo",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "default": "day",
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per",
+          "type": "string",
           "description": "Must be one of: `day`, `week`.",
+          "default": "day",
+          "required": false,
           "enum": [
             "day",
             "week"
           ],
-          "name": "per",
-          "required": false,
-          "type": "string"
+          "location": "query"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/traffic/views"
     },
     "merge": {
@@ -12173,66 +13584,74 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Perform a merge",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The name of the base branch that the head will be merged into.",
+        {
           "name": "base",
+          "type": "string",
+          "description": "The name of the base branch that the head will be merged into.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "The head to merge. This can be a branch name or a commit SHA1.",
+        {
           "name": "head",
+          "type": "string",
+          "description": "The head to merge. This can be a branch name or a commit SHA1.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "Commit message to use for the merge commit. If omitted, a default message will be used.",
+        {
           "name": "commit_message",
+          "type": "string",
+          "description": "Commit message to use for the merge commit. If omitted, a default message will be used.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/merges"
     },
     "pingHook": {
-      "description": "This will trigger a [ping event](/webhooks/#ping-event) to be sent to the hook.",
+      "description": "This will trigger a [ping event](https://developer.github.com/webhooks/#ping-event) to be sent to the hook.",
       "documentationUrl": "https://developer.github.com/v3/repos/hooks/#ping-a-hook",
       "enabledForApps": false,
       "method": "POST",
       "name": "Ping a hook",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/hooks/:id/pings"
     },
     "removeBranchProtection": {
@@ -12241,26 +13660,29 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Remove branch protection",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection"
     },
     "removeCollaborator": {
@@ -12269,26 +13691,29 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Remove user as a collaborator",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/collaborators/:username"
     },
     "removeProtectedBranchAdminEnforcement": {
@@ -12297,26 +13722,29 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Remove admin enforcement of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/enforce_admins"
     },
     "removeProtectedBranchPullRequestReviewEnforcement": {
@@ -12325,26 +13753,29 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Remove pull request review enforcement of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews"
     },
     "removeProtectedBranchRequiredStatusChecks": {
@@ -12353,26 +13784,29 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Remove required status checks of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks"
     },
     "removeProtectedBranchRequiredStatusChecksContexts": {
@@ -12381,110 +13815,122 @@
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Remove required status checks contexts of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
     },
     "removeProtectedBranchRestrictions": {
-      "description": "",
+      "description": "Disables the ability to restrict who can push to this branch.",
       "documentationUrl": "https://developer.github.com/v3/repos/branches/#remove-restrictions-of-protected-branch",
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Remove restrictions of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions"
     },
     "removeProtectedBranchTeamRestrictions": {
-      "description": "",
+      "description": "Removes the ability of a team to push to this branch. If you pass the `hellcat-preview` media type, you can include child teams.\n\n| Type    | Description                                                                                                                                  |\n| ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |\n| `array` | Teams that should no longer have push access. Use the team's `slug`. **Note**: The list of users and teams in total is limited to 100 items. |",
       "documentationUrl": "https://developer.github.com/v3/repos/branches/#remove-team-restrictions-of-protected-branch",
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Remove team restrictions of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
     },
     "removeProtectedBranchUserRestrictions": {
-      "description": "",
+      "description": "Removes the ability of a team to push to this branch.\n\n| Type    | Description                                                                                                                            |\n| ------- | -------------------------------------------------------------------------------------------------------------------------------------- |\n| `array` | Usernames of the people who should no longer have push access. **Note**: The list of users and teams in total is limited to 100 items. |",
       "documentationUrl": "https://developer.github.com/v3/repos/branches/#remove-user-restrictions-of-protected-branch",
       "enabledForApps": true,
       "method": "DELETE",
       "name": "Remove user restrictions of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
     },
     "replaceProtectedBranchRequiredStatusChecksContexts": {
@@ -12493,82 +13939,91 @@
       "enabledForApps": true,
       "method": "PUT",
       "name": "Replace required status checks contexts of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
     },
     "replaceProtectedBranchTeamRestrictions": {
-      "description": "Pass the list of team `slug`s with push access.\n\n**Note**: The list of users and teams in total is limited to 100 items.",
+      "description": "Replaces the list of teams that have push access to this branch. This removes all teams that previously had push access and grants push access to the new list of teams. If you pass the `hellcat-preview` media type, you can include child teams.\n\n| Type    | Description                                                                                                                         |\n| ------- | ----------------------------------------------------------------------------------------------------------------------------------- |\n| `array` | The teams that can have push access. Use the team's `slug`. **Note**: The list of users and teams in total is limited to 100 items. |",
       "documentationUrl": "https://developer.github.com/v3/repos/branches/#replace-team-restrictions-of-protected-branch",
       "enabledForApps": true,
       "method": "PUT",
       "name": "Replace team restrictions of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
     },
     "replaceProtectedBranchUserRestrictions": {
-      "description": "Pass the list of user `login`s with push access.\n\n**Note**: The list of users and teams in total is limited to 100 items.",
+      "description": "Replaces the list of people that have push access to this branch. This removes all people that previously had push access and grants push access to the new list of people.\n\n| Type    | Description                                                                                                            |\n| ------- | ---------------------------------------------------------------------------------------------------------------------- |\n| `array` | Usernames for people who can have push access. **Note**: The list of users and teams in total is limited to 100 items. |",
       "documentationUrl": "https://developer.github.com/v3/repos/branches/#replace-user-restrictions-of-protected-branch",
       "enabledForApps": true,
       "method": "PUT",
       "name": "Replace user restrictions of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
     },
     "replaceTopics": {
@@ -12577,26 +14032,29 @@
       "enabledForApps": true,
       "method": "PUT",
       "name": "Replace all topics for a repository",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
-          "name": "repo",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "2": {
-          "description": "An array of topics to add to the repository. Pass one or more topics to _replace_ the set of existing topics. Send an empty array (`[]`) to clear all topics from the repository.",
-          "name": "names",
+        {
+          "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "array of strings"
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "names",
+          "type": "string[]",
+          "description": "An array of topics to add to the repository. Pass one or more topics to _replace_ the set of existing topics. Send an empty array (`[]`) to clear all topics from the repository.",
+          "required": true,
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/topics"
     },
     "requestPageBuild": {
@@ -12605,20 +14063,22 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Request a page build",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/pages/builds"
     },
     "reviewUserPermissionLevel": {
@@ -12627,26 +14087,29 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "Review a user's permission level",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/collaborators/:username/permission"
     },
     "testHook": {
@@ -12655,26 +14118,29 @@
       "enabledForApps": false,
       "method": "POST",
       "name": "Test a push hook",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/hooks/:id/tests"
     },
     "updateBranchProtection": {
@@ -12683,114 +14149,131 @@
       "enabledForApps": true,
       "method": "PUT",
       "name": "Update branch protection",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "3": {
+        {
+          "name": "required_pull_request_reviews.dismissal_restrictions.users",
+          "type": "string[]",
           "description": "The list of user `login`s with dismissal access",
-          "name": "dismissal_restrictions.users",
           "required": false,
-          "type": "array"
+          "location": "body"
         },
-        "4": {
+        {
+          "name": "required_pull_request_reviews.dismissal_restrictions.teams",
+          "type": "string[]",
           "description": "The list of team `slug`s with dismissal access",
-          "name": "dismissal_restrictions.teams",
           "required": false,
-          "type": "array"
+          "location": "body"
         },
-        "5": {
-          "allowNull": true,
-          "description": "Require status checks to pass before merging. Set to `null` to disable.",
+        {
           "name": "required_status_checks",
+          "type": "object",
+          "description": "Require status checks to pass before merging. Set to `null` to disable.",
           "required": true,
-          "type": "object"
+          "allowNull": true,
+          "location": "body"
         },
-        "6": {
-          "description": "Require branches to be up to date before merging.",
+        {
           "name": "required_status_checks.strict",
+          "type": "boolean",
+          "description": "Require branches to be up to date before merging.",
           "required": true,
-          "type": "boolean"
+          "location": "body"
         },
-        "7": {
-          "description": "The list of status checks to require in order to merge into this branch",
+        {
           "name": "required_status_checks.contexts",
+          "type": "string[]",
+          "description": "The list of status checks to require in order to merge into this branch",
           "required": true,
-          "type": "array"
+          "location": "body"
         },
-        "8": {
-          "allowNull": true,
-          "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable.",
+        {
           "name": "enforce_admins",
+          "type": "boolean",
+          "description": "Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable.",
           "required": true,
-          "type": "boolean"
-        },
-        "9": {
           "allowNull": true,
-          "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
+          "location": "body"
+        },
+        {
           "name": "required_pull_request_reviews",
+          "type": "object",
+          "description": "Require at least one approving review on a pull request, before merging. Set to `null` to disable.",
           "required": true,
-          "type": "object"
-        },
-        "10": {
-          "description": "Specify which users and teams can dismiss pull request reviews. Pass an empty `dismissal_restrictions` object to disable. User and team `dismissal_restrictions` are only available for organization-owned repositories. Omit this parameter for personal repositories.",
-          "name": "required_pull_request_reviews.dismissal_restrictions",
-          "required": false,
-          "type": "object"
-        },
-        "11": {
-          "description": "Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit.",
-          "name": "required_pull_request_reviews.dismiss_stale_reviews",
-          "required": false,
-          "type": "boolean"
-        },
-        "12": {
-          "description": "Blocks merging pull requests until code owners review them.",
-          "name": "required_pull_request_reviews.require_code_owner_reviews",
-          "required": false,
-          "type": "boolean"
-        },
-        "13": {
-          "description": "Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6.",
-          "name": "required_pull_request_reviews.required_approving_review_count",
-          "required": false,
-          "type": "integer"
-        },
-        "14": {
           "allowNull": true,
-          "description": "Restrict who can push to this branch. Team and user `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
+          "location": "body"
+        },
+        {
+          "name": "required_pull_request_reviews.dismissal_restrictions",
+          "type": "object",
+          "description": "Specify which users and teams can dismiss pull request reviews. Pass an empty `dismissal_restrictions` object to disable. User and team `dismissal_restrictions` are only available for organization-owned repositories. Omit this parameter for personal repositories.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "required_pull_request_reviews.dismiss_stale_reviews",
+          "type": "boolean",
+          "description": "Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "required_pull_request_reviews.require_code_owner_reviews",
+          "type": "boolean",
+          "description": "Blocks merging pull requests until code owners review them.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "required_pull_request_reviews.required_approving_review_count",
+          "type": "integer",
+          "description": "Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6.",
+          "required": false,
+          "location": "body"
+        },
+        {
           "name": "restrictions",
+          "type": "object",
+          "description": "Restrict who can push to this branch. Team and user `restrictions` are only available for organization-owned repositories. Set to `null` to disable.",
           "required": true,
-          "type": "object"
+          "allowNull": true,
+          "location": "body"
         },
-        "15": {
-          "description": "The list of user `login`s with push access",
+        {
           "name": "restrictions.users",
+          "type": "string[]",
+          "description": "The list of user `login`s with push access",
           "required": false,
-          "type": "array"
+          "location": "body"
         },
-        "16": {
-          "description": "The list of team `slug`s with push access",
+        {
           "name": "restrictions.teams",
+          "type": "string[]",
+          "description": "The list of team `slug`s with push access",
           "required": false,
-          "type": "array"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection"
     },
     "updateCommitComment": {
@@ -12799,128 +14282,151 @@
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Update a commit comment",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "id",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "3": {
-          "description": "The contents of the comment",
-          "name": "body",
+        {
+          "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The contents of the comment",
+          "required": true,
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/comments/:id"
     },
     "updateFile": {
-      "description": "This method creates a new file in a repository\n\nThe `author` section is optional and is filled in with the `committer` information if omitted. If the `committer` information is omitted, the authenticated user's information is used.\n\nYou must provide values for both `name` and `email`, whether you choose to use `author` or `committer`. Otherwise, you'll receive a `422` status code.\n\nBoth the `author` and `committer` parameters have the same keys:\n\n| name  | type   | description                                          |\n| ----- | ------ | ---------------------------------------------------- |\n| name  | string | The name of the author (or committer) of the commit  |\n| email | string | The email of the author (or committer) of the commit |",
-      "documentationUrl": "https://developer.github.com/v3/repos/contents/#create-a-file",
+      "description": "This method updates a file in a repository\n\nThe `author` section is optional and is filled in with the `committer` information if omitted. If the `committer` information is omitted, the authenticated user's information is used.\n\nYou must provide values for both `name` and `email`, whether you choose to use `author` or `committer`. Otherwise, you'll receive a `422` status code.\n\nBoth the `author` and `committer` parameters have the same keys:\n\n| name  | type   | description                                          |\n| ----- | ------ | ---------------------------------------------------- |\n| name  | string | The name of the author (or committer) of the commit  |\n| email | string | The email of the author (or committer) of the commit |",
+      "documentationUrl": "https://developer.github.com/v3/repos/contents/#update-a-file",
       "enabledForApps": true,
       "method": "PUT",
-      "name": "Create a file",
-      "params": {
-        "0": {
-          "description": "",
+      "name": "Update a file",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "2": {
-          "description": "The content path.",
+        {
           "name": "path",
+          "type": "string",
+          "description": "The content path.",
           "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "3": {
-          "description": "The commit message.",
+        {
           "name": "message",
+          "type": "string",
+          "description": "The commit message.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The new file content, Base64 encoded.",
+        {
           "name": "content",
+          "type": "string",
+          "description": "The updated file content, Base64 encoded.",
           "required": true,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "default": "the repository’s default branch (usually `master`)",
-          "description": "The branch name.",
+        {
+          "name": "sha",
+          "type": "string",
+          "description": "The blob SHA of the file being replaced.",
+          "required": true,
+          "location": "body"
+        },
+        {
           "name": "branch",
+          "type": "string",
+          "description": "The branch name.",
+          "default": "the repository’s default branch (usually `master`)",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "6": {
-          "description": "object containing information about the committer.",
+        {
           "name": "committer",
-          "type": "object"
+          "type": "object",
+          "description": "object containing information about the committer.",
+          "location": "body"
         },
-        "7": {
-          "description": "object containing information about the author.",
+        {
           "name": "author",
-          "type": "object"
+          "type": "object",
+          "description": "object containing information about the author.",
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/contents/:path"
     },
     "updateInvite": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/repos/invitations/#update-a-repository-invitation",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "PATCH",
       "name": "Update a repository invitation",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
-          "name": "invitation_id",
-          "required": true,
-          "type": "string"
+          "location": "url"
         },
-        "3": {
+        {
+          "name": "invitation_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "permissions",
+          "type": "string",
           "description": "The permissions that the associated user will have on the repository. Valid values are `read`, `write`, and `admin`.",
+          "required": false,
           "enum": [
             "read",
             "write",
             "admin"
           ],
-          "name": "permissions",
-          "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/invitations/:invitation_id"
     },
     "updateProtectedBranchPullRequestReviewEnforcement": {
@@ -12929,62 +14435,71 @@
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Update pull request review enforcement of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "Specify which users and teams can dismiss pull request reviews. Pass an empty `dismissal_restrictions` object to disable. User and team `dismissal_restrictions` are only available for organization-owned repositories. Omit this parameter for personal repositories.",
+        {
           "name": "dismissal_restrictions",
+          "type": "object",
+          "description": "Specify which users and teams can dismiss pull request reviews. Pass an empty `dismissal_restrictions` object to disable. User and team `dismissal_restrictions` are only available for organization-owned repositories. Omit this parameter for personal repositories.",
           "required": false,
-          "type": "object"
+          "location": "body"
         },
-        "4": {
-          "description": "The list of user `login`s with dismissal access",
+        {
           "name": "dismissal_restrictions.users",
+          "type": "string[]",
+          "description": "The list of user `login`s with dismissal access",
           "required": false,
-          "type": "array"
+          "location": "body"
         },
-        "5": {
-          "description": "The list of team `slug`s with dismissal access",
+        {
           "name": "dismissal_restrictions.teams",
+          "type": "string[]",
+          "description": "The list of team `slug`s with dismissal access",
           "required": false,
-          "type": "array"
+          "location": "body"
         },
-        "6": {
-          "description": "Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit.",
+        {
           "name": "dismiss_stale_reviews",
+          "type": "boolean",
+          "description": "Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit.",
           "required": false,
-          "type": "boolean"
+          "location": "body"
         },
-        "7": {
-          "description": "Blocks merging pull requests until code owners have reviewed.",
+        {
           "name": "require_code_owner_reviews",
+          "type": "boolean",
+          "description": "Blocks merging pull requests until code owners have reviewed.",
           "required": false,
-          "type": "boolean"
+          "location": "body"
         },
-        "8": {
-          "description": "Specifies the number of reviewers required to approve pull requests. Use a number between 1 and 6.",
+        {
           "name": "required_approving_review_count",
+          "type": "integer",
+          "description": "Specifies the number of reviewers required to approve pull requests. Use a number between 1 and 6.",
           "required": false,
-          "type": "integer"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews"
     },
     "updateProtectedBranchRequiredStatusChecks": {
@@ -12993,333 +14508,378 @@
       "enabledForApps": true,
       "method": "PATCH",
       "name": "Update required status checks of protected branch",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "owner",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repo",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "2": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "branch",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "3": {
-          "description": "Require branches to be up to date before merging.",
+        {
           "name": "strict",
+          "type": "boolean",
+          "description": "Require branches to be up to date before merging.",
           "required": false,
-          "type": "boolean"
+          "location": "body"
         },
-        "4": {
-          "description": "The list of status checks to require in order to merge into this branch",
+        {
           "name": "contexts",
+          "type": "string[]",
+          "description": "The list of status checks to require in order to merge into this branch",
           "required": false,
-          "type": "array"
+          "location": "body"
         }
-      },
+      ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks"
     },
     "uploadAsset": {
-      "description": "This endpoint makes use of [a Hypermedia relation](/v3/#hypermedia) to determine which URL to access. This endpoint is provided by a URI template in [the release's API response](#get-a-single-release). You need to use an HTTP client which supports [SNI](http://en.wikipedia.org/wiki/Server_Name_Indication) to make calls to this endpoint.\n\nThe asset data is expected in its raw binary form, rather than JSON. Everything else about the endpoint is the same as the rest of the API. For example, you'll still need to pass your authentication to be able to upload an asset.\n\nSend the raw binary content of the asset as the request body.\n\nThis may leave an empty asset with a state of `\"new\"`. It can be safely deleted.",
+      "description": "This endpoint makes use of [a Hypermedia relation](https://developer.github.com/v3/#hypermedia) to determine which URL to access. This endpoint is provided by a URI template in [the release's API response](#get-a-single-release). You need to use an HTTP client which supports [SNI](http://en.wikipedia.org/wiki/Server_Name_Indication) to make calls to this endpoint.\n\nThe asset data is expected in its raw binary form, rather than JSON. Everything else about the endpoint is the same as the rest of the API. For example, you'll still need to pass your authentication to be able to upload an asset.\n\nSend the raw binary content of the asset as the request body.\n\nThis may leave an empty asset with a state of `\"new\"`. It can be safely deleted.",
       "documentationUrl": "https://developer.github.com/v3/repos/releases/#upload-a-release-asset",
       "enabledForApps": true,
+      "isOverride": true,
       "method": "POST",
       "name": "Upload a release asset",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "url",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "description": "The content type of the asset. This should be set in the Header. Example: `\"application/zip\"`. For a list of acceptable types, refer this list of [media types](https://www.iana.org/assignments/media-types/media-types.xhtml).",
+        {
+          "name": "Content-Length",
+          "type": "integer",
+          "description": "The content size of the asset in bytes",
+          "required": true,
+          "location": "headers"
+        },
+        {
           "name": "Content-Type",
+          "type": "string",
+          "description": "The content type of the asset. This should be set in the Header. Example: `\"application/zip\"`. For a list of acceptable types, refer this list of [media types](https://www.iana.org/assignments/media-types/media-types.xhtml).",
           "required": true,
-          "type": "string"
+          "location": "headers"
         },
-        "2": {
-          "description": "The file name of the asset. This should be set in a URI query parameter.",
+        {
           "name": "name",
+          "type": "string",
+          "description": "The file name of the asset. This should be set in a URI query parameter.",
           "required": true,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "description": "An alternate short description of the asset. Used in place of the filename. This should be set in a URI query parameter.",
+        {
           "name": "label",
+          "type": "string",
+          "description": "An alternate short description of the asset. Used in place of the filename. This should be set in a URI query parameter.",
           "required": false,
-          "type": "string"
+          "location": "query"
         }
-      },
+      ],
       "path": ":url"
     }
   },
   "search": {
     "code": {
-      "description": "Find file contents via various criteria. This method returns up to 100 results [per page](/v3/#pagination).\n\n**Note:** You must [authenticate](/v3/#authentication) to search for code across all public repositories.\n\n**Considerations for code search**\n\nDue to the complexity of searching code, there are a few restrictions on how searches are performed:\n\n*   Only the _default branch_ is considered. In most cases, this will be the `master` branch.\n*   Only files smaller than 384 KB are searchable.\n*   You must always include at least one search term when searching source code. For example, searching for [`language:go`](https://github.com/search?utf8=%E2%9C%93&q=language%3Ago&type=Code) is not valid, while [`amazing language:go`](https://github.com/search?utf8=%E2%9C%93&q=amazing+language%3Ago&type=Code) is.\n\nThe `q` search term can also contain any combination of the supported code search qualifiers as described by the in-browser [code search documentation](https://help.github.com/articles/searching-code/) and [search syntax documentation](https://help.github.com/articles/search-syntax/):\n\n*   [`in`](https://help.github.com/articles/searching-code#scope-the-search-fields) Qualifies which fields are searched. With this qualifier you can restrict the search to the file contents (`file`), the file path (`path`), or both.\n*   [`language`](https://help.github.com/articles/searching-code#search-by-language) Searches code based on the language it's written in.\n*   [`fork`](https://help.github.com/articles/searching-code#search-by-the-number-of-forks-the-parent-repository-has) Specifies that code from forked repositories should be searched (`true`). Repository forks will not be searchable unless the fork has more stars than the parent repository.\n*   [`size`](https://help.github.com/articles/searching-code#search-by-the-size-of-the-parent-repository) Finds files that match a certain size (in bytes).\n*   [`path`](https://help.github.com/articles/searching-code#search-by-the-location-of-a-file-within-the-repository) Specifies the path prefix that the resulting file must be under.\n*   [`filename`](https://help.github.com/articles/searching-code#search-by-filename) Matches files by a substring of the filename.\n*   [`extension`](https://help.github.com/articles/searching-code#search-by-the-file-extension) Matches files with a certain extension after a dot.\n*   [`user` or `repo`](https://help.github.com/articles/searching-code#search-within-a-users-or-organizations-repositories) Limits searches to a specific user or repository.\n\nSuppose you want to find the definition of the `addClass` function inside [jQuery](https://github.com/jquery/jquery). Your query would look something like this:\n\n\n\nHere, we're searching for the keyword `addClass` within a file's contents. We're making sure that we're only looking in files where the language is JavaScript. And we're scoping the search to the `repo:jquery/jquery` repository.\n\n**Highlighting code search results**\n\nYou might want to highlight the matching search terms when displaying search results. The API offers additional metadata to support this use case. To get this metadata in your search results, specify the `text-match` media type in your `Accept` header. For example, via cURL, the above query would look like this:\n\nThis produces the same JSON payload as above, with an extra key called `text_matches`, an array of objects. These objects provide information such as the position of your search terms within the text, as well as the `property` that included the search term.\n\nWhen searching for code, you can get text match metadata for the file **content** and file **path** fields. For details on the attributes present in the `text_matches` array, see [text match metadata](#text-match-metadata).\n\nHere's an example response:",
+      "description": "Find file contents via various criteria. This method returns up to 100 results [per page](https://developer.github.com/v3/#pagination).\n\n**Note:** You must [authenticate](https://developer.github.com/v3/#authentication) to search for code across all public repositories.\n\n**Considerations for code search**\n\nDue to the complexity of searching code, there are a few restrictions on how searches are performed:\n\n*   Only the _default branch_ is considered. In most cases, this will be the `master` branch.\n*   Only files smaller than 384 KB are searchable.\n*   You must always include at least one search term when searching source code. For example, searching for [`language:go`](https://github.com/search?utf8=%E2%9C%93&q=language%3Ago&type=Code) is not valid, while [`amazing language:go`](https://github.com/search?utf8=%E2%9C%93&q=amazing+language%3Ago&type=Code) is.\n\nThe `q` search term can also contain any combination of the supported code search qualifiers as described by the in-browser [code search documentation](https://help.github.com/articles/searching-code/) and [search syntax documentation](https://help.github.com/articles/search-syntax/):\n\n*   [`in`](https://help.github.com/articles/searching-code#scope-the-search-fields) Qualifies which fields are searched. With this qualifier you can restrict the search to the file contents (`file`), the file path (`path`), or both.\n*   [`language`](https://help.github.com/articles/searching-code#search-by-language) Searches code based on the language it's written in.\n*   [`fork`](https://help.github.com/articles/searching-code#search-by-the-number-of-forks-the-parent-repository-has) Specifies that code from forked repositories should be searched (`true`). Repository forks will not be searchable unless the fork has more stars than the parent repository.\n*   [`size`](https://help.github.com/articles/searching-code#search-by-the-size-of-the-parent-repository) Finds files that match a certain size (in bytes).\n*   [`path`](https://help.github.com/articles/searching-code#search-by-the-location-of-a-file-within-the-repository) Specifies the path prefix that the resulting file must be under.\n*   [`filename`](https://help.github.com/articles/searching-code#search-by-filename) Matches files by a substring of the filename.\n*   [`extension`](https://help.github.com/articles/searching-code#search-by-the-file-extension) Matches files with a certain extension after a dot.\n*   [`user` or `repo`](https://help.github.com/articles/searching-code#search-within-a-users-or-organizations-repositories) Limits searches to a specific user or repository.\n\nSuppose you want to find the definition of the `addClass` function inside [jQuery](https://github.com/jquery/jquery). Your query would look something like this:\n\nHere, we're searching for the keyword `addClass` within a file's contents. We're making sure that we're only looking in files where the language is JavaScript. And we're scoping the search to the `repo:jquery/jquery` repository.\n\n**Highlighting code search results**\n\nYou might want to highlight the matching search terms when displaying search results. The API offers additional metadata to support this use case. To get this metadata in your search results, specify the `text-match` media type in your `Accept` header. For example, via cURL, the above query would look like this:\n\nThis produces the same JSON payload as above, with an extra key called `text_matches`, an array of objects. These objects provide information such as the position of your search terms within the text, as well as the `property` that included the search term.\n\nWhen searching for code, you can get text match metadata for the file **content** and file **path** fields. For details on the attributes present in the `text_matches` array, see [text match metadata](#text-match-metadata).\n\nHere's an example response:",
       "documentationUrl": "https://developer.github.com/v3/search/#search-code",
       "enabledForApps": true,
       "method": "GET",
       "name": "Search code",
-      "params": {
-        "0": {
-          "description": "The search terms.",
+      "params": [
+        {
           "name": "q",
-          "required": false,
-          "type": "string"
+          "type": "string",
+          "description": "The search terms.",
+          "required": true,
+          "location": "query"
         },
-        "1": {
-          "default": "results are sorted by best match.",
-          "description": "The sort field. Can only be `indexed`, which indicates how recently a file has been indexed by the GitHub search infrastructure.",
+        {
           "name": "sort",
+          "type": "string",
+          "description": "The sort field. Can only be `indexed`, which indicates how recently a file has been indexed by the GitHub search infrastructure.",
+          "default": "results are sorted by best match.",
           "required": false,
-          "type": "string"
+          "enum": [
+            "indexed"
+          ],
+          "location": "query"
         },
-        "2": {
-          "default": "desc",
+        {
+          "name": "order",
+          "type": "string",
           "description": "The sort order if `sort` parameter is provided. One of `asc` or `desc`.",
+          "default": "desc",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "order",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/search/code"
     },
     "commits": {
-      "description": "Find commits via various criteria. This method returns up to 100 results [per page](/v3/#pagination).\n\n**Considerations for commit search**\n\nOnly the _default branch_ is considered. In most cases, this will be the `master` branch.\n\nThe `q` search term can also contain any combination of the supported commit search qualifiers as described by the in-browser [commit search documentation](https://help.github.com/articles/searching-commits/) and [search syntax documentation](https://help.github.com/articles/search-syntax/):\n\n*   [`author`](https://help.github.com/articles/searching-commits#search-by-author-or-committer) Matches commits authored by a user (based on email settings).\n*   [`committer`](https://help.github.com/articles/searching-commits#search-by-author-or-committer) Matches commits committed by a user (based on email settings).\n*   [`author-name`](https://help.github.com/articles/searching-commits#search-by-author-or-committer) Matches commits by author name.\n*   [`committer-name`](https://help.github.com/articles/searching-commits#search-by-author-or-committer) Matches commits by committer name.\n*   [`author-email`](https://help.github.com/articles/searching-commits#search-by-author-or-committer) Matches commits by author email.\n*   [`committer-email`](https://help.github.com/articles/searching-commits#search-by-author-or-committer) Matches commits by committer email.\n*   [`author-date`](https://help.github.com/articles/searching-commits#search-by-authored-or-committed-date) Matches commits by author date range.\n*   [`committer-date`](https://help.github.com/articles/searching-commits/#search-by-authored-or-committed-date) Matches commits by committer date range.\n*   [`merge`](https://help.github.com/articles/searching-commits#filter-merge-commits) `true` filters to merge commits, `false` filters out merge commits.\n*   [`hash`](https://help.github.com/articles/searching-commits#search-by-hash) Matches commits by hash.\n*   [`parent`](https://help.github.com/articles/searching-commits#search-by-parent) Matches commits that have a particular parent.\n*   [`tree`](https://help.github.com/articles/searching-commits#search-by-tree) Matches commits by tree hash.\n*   [`is`](https://help.github.com/articles/searching-commits#filter-to-public-or-private-repositories) Matches `public` or `private` repositories.\n*   [`user`, `org`, or `repo`](https://help.github.com/articles/searching-commits#search-within-a-users-or-organizations-repositories) Limits searches to a specific user, organization, or repository.\n\nSuppose you want to find commits related to CSS in the [octocat/Spoon-Knife](https://github.com/octocat/Spoon-Knife) repository. Your query would look something like this:\n\n\n\n**Highlighting code search results**\n\nWhen searching for commits, you can get text match metadata for the **message** field. See the section on [text match metadata](#text-match-metadata) for full details.",
+      "description": "Find commits via various criteria. This method returns up to 100 results [per page](https://developer.github.com/v3/#pagination).\n\n**Considerations for commit search**\n\nOnly the _default branch_ is considered. In most cases, this will be the `master` branch.\n\nThe `q` search term can also contain any combination of the supported commit search qualifiers as described by the in-browser [commit search documentation](https://help.github.com/articles/searching-commits/) and [search syntax documentation](https://help.github.com/articles/search-syntax/):\n\n*   [`author`](https://help.github.com/articles/searching-commits#search-by-author-or-committer) Matches commits authored by a user (based on email settings).\n*   [`committer`](https://help.github.com/articles/searching-commits#search-by-author-or-committer) Matches commits committed by a user (based on email settings).\n*   [`author-name`](https://help.github.com/articles/searching-commits#search-by-author-or-committer) Matches commits by author name.\n*   [`committer-name`](https://help.github.com/articles/searching-commits#search-by-author-or-committer) Matches commits by committer name.\n*   [`author-email`](https://help.github.com/articles/searching-commits#search-by-author-or-committer) Matches commits by author email.\n*   [`committer-email`](https://help.github.com/articles/searching-commits#search-by-author-or-committer) Matches commits by committer email.\n*   [`author-date`](https://help.github.com/articles/searching-commits#search-by-authored-or-committed-date) Matches commits by author date range.\n*   [`committer-date`](https://help.github.com/articles/searching-commits/#search-by-authored-or-committed-date) Matches commits by committer date range.\n*   [`merge`](https://help.github.com/articles/searching-commits#filter-merge-commits) `true` filters to merge commits, `false` filters out merge commits.\n*   [`hash`](https://help.github.com/articles/searching-commits#search-by-hash) Matches commits by hash.\n*   [`parent`](https://help.github.com/articles/searching-commits#search-by-parent) Matches commits that have a particular parent.\n*   [`tree`](https://help.github.com/articles/searching-commits#search-by-tree) Matches commits by tree hash.\n*   [`is`](https://help.github.com/articles/searching-commits#filter-to-public-or-private-repositories) Matches `public` or `private` repositories.\n*   [`user`, `org`, or `repo`](https://help.github.com/articles/searching-commits#search-within-a-users-or-organizations-repositories) Limits searches to a specific user, organization, or repository.\n\nSuppose you want to find commits related to CSS in the [octocat/Spoon-Knife](https://github.com/octocat/Spoon-Knife) repository. Your query would look something like this:\n\n**Highlighting code search results**\n\nWhen searching for commits, you can get text match metadata for the **message** field. See the section on [text match metadata](#text-match-metadata) for full details.",
       "documentationUrl": "https://developer.github.com/v3/search/#search-commits",
       "enabledForApps": true,
       "method": "GET",
       "name": "Search commits",
-      "params": {
-        "0": {
-          "description": "The search terms.",
+      "params": [
+        {
           "name": "q",
-          "required": false,
-          "type": "string"
+          "type": "string",
+          "description": "The search terms.",
+          "required": true,
+          "location": "query"
         },
-        "1": {
-          "default": "results are sorted by best match.",
+        {
+          "name": "sort",
+          "type": "string",
           "description": "The sort field. Can be `author-date` or `committer-date`.",
+          "default": "results are sorted by best match.",
+          "required": false,
           "enum": [
             "author-date",
             "committer-date"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
-          "default": "desc",
+        {
+          "name": "order",
+          "type": "string",
           "description": "The sort order if `sort` parameter is provided. One of `asc` or `desc`.",
+          "default": "desc",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "order",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/search/commits"
     },
     "issues": {
-      "description": "Find issues by state and keyword. This method returns up to 100 results [per page](/v3/#pagination).\n\nThe `q` search term can also contain any combination of the supported issue search qualifiers as described by the in-browser [issue search documentation](https://help.github.com/articles/searching-issues/) and [search syntax documentation](https://help.github.com/articles/search-syntax/):\n\n*   [`type`](https://help.github.com/articles/searching-issues#search-issues-or-pull-requests) With this qualifier you can restrict the search to issues (`issue`) or pull request (`pr`) only.\n*   [`in`](https://help.github.com/articles/searching-issues#scope-the-search-fields) Qualifies which fields are searched. With this qualifier you can restrict the search to just the title (`title`), body (`body`), comments (`comments`), or any combination of these.\n*   [`author`](https://help.github.com/articles/searching-issues#search-by-the-author-of-an-issue-or-pull-request) Finds issues or pull requests created by a certain user.\n*   [`assignee`](https://help.github.com/articles/searching-issues#search-by-the-assignee-of-an-issue-or-pull-request) Finds issues or pull requests that are assigned to a certain user.\n*   [`mentions`](https://help.github.com/articles/searching-issues#search-by-a-mentioned-user-within-an-issue-or-pull-request) Finds issues or pull requests that mention a certain user.\n*   [`commenter`](https://help.github.com/articles/searching-issues#search-by-a-commenter-within-an-issue-or-pull-request) Finds issues or pull requests that a certain user commented on.\n*   [`involves`](https://help.github.com/articles/searching-issues#search-by-a-user-thats-involved-within-an-issue-or-pull-request) Finds issues or pull requests that were either created by a certain user, assigned to that user, mention that user, or were commented on by that user.\n*   [`team`](https://help.github.com/articles/searching-issues/#search-by-a-team-thats-mentioned-within-an-issue-or-pull-request) For organizations you're a member of, finds issues or pull requests that @mention a team within the organization.\n*   [`state`](https://help.github.com/articles/searching-issues#search-based-on-whether-an-issue-or-pull-request-is-open) Filter issues or pull requests based on whether they're open or closed.\n*   [`labels`](https://help.github.com/articles/searching-issues#search-by-the-labels-on-an-issue) Filters issues or pull requests based on their labels.\n*   [`no`](https://help.github.com/articles/searching-issues#search-by-missing-metadata-on-an-issue-or-pull-request) Filters items missing certain metadata, such as `label`, `milestone`, or `assignee`\n*   [`language`](https://help.github.com/articles/searching-issues#search-by-the-main-language-of-a-repository) Searches for issues or pull requests within repositories that match a certain language.\n*   [`is`](https://help.github.com/articles/searching-issues#search-based-on-the-state-of-an-issue-or-pull-request) Searches for items within repositories that match a certain state, such as `open`, `closed`, or `merged`\n*   [`created` or `updated`](https://help.github.com/articles/searching-issues#search-based-on-when-an-issue-or-pull-request-was-created-or-last-updated) Filters issues or pull requests based on date of creation, or when they were last updated.\n*   [`merged`](https://help.github.com/articles/searching-issues#search-based-on-when-a-pull-request-was-merged) Filters pull requests based on the date when they were merged.\n*   [`status`](https://help.github.com/articles/searching-issues#search-based-on-commit-status) Filters pull requests based on the commit status.\n*   [`head` or `base`](https://help.github.com/articles/searching-issues#search-based-on-branch-names) Filters pull requests based on the branch that they came from or that they are modifying.\n*   [`closed`](https://help.github.com/articles/searching-issues#search-based-on-when-an-issue-or-pull-request-was-closed) Filters issues or pull requests based on the date when they were closed.\n*   [`comments`](https://help.github.com/articles/searching-issues#search-by-the-number-of-comments-an-issue-or-pull-request-has) Filters issues or pull requests based on the quantity of comments.\n*   [`user` or `repo`](https://help.github.com/articles/searching-issues#search-within-a-users-or-organizations-repositories) Limits searches to a specific user or repository.\n*   [`project`](https://help.github.com/articles/searching-issues/#search-by-project-board) Limits searches to a specific project board in a repository or organization.\n*   [`archived`](https://help.github.com/articles/searching-issues/#search-within-archived-repositories) Filters issues or pull requests based on whether they are in an archived repository.\n\nIf you know the specific SHA hash of a commit, you can use also [use it to search for pull requests](https://help.github.com/articles/searching-issues#search-by-the-commit-shas-within-a-pull-request) that contain that SHA. Note that the SHA syntax must be at least seven characters.\n\nLet's say you want to find the oldest unresolved Python bugs on Windows. Your query might look something like this.\n\n\n\nIn this query, we're searching for the keyword `windows`, within any open issue that's labeled as `bug`. The search runs across repositories whose primary language is Python. We’re sorting by creation date in ascending order, so that the oldest issues appear first in the search results.\n\n**Highlighting issue search results**\n\nYou might want to highlight the matching search terms when displaying search results. The API offers additional metadata to support this use case. To get this metadata in your search results, specify the `text-match` media type in your `Accept` header. For example, via cURL, the above query would look like this:\n\nThis produces the same JSON payload as above, with an extra key called `text_matches`, an array of objects. These objects provide information such as the position of your search terms within the text, as well as the `property` that included the search term.\n\nWhen searching for issues, you can get text match metadata for the issue **title**, issue **body**, and issue **comment body** fields. For details on the attributes present in the `text_matches` array, see [text match metadata](#text-match-metadata).\n\nHere's an example response:",
+      "description": "Find issues by state and keyword. This method returns up to 100 results [per page](https://developer.github.com/v3/#pagination).\n\nThe `q` search term can also contain any combination of the supported issue search qualifiers as described by the in-browser [issue search documentation](https://help.github.com/articles/searching-issues/) and [search syntax documentation](https://help.github.com/articles/search-syntax/):\n\n*   [`type`](https://help.github.com/articles/searching-issues#search-issues-or-pull-requests) With this qualifier you can restrict the search to issues (`issue`) or pull request (`pr`) only.\n*   [`in`](https://help.github.com/articles/searching-issues#scope-the-search-fields) Qualifies which fields are searched. With this qualifier you can restrict the search to just the title (`title`), body (`body`), comments (`comments`), or any combination of these.\n*   [`author`](https://help.github.com/articles/searching-issues#search-by-the-author-of-an-issue-or-pull-request) Finds issues or pull requests created by a certain user.\n*   [`assignee`](https://help.github.com/articles/searching-issues#search-by-the-assignee-of-an-issue-or-pull-request) Finds issues or pull requests that are assigned to a certain user.\n*   [`mentions`](https://help.github.com/articles/searching-issues#search-by-a-mentioned-user-within-an-issue-or-pull-request) Finds issues or pull requests that mention a certain user.\n*   [`commenter`](https://help.github.com/articles/searching-issues#search-by-a-commenter-within-an-issue-or-pull-request) Finds issues or pull requests that a certain user commented on.\n*   [`involves`](https://help.github.com/articles/searching-issues#search-by-a-user-thats-involved-within-an-issue-or-pull-request) Finds issues or pull requests that were either created by a certain user, assigned to that user, mention that user, or were commented on by that user.\n*   [`team`](https://help.github.com/articles/searching-issues/#search-by-a-team-thats-mentioned-within-an-issue-or-pull-request) For organizations you're a member of, finds issues or pull requests that @mention a team within the organization.\n*   [`state`](https://help.github.com/articles/searching-issues#search-based-on-whether-an-issue-or-pull-request-is-open) Filter issues or pull requests based on whether they're open or closed.\n*   [`labels`](https://help.github.com/articles/searching-issues#search-by-the-labels-on-an-issue) Filters issues or pull requests based on their labels.\n*   [`no`](https://help.github.com/articles/searching-issues#search-by-missing-metadata-on-an-issue-or-pull-request) Filters items missing certain metadata, such as `label`, `milestone`, or `assignee`\n*   [`language`](https://help.github.com/articles/searching-issues#search-by-the-main-language-of-a-repository) Searches for issues or pull requests within repositories that match a certain language.\n*   [`is`](https://help.github.com/articles/searching-issues#search-based-on-the-state-of-an-issue-or-pull-request) Searches for items within repositories that match a certain state, such as `open`, `closed`, or `merged`\n*   [`created` or `updated`](https://help.github.com/articles/searching-issues#search-based-on-when-an-issue-or-pull-request-was-created-or-last-updated) Filters issues or pull requests based on date of creation, or when they were last updated.\n*   [`merged`](https://help.github.com/articles/searching-issues#search-based-on-when-a-pull-request-was-merged) Filters pull requests based on the date when they were merged.\n*   [`status`](https://help.github.com/articles/searching-issues#search-based-on-commit-status) Filters pull requests based on the commit status.\n*   [`head` or `base`](https://help.github.com/articles/searching-issues#search-based-on-branch-names) Filters pull requests based on the branch that they came from or that they are modifying.\n*   [`closed`](https://help.github.com/articles/searching-issues#search-based-on-when-an-issue-or-pull-request-was-closed) Filters issues or pull requests based on the date when they were closed.\n*   [`comments`](https://help.github.com/articles/searching-issues#search-by-the-number-of-comments-an-issue-or-pull-request-has) Filters issues or pull requests based on the quantity of comments.\n*   [`user` or `repo`](https://help.github.com/articles/searching-issues#search-within-a-users-or-organizations-repositories) Limits searches to a specific user or repository.\n*   [`project`](https://help.github.com/articles/searching-issues/#search-by-project-board) Limits searches to a specific project board in a repository or organization.\n*   [`archived`](https://help.github.com/articles/searching-issues/#search-within-archived-repositories) Filters issues or pull requests based on whether they are in an archived repository.\n\nIf you know the specific SHA hash of a commit, you can use also [use it to search for pull requests](https://help.github.com/articles/searching-issues#search-by-the-commit-shas-within-a-pull-request) that contain that SHA. Note that the SHA syntax must be at least seven characters.\n\nLet's say you want to find the oldest unresolved Python bugs on Windows. Your query might look something like this.\n\nIn this query, we're searching for the keyword `windows`, within any open issue that's labeled as `bug`. The search runs across repositories whose primary language is Python. We’re sorting by creation date in ascending order, so that the oldest issues appear first in the search results.\n\n**Highlighting issue search results**\n\nYou might want to highlight the matching search terms when displaying search results. The API offers additional metadata to support this use case. To get this metadata in your search results, specify the `text-match` media type in your `Accept` header. For example, via cURL, the above query would look like this:\n\nThis produces the same JSON payload as above, with an extra key called `text_matches`, an array of objects. These objects provide information such as the position of your search terms within the text, as well as the `property` that included the search term.\n\nWhen searching for issues, you can get text match metadata for the issue **title**, issue **body**, and issue **comment body** fields. For details on the attributes present in the `text_matches` array, see [text match metadata](#text-match-metadata).\n\nHere's an example response:",
       "documentationUrl": "https://developer.github.com/v3/search/#search-issues",
       "enabledForApps": true,
       "method": "GET",
       "name": "Search issues",
-      "params": {
-        "0": {
-          "description": "The search terms.",
+      "params": [
+        {
           "name": "q",
-          "required": false,
-          "type": "string"
+          "type": "string",
+          "description": "The search terms.",
+          "required": true,
+          "location": "query"
         },
-        "1": {
-          "default": "results are sorted by best match.",
+        {
+          "name": "sort",
+          "type": "string",
           "description": "The sort field. Can be `comments`, `created`, or `updated`.",
+          "default": "results are sorted by best match.",
+          "required": false,
           "enum": [
             "comments",
             "created",
             "updated"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
-          "default": "desc",
+        {
+          "name": "order",
+          "type": "string",
           "description": "The sort order if `sort` parameter is provided. One of `asc` or `desc`.",
+          "default": "desc",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "order",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/search/issues"
     },
     "repos": {
-      "description": "Find repositories via various criteria. This method returns up to 100 results [per page](/v3/#pagination).\n\nThe `q` search term can also contain any combination of the supported repository search qualifiers as described by the in-browser [repository search documentation](https://help.github.com/articles/searching-repositories/) and [search syntax documentation](https://help.github.com/articles/search-syntax/):\n\n*   [`created` or `pushed`](https://help.github.com/articles/searching-repositories#search-based-on-when-a-repository-was-created-or-last-updated) Filters repositories based on date of creation, or when they were last updated.\n*   [`fork`](https://help.github.com/articles/searching-repositories#search-based-on-the-number-of-forks-the-parent-repository-has) Filters whether forked repositories should be included (`true`) or only forked repositories should be returned (`only`).\n*   [`forks`](https://help.github.com/articles/searching-repositories#search-based-on-the-number-of-forks-the-parent-repository-has) Filters repositories based on the number of forks.\n*   [`in`](https://help.github.com/articles/searching-repositories#scope-the-search-fields) Qualifies which fields are searched. With this qualifier you can restrict the search to just the repository name, description, readme, or any combination of these.\n*   [`language`](https://help.github.com/articles/searching-repositories#search-based-on-the-main-language-of-a-repository) Searches repositories based on the language they're written in.\n*   [`license`](https://help.github.com/articles/searching-repositories#search-by-license) Filters repositories by license or license family, using the [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type).\n*   [`repo` or `user`](https://help.github.com/articles/searching-repositories#search-within-a-users-or-organizations-repositories) Limits searches to a specific repository or user.\n*   [`size`](https://help.github.com/articles/searching-repositories#search-based-on-the-size-of-a-repository) Finds repositories that match a certain size (in kilobytes).\n*   [`stars`](https://help.github.com/articles/searching-repositories#search-based-on-the-number-of-stars-a-repository-has) Searches repositories based on the number of stars.\n*   [`topic`](https://help.github.com/articles/classifying-your-repository-with-topics/) Filters repositories based on the specified topic.\n*   [`archived`](https://help.github.com/articles/searching-repositories/#search-based-on-whether-a-repository-is-archived) Filters whether archived repositories should be included (`true`) or not (`false`).\n    \n    You can search for multiple topics by adding more `topic:` instances. For example:\n    \n    ```\n    curl -H \"Authentication: token TOKEN\" \\\n    -H \"Accept: application/vnd.github.mercy-preview+json\" \\\n    https://api.github.com/search/repositories?q=topic:ruby+topic:rails\n    \n    ```\n\nSuppose you want to search for popular Tetris repositories written in Assembly. Your query might look like this.\n\n\n\nIn this request, we're searching for repositories with the word `tetris` in the name, the description, or the README. We're limiting the results to only find repositories where the primary language is Assembly. We're sorting by stars in descending order, so that the most popular repositories appear first in the search results.\n\n**Highlighting repository search results**\n\nYou might want to highlight the matching search terms when displaying search results. The API offers additional metadata to support this use case. To get this metadata in your search results, specify the `text-match` media type in your `Accept` header. For example, via cURL, the above query would look like this:\n\nThis produces the same JSON payload as above, with an extra key called `text_matches`, an array of objects. These objects provide information such as the position of your search terms within the text, as well as the `property` that included the search term.\n\nWhen searching for repositories, you can get text match metadata for the **name** and **description** fields. For details on the attributes present in the `text_matches` array, see [text match metadata](#text-match-metadata).\n\nHere's an example response:",
+      "description": "Find repositories via various criteria. This method returns up to 100 results [per page](https://developer.github.com/v3/#pagination).\n\nThe `q` search term can also contain any combination of the supported repository search qualifiers as described by the in-browser [repository search documentation](https://help.github.com/articles/searching-repositories/) and [search syntax documentation](https://help.github.com/articles/search-syntax/):\n\n*   [`created` or `pushed`](https://help.github.com/articles/searching-repositories#search-based-on-when-a-repository-was-created-or-last-updated) Filters repositories based on date of creation, or when they were last updated.\n*   [`fork`](https://help.github.com/articles/searching-repositories#search-based-on-the-number-of-forks-the-parent-repository-has) Filters whether forked repositories should be included (`true`) or only forked repositories should be returned (`only`).\n*   [`forks`](https://help.github.com/articles/searching-repositories#search-based-on-the-number-of-forks-the-parent-repository-has) Filters repositories based on the number of forks.\n*   [`in`](https://help.github.com/articles/searching-repositories#scope-the-search-fields) Qualifies which fields are searched. With this qualifier you can restrict the search to just the repository name, description, readme, or any combination of these.\n*   [`language`](https://help.github.com/articles/searching-repositories#search-based-on-the-main-language-of-a-repository) Searches repositories based on the language they're written in.\n*   [`license`](https://help.github.com/articles/searching-repositories#search-by-license) Filters repositories by license or license family, using the [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type).\n*   [`repo` or `user`](https://help.github.com/articles/searching-repositories#search-within-a-users-or-organizations-repositories) Limits searches to a specific repository or user.\n*   [`size`](https://help.github.com/articles/searching-repositories#search-based-on-the-size-of-a-repository) Finds repositories that match a certain size (in kilobytes).\n*   [`stars`](https://help.github.com/articles/searching-repositories#search-based-on-the-number-of-stars-a-repository-has) Searches repositories based on the number of stars.\n*   [`topic`](https://help.github.com/articles/classifying-your-repository-with-topics/) Filters repositories based on the specified topic.\n*   [`archived`](https://help.github.com/articles/searching-repositories/#search-based-on-whether-a-repository-is-archived) Filters whether archived repositories should be included (`true`) or not (`false`).\n\nSuppose you want to search for popular Tetris repositories written in Assembly. Your query might look like this.\n\nYou can search for multiple topics by adding more `topic:` instances, and including the `mercy-preview` header. For example:\n\nIn this request, we're searching for repositories with the word `tetris` in the name, the description, or the README. We're limiting the results to only find repositories where the primary language is Assembly. We're sorting by stars in descending order, so that the most popular repositories appear first in the search results.\n\n**Highlighting repository search results**\n\nYou might want to highlight the matching search terms when displaying search results. The API offers additional metadata to support this use case. To get this metadata in your search results, specify the `text-match` media type in your `Accept` header. For example, via cURL, the above query would look like this:\n\nThis produces the same JSON payload as above, with an extra key called `text_matches`, an array of objects. These objects provide information such as the position of your search terms within the text, as well as the `property` that included the search term.\n\nWhen searching for repositories, you can get text match metadata for the **name** and **description** fields. For details on the attributes present in the `text_matches` array, see [text match metadata](#text-match-metadata).\n\nHere's an example response:",
       "documentationUrl": "https://developer.github.com/v3/search/#search-repositories",
       "enabledForApps": true,
       "method": "GET",
       "name": "Search repositories",
-      "params": {
-        "0": {
-          "description": "The search keywords, as well as any qualifiers.",
+      "params": [
+        {
           "name": "q",
-          "required": false,
-          "type": "string"
+          "type": "string",
+          "description": "The search keywords, as well as any qualifiers.",
+          "required": true,
+          "location": "query"
         },
-        "1": {
-          "default": "results are sorted by best match.",
+        {
+          "name": "sort",
+          "type": "string",
           "description": "The sort field. One of `stars`, `forks`, or `updated`.",
+          "default": "results are sorted by best match.",
+          "required": false,
           "enum": [
             "stars",
             "forks",
             "updated"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
-          "default": "desc",
+        {
+          "name": "order",
+          "type": "string",
           "description": "The sort order if `sort` parameter is provided. One of `asc` or `desc`.",
+          "default": "desc",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "order",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/search/repositories"
     },
     "users": {
-      "description": "Find users via various criteria. This method returns up to 100 results [per page](/v3/#pagination).\n\nThe `q` search term can also contain any combination of the supported user search qualifiers as described by the in-browser [user search documentation](https://help.github.com/articles/searching-users/) and [search syntax documentation](https://help.github.com/articles/search-syntax/):\n\n*   [`type`](https://help.github.com/articles/searching-users#search-for-users-or-organizations) With this qualifier you can restrict the search to just personal accounts (`user`) or just organization accounts (`org`).\n*   [`in`](https://help.github.com/articles/searching-users#scope-the-search-fields) Qualifies which fields are searched. With this qualifier you can restrict the search to just the username (`login`), public email (`email`), full name (`fullname`), or any combination of these.\n*   [`repos`](https://help.github.com/articles/searching-users#search-based-on-the-number-of-repositories-a-user-has) Filters users based on the number of repositories they have.\n*   [`location`](https://help.github.com/articles/searching-users#search-based-on-the-location-where-a-user-resides) Filter users by the location indicated in their profile.\n*   [`language`](https://help.github.com/articles/searching-users#search-based-on-the-languages-of-a-users-repositories) Search for users that have repositories that match a certain language.\n*   [`created`](https://help.github.com/articles/searching-users#search-based-on-when-a-user-joined-github) Filter users based on when they joined.\n*   [`followers`](https://help.github.com/articles/searching-users#search-based-on-the-number-of-followers-a-user-has) Filter users based on the number of followers they have.\n\nImagine you're looking for a list of popular users. You might try out this query:\n\n\n\nHere, we're looking at users with the name Tom. We're only interested in those with more than 42 repositories, and only if they have over 1,000 followers.\n\n**Highlighting user search results**\n\nYou might want to highlight the matching search terms when displaying search results. The API offers additional metadata to support this use case. To get this metadata in your search results, specify the `text-match` media type in your `Accept` header. For example, via cURL, the above query would look like this:\n\nThis produces the same JSON payload as above, with an extra key called `text_matches`, an array of objects. These objects provide information such as the position of your search terms within the text, as well as the `property` that included the search term.\n\nWhen searching for users, you can get text match metadata for the issue **login**, **email**, and **name** fields. For details on the attributes present in the `text_matches` array, see [text match metadata](#text-match-metadata).",
+      "description": "Find users via various criteria. This method returns up to 100 results [per page](https://developer.github.com/v3/#pagination).\n\nThe `q` search term can also contain any combination of the supported user search qualifiers as described by the in-browser [user search documentation](https://help.github.com/articles/searching-users/) and [search syntax documentation](https://help.github.com/articles/search-syntax/):\n\n*   [`type`](https://help.github.com/articles/searching-users#search-for-users-or-organizations) With this qualifier you can restrict the search to just personal accounts (`user`) or just organization accounts (`org`).\n*   [`in`](https://help.github.com/articles/searching-users#scope-the-search-fields) Qualifies which fields are searched. With this qualifier you can restrict the search to just the username (`login`), public email (`email`), full name (`fullname`), or any combination of these.\n*   [`repos`](https://help.github.com/articles/searching-users#search-based-on-the-number-of-repositories-a-user-has) Filters users based on the number of repositories they have.\n*   [`location`](https://help.github.com/articles/searching-users#search-based-on-the-location-where-a-user-resides) Filter users by the location indicated in their profile.\n*   [`language`](https://help.github.com/articles/searching-users#search-based-on-the-languages-of-a-users-repositories) Search for users that have repositories that match a certain language.\n*   [`created`](https://help.github.com/articles/searching-users#search-based-on-when-a-user-joined-github) Filter users based on when they joined.\n*   [`followers`](https://help.github.com/articles/searching-users#search-based-on-the-number-of-followers-a-user-has) Filter users based on the number of followers they have.\n\nImagine you're looking for a list of popular users. You might try out this query:\n\nHere, we're looking at users with the name Tom. We're only interested in those with more than 42 repositories, and only if they have over 1,000 followers.\n\n**Highlighting user search results**\n\nYou might want to highlight the matching search terms when displaying search results. The API offers additional metadata to support this use case. To get this metadata in your search results, specify the `text-match` media type in your `Accept` header. For example, via cURL, the above query would look like this:\n\nThis produces the same JSON payload as above, with an extra key called `text_matches`, an array of objects. These objects provide information such as the position of your search terms within the text, as well as the `property` that included the search term.\n\nWhen searching for users, you can get text match metadata for the issue **login**, **email**, and **name** fields. For details on the attributes present in the `text_matches` array, see [text match metadata](#text-match-metadata).",
       "documentationUrl": "https://developer.github.com/v3/search/#search-users",
       "enabledForApps": true,
       "method": "GET",
       "name": "Search users",
-      "params": {
-        "0": {
-          "description": "The search terms.",
+      "params": [
+        {
           "name": "q",
-          "required": false,
-          "type": "string"
+          "type": "string",
+          "description": "The search terms.",
+          "required": true,
+          "location": "query"
         },
-        "1": {
-          "default": "results are sorted by best match.",
+        {
+          "name": "sort",
+          "type": "string",
           "description": "The sort field. Can be `followers`, `repositories`, or `joined`.",
+          "default": "results are sorted by best match.",
+          "required": false,
           "enum": [
             "followers",
             "repositories",
             "joined"
           ],
-          "name": "sort",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "2": {
-          "default": "desc",
+        {
+          "name": "order",
+          "type": "string",
           "description": "The sort order if `sort` parameter is provided. One of `asc` or `desc`.",
+          "default": "desc",
+          "required": false,
           "enum": [
             "asc",
             "desc"
           ],
-          "name": "order",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "3": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "4": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/search/users"
     }
   },
@@ -13330,14 +14890,15 @@
       "enabledForApps": false,
       "method": "PATCH",
       "name": "Accept a repository invitation",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "invitation_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/repository_invitations/:invitation_id"
     },
     "addEmails": {
@@ -13346,7 +14907,7 @@
       "enabledForApps": false,
       "method": "POST",
       "name": "Add email address(es)",
-      "params": {},
+      "params": [],
       "path": "/user/emails"
     },
     "addRepoToInstallation": {
@@ -13355,20 +14916,22 @@
       "enabledForApps": false,
       "method": "PUT",
       "name": "Add repository to installation",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "installation_id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repository_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/installations/:installation_id/repositories/:repository_id"
     },
     "blockUser": {
@@ -13377,14 +14940,15 @@
       "enabledForApps": false,
       "method": "PUT",
       "name": "Block a user",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/blocks/:username"
     },
     "checkBlockedUser": {
@@ -13393,14 +14957,15 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Check whether you've blocked a user",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/blocks/:username"
     },
     "checkFollowing": {
@@ -13409,54 +14974,57 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Check if you are following a user",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/following/:username"
     },
     "checkIfOneFollowersOther": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/users/followers/#check-if-one-user-follows-another",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "Check if one user follows another",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "target_user",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/users/:username/following/:target_user"
     },
     "createGpgKey": {
-      "description": "Creates a GPG key. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:gpg_key` [scope](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
+      "description": "Creates a GPG key. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:gpg_key` [scope](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
       "documentationUrl": "https://developer.github.com/v3/users/gpg_keys/#create-a-gpg-key",
       "enabledForApps": false,
       "method": "POST",
       "name": "Create a GPG key",
-      "params": {},
+      "params": [],
       "path": "/user/gpg_keys"
     },
     "createKey": {
-      "description": "Creates a public key. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
+      "description": "Creates a public key. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
       "documentationUrl": "https://developer.github.com/v3/users/keys/#create-a-public-key",
       "enabledForApps": false,
       "method": "POST",
       "name": "Create a public key",
-      "params": {},
+      "params": [],
       "path": "/user/keys"
     },
     "declineRepoInvite": {
@@ -13465,14 +15033,15 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Decline a repository invitation",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "invitation_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/repository_invitations/:invitation_id"
     },
     "deleteEmails": {
@@ -13481,39 +15050,41 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Delete email address(es)",
-      "params": {},
+      "params": [],
       "path": "/user/emails"
     },
     "deleteGpgKey": {
-      "description": "Removes a GPG key. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:gpg_key` [scope](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
+      "description": "Removes a GPG key. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:gpg_key` [scope](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
       "documentationUrl": "https://developer.github.com/v3/users/gpg_keys/#delete-a-gpg-key",
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Delete a GPG key",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/gpg_keys/:id"
     },
     "deleteKey": {
-      "description": "Removes a public key. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
+      "description": "Removes a public key. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
       "documentationUrl": "https://developer.github.com/v3/users/keys/#delete-a-public-key",
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Delete a public key",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/keys/:id"
     },
     "editOrgMembership": {
@@ -13522,36 +15093,42 @@
       "enabledForApps": false,
       "method": "PATCH",
       "name": "Edit your organization membership",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "description": "The state that the membership should be in. Only `\"active\"` will be accepted.",
+        {
           "name": "state",
+          "type": "string",
+          "description": "The state that the membership should be in. Only `\"active\"` will be accepted.",
           "required": true,
-          "type": "string"
+          "enum": [
+            "active"
+          ],
+          "location": "body"
         }
-      },
+      ],
       "path": "/user/memberships/orgs/:org"
     },
     "followUser": {
-      "description": "Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](/v3/#http-verbs).\"\n\nFollowing a user requires the user to be logged in and authenticated with basic auth or OAuth with the `user:follow` scope.",
+      "description": "Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see \"[HTTP verbs](https://developer.github.com/v3/#http-verbs).\"\n\nFollowing a user requires the user to be logged in and authenticated with basic auth or OAuth with the `user:follow` scope.",
       "documentationUrl": "https://developer.github.com/v3/users/followers/#follow-a-user",
       "enabledForApps": false,
       "method": "PUT",
       "name": "Follow a user",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/following/:username"
     },
     "get": {
@@ -13560,37 +15137,40 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Get the authenticated user",
-      "params": {},
+      "params": [],
       "path": "/user"
     },
     "getAll": {
-      "description": "Lists all users, in the order that they signed up on GitHub. This list includes personal user accounts and organization accounts.\n\nNote: Pagination is powered exclusively by the `since` parameter. Use the [Link header](/v3/#link-header) to get the URL for the next page of users.",
+      "description": "Lists all users, in the order that they signed up on GitHub. This list includes personal user accounts and organization accounts.\n\nNote: Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://developer.github.com/v3/#link-header) to get the URL for the next page of users.",
       "documentationUrl": "https://developer.github.com/v3/users/#get-all-users",
       "enabledForApps": true,
       "method": "GET",
       "name": "Get all users",
-      "params": {
-        "0": {
-          "description": "The integer ID of the last User that you've seen.",
+      "params": [
+        {
           "name": "since",
+          "type": "string",
+          "description": "The integer ID of the last User that you've seen.",
           "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/users"
     },
     "getBlockedUsers": {
@@ -13599,225 +15179,244 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List blocked users",
-      "params": {},
+      "params": [],
       "path": "/user/blocks"
     },
     "getEmails": {
-      "description": "This endpoint is accessible with the user:email scope.",
+      "description": "Lists all of your email addresses, and specifies which one is visible to the public. This endpoint is accessible with the `user:email` scope.",
       "documentationUrl": "https://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user",
       "enabledForApps": false,
       "method": "GET",
       "name": "List email addresses for a user",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/user/emails"
     },
     "getFollowers": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/users/followers/#list-followers-of-a-user",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "List the authenticated user's followers",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/user/followers"
     },
     "getFollowersForUser": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/users/followers/#list-followers-of-a-user",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "List a user's followers",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/users/:username/followers"
     },
     "getFollowing": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/users/followers/#list-users-followed-by-another-user",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "List who the authenticated user is following",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/user/following"
     },
     "getFollowingForUser": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/users/followers/#list-users-followed-by-another-user",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "List who a user is following",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/users/:username/following"
     },
     "getForUser": {
-      "description": "Note: The returned email is the user's publicly visible email address (or `null` if the user has not [specified a public email address in their profile](https://github.com/settings/profile)). The publicly visible email address only displays for authenticated API users.",
+      "description": "Provides publicly available information about someone with a GitHub account.\n\nThe `email` key in the following response is the publicly visible email address from your GitHub [profile page](https://github.com/settings/profile). When setting up your profile, you can select a primary email address to be “public” which provides an email entry for this endpoint. If you do not set a public email address for `email`, then it will have a value of `null`. You only see publicly visible email addresses when authenticated with GitHub. For more information, see [Authentication](https://developer.github.com/v3/#authentication).\n\nThe Emails API enables you to list all of your email addresses, and toggle a primary email to be visible publicly. For more information, see \"[Emails API](https://developer.github.com/v3/users/emails/)\".",
       "documentationUrl": "https://developer.github.com/v3/users/#get-a-single-user",
       "enabledForApps": true,
       "method": "GET",
       "name": "Get a single user",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/users/:username"
     },
     "getGpgKey": {
-      "description": "View extended details for a single GPG key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:gpg_key` [scope](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
+      "description": "View extended details for a single GPG key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:gpg_key` [scope](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
       "documentationUrl": "https://developer.github.com/v3/users/gpg_keys/#get-a-single-gpg-key",
       "enabledForApps": false,
       "method": "GET",
       "name": "Get a single GPG key",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/gpg_keys/:id"
     },
     "getGpgKeys": {
-      "description": "Lists the current user's GPG keys. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:gpg_key` [scope](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
+      "description": "Lists the current user's GPG keys. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:gpg_key` [scope](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
       "documentationUrl": "https://developer.github.com/v3/users/gpg_keys/#list-your-gpg-keys",
       "enabledForApps": false,
       "method": "GET",
       "name": "List your GPG keys",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/user/gpg_keys"
     },
     "getGpgKeysForUser": {
       "description": "Lists the GPG keys for a user. This information is accessible by anyone.",
       "documentationUrl": "https://developer.github.com/v3/users/gpg_keys/#list-gpg-keys-for-a-user",
-      "enabledForApps": false,
+      "enabledForApps": true,
       "method": "GET",
       "name": "List GPG keys for a user",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/users/:username/gpg_keys"
     },
     "getInstallationRepos": {
@@ -13826,28 +15425,31 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List repositories accessible to the user for an installation",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "installation_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/user/installations/:installation_id/repositories"
     },
     "getInstallations": {
@@ -13856,62 +15458,67 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List installations for user",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/user/installations"
     },
     "getKey": {
-      "description": "View extended details for a single public key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
+      "description": "View extended details for a single public key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
       "documentationUrl": "https://developer.github.com/v3/users/keys/#get-a-single-public-key",
       "enabledForApps": false,
       "method": "GET",
       "name": "Get a single public key",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/keys/:id"
     },
     "getKeys": {
-      "description": "Lists the current user's keys. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
+      "description": "Lists the current user's keys. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).",
       "documentationUrl": "https://developer.github.com/v3/users/keys/#list-your-public-keys",
       "enabledForApps": false,
       "method": "GET",
       "name": "List your public keys",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/user/keys"
     },
     "getKeysForUser": {
@@ -13920,76 +15527,83 @@
       "enabledForApps": true,
       "method": "GET",
       "name": "List public keys for a user",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/users/:username/keys"
     },
     "getMarketplacePurchases": {
-      "description": "**Note:** This call must be authenticated with a user's OAuth token.",
+      "description": "Returns only active subscriptions. You need to authenticate this call with the user's OAuth token.",
       "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#get-a-users-marketplace-purchases",
       "enabledForApps": false,
       "method": "GET",
       "name": "Get a user's Marketplace purchases",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/user/marketplace_purchases"
     },
     "getMarketplaceStubbedPurchases": {
-      "description": "**Note:** This call must be authenticated with a user's OAuth token.",
+      "description": "Returns only active subscriptions. You need to authenticate this call with the user's OAuth token.",
       "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#get-a-users-marketplace-purchases",
       "enabledForApps": false,
       "method": "GET",
       "name": "Get a user's Marketplace purchases (stubbed)",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/user/marketplace_purchases/stubbed"
     },
     "getOrgMembership": {
@@ -13998,14 +15612,15 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "Get your organization membership",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "org",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/memberships/orgs/:org"
     },
     "getOrgMemberships": {
@@ -14014,32 +15629,35 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List your organization memberships",
-      "params": {
-        "0": {
+      "params": [
+        {
+          "name": "state",
+          "type": "string",
           "description": "Indicates the state of the memberships to return. Can be either `active` or `pending`. If not specified, the API returns both active and pending memberships.",
+          "required": false,
           "enum": [
             "active",
             "pending"
           ],
-          "name": "state",
-          "required": false,
-          "type": "string"
+          "location": "query"
         },
-        "1": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "2": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/user/memberships/orgs"
     },
     "getOrgs": {
@@ -14048,46 +15666,50 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List your organizations",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/user/orgs"
     },
     "getPublicEmails": {
-      "description": "This endpoint is accessible with the `user:email` scope.",
+      "description": "Lists your publicly visible email address, which you can set with the [Toggle primary email visibility](#toggle-primary-email-visibility) endpoint. This endpoint is accessible with the `user:email` scope.",
       "documentationUrl": "https://developer.github.com/v3/users/emails/#list-public-email-addresses-for-a-user",
       "enabledForApps": false,
       "method": "GET",
       "name": "List public email addresses for a user",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/user/public_emails"
     },
     "getRepoInvites": {
@@ -14096,46 +15718,50 @@
       "enabledForApps": false,
       "method": "GET",
       "name": "List a user's repository invitations",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/user/repository_invitations"
     },
     "getTeams": {
-      "description": "List all of the teams across all of the organizations to which the authenticated user belongs. This method requires `user`, `repo`, or `read:org` [scope](/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/) when authenticating via [OAuth](/apps/building-integrations/setting-up-and-registering-oauth-apps/).",
+      "description": "List all of the teams across all of the organizations to which the authenticated user belongs. This method requires `user`, `repo`, or `read:org` [scope](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/) when authenticating via [OAuth](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/).",
       "documentationUrl": "https://developer.github.com/v3/teams/#list-user-teams",
       "enabledForApps": false,
       "method": "GET",
       "name": "List user teams",
-      "params": {
-        "0": {
-          "default": 30,
-          "description": "Results per page (max 100)",
+      "params": [
+        {
           "name": "per_page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
         },
-        "1": {
-          "default": 1,
-          "description": "Page number of the results to fetch.",
+        {
           "name": "page",
+          "type": "integer",
           "required": false,
-          "type": "integer"
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
         }
-      },
+      ],
       "path": "/user/teams"
     },
     "removeRepoFromInstallation": {
@@ -14144,29 +15770,46 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Remove repository from installation",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "installation_id",
+          "type": "string",
           "required": true,
-          "type": "string"
-        },
-        "1": {
           "description": "",
+          "location": "url"
+        },
+        {
           "name": "repository_id",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/installations/:installation_id/repositories/:repository_id"
     },
     "togglePrimaryEmailVisibility": {
-      "description": "",
+      "description": "Sets the visibility for your primary email addresses.",
       "documentationUrl": "https://developer.github.com/v3/users/emails/#toggle-primary-email-visibility",
       "enabledForApps": false,
       "method": "PATCH",
       "name": "Toggle primary email visibility",
-      "params": {},
+      "params": [
+        {
+          "name": "email",
+          "type": "string",
+          "description": "Specify the _primary_ email address that needs a visibility change.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "visibility",
+          "type": "string",
+          "description": "Use `public` to enable an authenticated user to view the specified email address, or use `private` so this primary email address cannot be seen publicly.",
+          "required": true,
+          "location": "body"
+        }
+      ],
       "path": "/user/email/visibility"
     },
     "unblockUser": {
@@ -14175,14 +15818,15 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Unblock a user",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/blocks/:username"
     },
     "unfollowUser": {
@@ -14191,14 +15835,15 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Unfollow a user",
-      "params": {
-        "0": {
-          "description": "",
+      "params": [
+        {
           "name": "username",
+          "type": "string",
           "required": true,
-          "type": "string"
+          "description": "",
+          "location": "url"
         }
-      },
+      ],
       "path": "/user/following/:username"
     },
     "update": {
@@ -14207,50 +15852,57 @@
       "enabledForApps": false,
       "method": "PATCH",
       "name": "Update the authenticated user",
-      "params": {
-        "0": {
-          "description": "The new name of the user.",
+      "params": [
+        {
           "name": "name",
+          "type": "string",
+          "description": "The new name of the user.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "1": {
-          "description": "The publicly visible email address of the user.",
+        {
           "name": "email",
+          "type": "string",
+          "description": "The publicly visible email address of the user.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "2": {
-          "description": "The new blog URL of the user.",
+        {
           "name": "blog",
+          "type": "string",
+          "description": "The new blog URL of the user.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "3": {
-          "description": "The new company of the user.",
+        {
           "name": "company",
+          "type": "string",
+          "description": "The new company of the user.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "4": {
-          "description": "The new location of the user.",
+        {
           "name": "location",
+          "type": "string",
+          "description": "The new location of the user.",
           "required": false,
-          "type": "string"
+          "location": "body"
         },
-        "5": {
-          "description": "The new hiring availability of the user.",
+        {
           "name": "hireable",
+          "type": "boolean",
+          "description": "The new hiring availability of the user.",
           "required": false,
-          "type": "boolean"
+          "location": "body"
         },
-        "6": {
-          "description": "The new short biography of the user.",
+        {
           "name": "bio",
+          "type": "string",
+          "description": "The new short biography of the user.",
           "required": false,
-          "type": "string"
+          "location": "body"
         }
-      },
+      ],
       "path": "/user"
     }
   }

--- a/scripts/routes-for-api-docs.json
+++ b/scripts/routes-for-api-docs.json
@@ -2662,14 +2662,14 @@
           "location": "body"
         },
         {
-          "name": "tree.path",
+          "name": "tree[].path",
           "type": "string",
           "description": "The file referenced in the tree",
           "required": false,
           "location": "body"
         },
         {
-          "name": "tree.mode",
+          "name": "tree[].mode",
           "type": "string",
           "description": "The file mode; one of `100644` for file (blob), `100755` for executable (blob), `040000` for subdirectory (tree), `160000` for submodule (commit), or `120000` for a blob that specifies the path of a symlink",
           "required": false,
@@ -2683,7 +2683,7 @@
           "location": "body"
         },
         {
-          "name": "tree.type",
+          "name": "tree[].type",
           "type": "string",
           "description": "Either `blob`, `tree`, or `commit`",
           "required": false,
@@ -2695,14 +2695,14 @@
           "location": "body"
         },
         {
-          "name": "tree.sha",
+          "name": "tree[].sha",
           "type": "string",
           "description": "The SHA1 checksum ID of the object in the tree",
           "required": false,
           "location": "body"
         },
         {
-          "name": "tree.content",
+          "name": "tree[].content",
           "type": "string",
           "description": "The content you want this file to have. GitHub will write this blob out and use that SHA for this entry. Use either this, or `tree.sha`.",
           "required": false,
@@ -8023,21 +8023,21 @@
           "location": "body"
         },
         {
-          "name": "comments.path",
+          "name": "comments[].path",
           "type": "string",
           "description": "**Required.** The relative path to the file that necessitates a review comment.",
           "required": false,
           "location": "body"
         },
         {
-          "name": "comments.position",
+          "name": "comments[].position",
           "type": "integer",
           "description": "**Required.** The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
           "required": false,
           "location": "body"
         },
         {
-          "name": "comments.body",
+          "name": "comments[].body",
           "type": "string",
           "description": "**Required.** Text of the review comment.",
           "required": false,
@@ -10339,7 +10339,7 @@
       "path": "/orgs/:org/repos"
     },
     "createHook": {
-      "description": "**Note**: Repository service hooks (like email or Campfire) can have at most one configured at a time. Creating hooks for a service that already has one configured will [update the existing hook](#edit-a-hook).\n\nRepositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\nHere's how you can create a hook that posts payloads in JSON format:",
+      "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\n**Note**: Repository service hooks (like email or Campfire) can have at most one configured at a time. Creating hooks for a service that already has one configured will [update the existing hook](#edit-a-hook).\n\n**Note**: GitHub Services will no longer be supported as of October 1, 2018. Please see the [blog post](/changes/2018-04-25-github-services-deprecation) for details. You can use the [Replacing GitHub Services guide](https://developer.github.com/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nHere's how you can create a hook that posts payloads in JSON format:",
       "documentationUrl": "https://developer.github.com/v3/repos/hooks/#create-a-hook",
       "enabledForApps": false,
       "method": "POST",
@@ -10362,7 +10362,7 @@
         {
           "name": "name",
           "type": "string",
-          "description": "Must be passed as \"web\".",
+          "description": "Use \"web\" for a webhook or use the name of a valid service. You can use [/hooks](https://api.github.com/hooks) for the list of valid service names. **Note**: GitHub Services will no longer be supported as of October 1, 2018. Please see the [blog post](/changes/2018-04-25-github-services-deprecation) for details.",
           "required": true,
           "location": "body"
         },

--- a/scripts/routes-for-api-docs.json
+++ b/scripts/routes-for-api-docs.json
@@ -157,46 +157,6 @@
       ],
       "path": "/repos/:owner/:repo/events"
     },
-    "getEventsForRepoIssues": {
-      "description": "Repository issue events have a different format than other events, as documented in the [Issue Events API](https://developer.github.com/v3/issues/events/).",
-      "documentationUrl": "https://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository",
-      "enabledForApps": false,
-      "method": "GET",
-      "name": "List issue events for a repository",
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "path": "/repos/:owner/:repo/issues/events"
-    },
     "getEventsForRepoNetwork": {
       "description": "",
       "documentationUrl": "https://developer.github.com/v3/activity/events/#list-public-events-for-a-network-of-repositories",

--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -130,7 +130,12 @@ declare namespace Github {
     {{#ownParams}}
     & {
     {{#params}}
-      {{key}}{{^required}}?{{/required}}: {{{type}}};
+      {{#deprecated}}
+      /**
+       * @deprecated {{{.}}}
+       */
+       {{/deprecated}}
+      "{{key}}"{{^required}}?{{/required}}: {{{type}}};
     {{/params}}
     };
     {{/ownParams}}
@@ -141,6 +146,19 @@ declare namespace Github {
   {{/paramTypeName}}
   {{/methods}}
   {{/namespaces}}
+  {{#childParams}}
+  export type {{paramTypeName}} =
+    & {
+    {{#params}}
+      {{#deprecated}}
+      /**
+       * @deprecated {{{.}}}
+       */
+       {{/deprecated}}
+      "{{key}}"{{^required}}?{{/required}}: {{{type}}};
+    {{/params}}
+    };
+  {{/childParams}}
 }
 
 declare class Github {

--- a/test/integration/deprecations-test.js
+++ b/test/integration/deprecations-test.js
@@ -121,4 +121,20 @@ describe('deprecations', () => {
         expect(console.warn.callCount).to.equal(1)
       })
   })
+
+  it('deprecated sha parameter for client.gitdata.getCommit({sha})', () => {
+    nock('https://deprecations-test.com')
+      .get('/repos/foo/bar/git/commits/sha123')
+      .reply(200, {})
+
+    return github.gitdata.getCommit({
+      owner: 'foo',
+      repo: 'bar',
+      sha: 'sha123'
+    })
+
+      .then(() => {
+        expect(console.warn.callCount).to.equal(1)
+      })
+  })
 })

--- a/test/integration/deprecations-test.js
+++ b/test/integration/deprecations-test.js
@@ -106,4 +106,19 @@ describe('deprecations', () => {
     })
     expect(console.warn.callCount).to.equal(1)
   })
+
+  it('deprecated client.activity.getEventsForRepoIssues()', () => {
+    nock('https://deprecations-test.com')
+      .get('/repos/foo/bar/issues/events')
+      .reply(200, [])
+
+    return github.activity.getEventsForRepoIssues({
+      owner: 'foo',
+      repo: 'bar'
+    })
+
+      .then(() => {
+        expect(console.warn.callCount).to.equal(1)
+      })
+  })
 })

--- a/test/integration/params-validations-test.js
+++ b/test/integration/params-validations-test.js
@@ -44,7 +44,7 @@ describe('params validations', () => {
       .catch(error => {
         expect(error.toJSON()).to.deep.equal({
           code: 400,
-          message: 'Invalid value for parameter \'filter\': foo',
+          message: 'Invalid value for parameter \'filter\': "foo"',
           status: 'Bad Request'
         })
       })
@@ -58,7 +58,7 @@ describe('params validations', () => {
       .catch(error => {
         expect(error.toJSON()).to.deep.equal({
           code: 400,
-          message: 'Invalid value for parameter \'position\': foo',
+          message: 'Invalid value for parameter \'position\': "foo"',
           status: 'Bad Request'
         })
       })
@@ -78,7 +78,7 @@ describe('params validations', () => {
       .catch(error => {
         expect(error.toJSON()).to.deep.equal({
           code: 400,
-          message: 'Invalid value for parameter \'position\': Age Ain’t Nothing is NaN',
+          message: 'Invalid value for parameter \'position\': "Age Ain’t Nothing" is NaN',
           status: 'Bad Request'
         })
       })
@@ -97,7 +97,7 @@ describe('params validations', () => {
       .catch(error => {
         expect(error.toJSON()).to.deep.equal({
           code: 400,
-          message: 'JSON parse error of value for parameter \'config\': I’m no Je-Son!',
+          message: 'JSON parse error of value for parameter \'config\': "I’m no Je-Son!"',
           status: 'Bad Request'
         })
       })

--- a/test/integration/params-validations-test.js
+++ b/test/integration/params-validations-test.js
@@ -10,6 +10,10 @@ describe('params validations', () => {
 
     return github.orgs.get({})
 
+      .then(() => {
+        expect.fail('should throw error')
+      })
+
       .catch(error => {
         expect(error.toString()).to.equal('Empty value for parameter \'org\': undefined')
         expect(error.toJSON()).to.deep.equal({
@@ -27,6 +31,10 @@ describe('params validations', () => {
 
     return github.orgs.get({org: 'foo'})
 
+      .then(() => {
+        expect.fail('should throw error')
+      })
+
       .catch(error => {
         expect(error.toJSON()).to.deep.equal({
           code: 500,
@@ -41,6 +49,10 @@ describe('params validations', () => {
 
     return github.issues.getAll({filter: 'foo'})
 
+      .then(() => {
+        expect.fail('should throw error')
+      })
+
       .catch(error => {
         expect(error.toJSON()).to.deep.equal({
           code: 400,
@@ -54,6 +66,10 @@ describe('params validations', () => {
     const github = new GitHub()
 
     return github.projects.moveProjectCard({id: 123, position: 'foo'})
+
+      .then(() => {
+        expect.fail('should throw error')
+      })
 
       .catch(error => {
         expect(error.toJSON()).to.deep.equal({
@@ -93,6 +109,10 @@ describe('params validations', () => {
       name: 'captain',
       config: 'I’m no Je-Son!'
     })
+
+      .then(() => {
+        expect.fail('should throw error')
+      })
 
       .catch(error => {
         expect(error.toJSON()).to.deep.equal({
@@ -156,10 +176,37 @@ describe('params validations', () => {
       ]
     })
 
+      .then(() => {
+        expect.fail('should throw error')
+      })
+
       .catch(error => {
         expect(error.toJSON()).to.deep.equal({
           code: 400,
           message: 'Invalid value for parameter \'tree[0].type\': "foo"',
+          status: 'Bad Request'
+        })
+      })
+  })
+
+  it('client.issues.createLabel() with description: null', () => {
+    const client = new GitHub()
+    return client.issues.createLabel({
+      owner: 'foo',
+      repo: 'bar',
+      name: 'baz',
+      color: '#bada55',
+      description: null
+    })
+
+      .then(() => {
+        expect.fail('should throw error')
+      })
+
+      .catch(error => {
+        expect(error.toJSON()).to.deep.equal({
+          code: 400,
+          message: '\'description\' cannot be null',
           status: 'Bad Request'
         })
       })

--- a/test/integration/params-validations-test.js
+++ b/test/integration/params-validations-test.js
@@ -143,6 +143,28 @@ describe('params validations', () => {
     })
   })
 
+  it('client.gitdata.createTree() with invalid tree[] object', () => {
+    const github = new GitHub()
+    return github.gitdata.createTree({
+      owner: 'foo',
+      repo: 'bar',
+      base_tree: '9fb037999f264ba9a7fc6274d15fa3ae2ab98312',
+      tree: [
+        {
+          type: 'foo'
+        }
+      ]
+    })
+
+      .catch(error => {
+        expect(error.toJSON()).to.deep.equal({
+          code: 400,
+          message: 'Invalid value for parameter \'tree[0].type\': "foo"',
+          status: 'Bad Request'
+        })
+      })
+  })
+
   it('does not alter passed options', () => {
     const github = new GitHub({
       baseUrl: 'https://params-test-host.com'


### PR DESCRIPTION
This is the first light at the end of the tunnel of auto-generated and auto-upated endpoint methods based on https://github.com/octokit/routes. Lot’s and lots of work to be done but the general setup works, so we can start working off the bugs.

We remove all descriptions as they are not needed for the endpoint methods, instead we generate a [secondary JSON files for the documentation only](https://github.com/octokit/rest.js/blob/generate-routes/scripts/routes-for-api-docs.json). It will have more information than we have available today

### v3 Docs: Required parameters

- [x] `assignees` 
      https://developer.github.com/v3/issues/assignees/#add-assignees-to-an-issue

  - Turns out no, `assignees` is not required, which is somewhat odd.

- [x] `role`
      https://developer.github.com/v3/orgs/members/#add-or-update-organization-membership

  - Turns out no, `role` is not required, it defaults to "member". So if role is not set at all and the current user is admin, it will change role to member

- [x] `title`, `key` (double check!)
      https://developer.github.com/v3/repos/keys/#add-a-new-deploy-key

  - `title` is not required, but `key` is required
    ```
    curl -i -H'Authorization: token ...' -XPOST https://api.github.com/repos/gr2m/sandbox/keys -d '{}'
    HTTP/1.1 422 Unprocessable Entity
    Date: Sun, 01 Apr 2018 21:14:32 GMT
    Content-Type: application/json; charset=utf-8
    Content-Length: 452
    Server: GitHub.com
    Status: 422 Unprocessable Entity
    X-RateLimit-Limit: 5000
    X-RateLimit-Remaining: 4986
    X-RateLimit-Reset: 1522618861
    X-OAuth-Scopes: repo
    X-Accepted-OAuth-Scopes: 
    X-GitHub-Media-Type: github.v3; format=json
    Access-Control-Expose-Headers: ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
    Access-Control-Allow-Origin: *
    Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
    X-Frame-Options: deny
    X-Content-Type-Options: nosniff
    X-XSS-Protection: 1; mode=block
    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
    Content-Security-Policy: default-src 'none'
    X-Runtime-rack: 0.032849
    X-GitHub-Request-Id: D0D6:25FC:68834C:80744A:5AC14BB8

    {
      "message": "Validation Failed",
      "errors": [
        {
          "resource": "PublicKey",
          "code": "custom",
          "field": "key",
          "message": "key is invalid. It must begin with 'ssh-ed25519', 'ssh-rsa', 'ssh-dss', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', or 'ecdsa-sha2-nistp521'. Check that you're copying the public half of the key"
        }
      ],
      "documentation_url": "https://developer.github.com/v3/repos/keys/#add-a-new-deploy-key"
    }
    ```

- [x] either `name` or `label`? (double check)
      https://developer.github.com/v3/repos/releases/#edit-a-release-asset

  - neither is required.

- [x] double check
      https://developer.github.com/v3/git/tags/#create-a-tag-object
      
  - `message` (required)
  - `object` (required)
  - `tag` (required)
  - `type` (required)
  - `tagger` (not required)
      
  - ```
    curl -i -H'Authorization: token ...' -XPOST https://api.github.com/repos/gr2m/sandbox/git/tags -d '{}'
    HTTP/1.1 422 Unprocessable Entity
    Date: Sun, 01 Apr 2018 21:18:20 GMT
    Content-Type: application/json; charset=utf-8
    Content-Length: 188
    Server: GitHub.com
    Status: 422 Unprocessable Entity
    X-RateLimit-Limit: 5000
    X-RateLimit-Remaining: 4984
    X-RateLimit-Reset: 1522618861
    X-OAuth-Scopes: repo
    X-Accepted-OAuth-Scopes: 
    X-GitHub-Media-Type: github.v3; format=json
    Access-Control-Expose-Headers: ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
    Access-Control-Allow-Origin: *
    Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
    X-Frame-Options: deny
    X-Content-Type-Options: nosniff
    X-XSS-Protection: 1; mode=block
    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
    Content-Security-Policy: default-src 'none'
    X-Runtime-rack: 0.025889
    X-GitHub-Request-Id: D7E7:25FF:25828DB:2E4EF9C:5AC14C9C

    {
      "message": "Invalid request.\n\n\"message\", \"object\", \"tag\", \"type\" weren't supplied.",
      "documentation_url": "https://developer.github.com/v3/git/tags/#create-a-tag-object"
    }
    ```

### v3 Docs: Other

- `name` parameter missing?
  https://developer.github.com/v3/repos/hooks/#edit-a-hook

  - `name` is not missing, but turns out that `config` is actually not required.

  ```
  curl -i -H'Authorization: token ...' -XPATCH https://api.github.com/repos/gr2m/sandbox/hooks/25416892 -d '{"active": false}'
  HTTP/1.1 200 OK
  Date: Sun, 01 Apr 2018 21:29:45 GMT
  Content-Type: application/json; charset=utf-8
  Content-Length: 637
  Server: GitHub.com
  Status: 200 OK
  X-RateLimit-Limit: 5000
  X-RateLimit-Remaining: 4972
  X-RateLimit-Reset: 1522618861
  Cache-Control: private, max-age=60, s-maxage=60
  Vary: Accept, Authorization, Cookie, X-GitHub-OTP
  ETag: "709b48cc7c5965dac533d78fcfa0abf6"
  X-OAuth-Scopes: repo
  X-Accepted-OAuth-Scopes: admin:repo_hook, public_repo, repo, write:repo_hook
  X-GitHub-Media-Type: github.v3; format=json
  Access-Control-Expose-Headers: ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
  Access-Control-Allow-Origin: *
  Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
  X-Frame-Options: deny
  X-Content-Type-Options: nosniff
  X-XSS-Protection: 1; mode=block
  Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
  Content-Security-Policy: default-src 'none'
  X-Runtime-rack: 0.180648
  Vary: Accept-Encoding
  X-GitHub-Request-Id: ED02:25FE:22AD4AD:2AF792B:5AC14F49

  {
    "type": "Repository",
    "id": 25416892,
    "name": "web",
    "active": false,
    "events": [
      "push"
    ],
    "config": {
      "content_type": "json",
      "insecure_ssl": "0",
      "secret": "********",
      "url": "https://example.com"
    },
    "updated_at": "2018-04-01T21:29:04Z",
    "created_at": "2018-04-01T21:25:45Z",
    "url": "https://api.github.com/repos/gr2m/sandbox/hooks/25416892",
    "test_url": "https://api.github.com/repos/gr2m/sandbox/hooks/25416892/test",
    "ping_url": "https://api.github.com/repos/gr2m/sandbox/hooks/25416892/pings",
    "last_response": {
      "code": 200,
      "status": "active",
      "message": "OK"
    }
  }
  ```

Description of `files.*` parameters should be table
https://developer.github.com/v3/gists/#edit-a-gist

### TODOs with follow up issues

- [x] https://developer.github.com/v3/teams/#create-team
`privacy` enum. 👉 https://github.com/octokit/routes/issues/94
- [x] https://developer.github.com/v3/teams/#edit-team
`privacy` enum. 👉 https://github.com/octokit/routes/issues/94
- [x] https://developer.github.com/v3/orgs/#edit-an-organization
      `default_repository_permission` enum. 👉 https://github.com/octokit/routes/issues/95
- [x] https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment
      `content` is enum with `"+1"`, `"-1"`, `"laugh"`, etc. 👉 https://github.com/octokit/routes/issues/94
- [x] https://developer.github.com/v3/repos/branches/#update-branch-protection
      `dismissal_restrictions.teams` should be `required_pull_request_reviews .dismissal_restrictions.teams`, `dismissal_restrictions.users` should be `required_pull_request_reviews .dismissal_restrictions.users`. 👉 https://github.com/octokit/routes/issues/97
- [x] https://developer.github.com/v3/orgs/members/#edit-your-organization-membership
`state` enum. 👉 https://github.com/octokit/routes/issues/98
- [x] https://developer.github.com/v3/git/tags/#create-a-tag-object
`type` enum. 👉 https://github.com/octokit/routes/issues/99
- [x] https://developer.github.com/v3/git/trees/#get-a-tree-recursively
is `recursive` boolean or an integer enum. 👉 pinged docs team about it
- [x] uploadAsset `Content-Type` header. 👉 https://github.com/octokit/routes/issues/100

### Open Todos

- [x] test against test suites of most popular dependends
  - [x] semantic-release
  - [x] greenkeeper
  - [x] danger.js
  - [x] release-it
- [x] automate update of `lib/routes.json` for each Greenkeeper pull request for `@octokit/routes`
- [x] [Create a Tree](https://developer.github.com/v3/git/trees/#get-a-tree)’s `tree` parameter is an array of objects. I don’t think we validate correctly at this point. We definitely should add a test for it
  - same with `createReview#comments`
- [x] update documentation
- [x] install `@octokit/routes` from npm instead from `file:../routes`. Make sure to pin the version
- [x] enum values that contain placeholders won’t work for us, see `position` parameter. We have to turn the enum into a regex instead
- [x] remove temporary workaround if still present
  ```js
  if (!currentEndpoint.params[name]) {
    return
  }
  ```
- [x] `updateBranchProtection#dismissal_restrictions` gets removed
- [x] `search.code#sort`: enum with `["indexed"]` should not be removed.
- [x] `repos.uploadAsset`: `Content-Type` parameter is wrong

closes #843 