### PR TITLE
failing test for notifications date parsing

### DIFF
--- a/test/integration/params-validations-test.js
+++ b/test/integration/params-validations-test.js
@@ -127,4 +127,17 @@ describe('params validations', () => {
       due_on: new Date('2012-10-09T23:39:01Z')
     })
   })
+
+  it('Date object for github.activity.getNotifications({..., since})', () => {
+    const github = new GitHub({
+      host: 'notifications-test-host.com'
+    })
+
+    nock('https://notifications-test-host.com')
+      .get('/notifications')
+      .query({ since: '2012-10-09T23:39:01Z' })
+      .reply(201, {})
+
+    return github.activity.getNotifications({since: new Date('2012-10-09T23:39:01Z')})
+  })
 })


### PR DESCRIPTION
Adds a failing test to showcase the problem in #833 

Note that this also causes a second test to fail that expects there not to be any pending mocks. I think this should go away once the test is passing 