### PR TITLE
refactor: replace 'node-fetch' dependency with 'cross-fetch' 

### DIFF
--- a/lib/request/request.js
+++ b/lib/request/request.js
@@ -2,7 +2,7 @@
 
 module.exports = request
 
-const fetch = require('node-fetch')
+const fetch = require('cross-fetch')
 const debug = require('debug')('octokit:rest')
 const defaults = require('lodash/defaults')
 const isPlainObject = require('lodash/isPlainObject')

--- a/package.json
+++ b/package.json
@@ -38,15 +38,14 @@
   "dependencies": {
     "before-after-hook": "^1.1.0",
     "btoa-lite": "^1.0.0",
+    "cross-fetch": "^2.1.1",
     "debug": "^3.1.0",
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.0",
     "lodash": "^4.17.4",
-    "node-fetch": "^2.1.1",
     "url-template": "^2.0.8"
   },
   "devDependencies": {
-    "@gr2m/node-fetch": "^2.0.0",
     "@octokit/fixtures-server": "^2.0.1",
     "@octokit/routes": "7.2.6",
     "@types/node": "^9.4.6",

--- a/test/util.js
+++ b/test/util.js
@@ -4,7 +4,7 @@ module.exports = {
   getInstance
 }
 
-const fetch = require('node-fetch')
+const fetch = require('cross-fetch')
 const merge = require('lodash/merge')
 
 const GitHub = require('../')


### PR DESCRIPTION
This patch replaces the `node-fetch` dependency with `cross-fetch`. Please note both `node-fetch` and `@gr2m/node-fetch` are removed from package.json.

This may address the "fetch is undefined" error from #830.