### PR TITLE
machine-man-preview header required for installation tokens

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -523,6 +523,9 @@
   },
   "apps": {
     "addRepoToInstallation": {
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview+json"
+      },
       "method": "PUT",
       "params": {
         "installation_id": {
@@ -575,6 +578,9 @@
       "url": "/marketplace_listing/stubbed/accounts/:id"
     },
     "createInstallationToken": {
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview+json"
+      },
       "method": "POST",
       "params": {
         "installation_id": {
@@ -590,6 +596,9 @@
       "url": "/app"
     },
     "getForSlug": {
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview+json"
+      },
       "method": "GET",
       "params": {
         "app_slug": {
@@ -600,6 +609,9 @@
       "url": "/apps/:app_slug"
     },
     "getInstallation": {
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview+json"
+      },
       "method": "GET",
       "params": {
         "installation_id": {
@@ -610,6 +622,9 @@
       "url": "/app/installations/:installation_id"
     },
     "getInstallationRepositories": {
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview+json"
+      },
       "method": "GET",
       "params": {
         "page": {
@@ -622,6 +637,9 @@
       "url": "/installation/repositories"
     },
     "getInstallations": {
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview+json"
+      },
       "method": "GET",
       "params": {
         "page": {
@@ -730,6 +748,9 @@
       "url": "/marketplace_listing/stubbed/plans"
     },
     "removeRepoFromInstallation": {
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview+json"
+      },
       "method": "DELETE",
       "params": {
         "installation_id": {
@@ -975,7 +996,7 @@
   "checks": {
     "create": {
       "headers": {
-        "accept": "application/vnd.github.antiope-preview+json"
+        "accept": "application/vnd.github.antiope-preview+json,application/vnd.github.machine-man-preview+json"
       },
       "method": "POST",
       "params": {
@@ -1126,7 +1147,7 @@
     },
     "get": {
       "headers": {
-        "accept": "application/vnd.github.antiope-preview+json"
+        "accept": "application/vnd.github.antiope-preview+json,application/vnd.github.machine-man-preview+json"
       },
       "method": "GET",
       "params": {
@@ -1147,7 +1168,7 @@
     },
     "getSuite": {
       "headers": {
-        "accept": "application/vnd.github.antiope-preview+json"
+        "accept": "application/vnd.github.antiope-preview+json,application/vnd.github.machine-man-preview+json"
       },
       "method": "GET",
       "params": {
@@ -1168,7 +1189,7 @@
     },
     "listAnnotations": {
       "headers": {
-        "accept": "application/vnd.github.antiope-preview+json"
+        "accept": "application/vnd.github.antiope-preview+json,application/vnd.github.machine-man-preview+json"
       },
       "method": "GET",
       "params": {
@@ -1195,7 +1216,7 @@
     },
     "listForRef": {
       "headers": {
-        "accept": "application/vnd.github.antiope-preview+json"
+        "accept": "application/vnd.github.antiope-preview+json,application/vnd.github.machine-man-preview+json"
       },
       "method": "GET",
       "params": {
@@ -1240,7 +1261,7 @@
     },
     "listForSuite": {
       "headers": {
-        "accept": "application/vnd.github.antiope-preview+json"
+        "accept": "application/vnd.github.antiope-preview+json,application/vnd.github.machine-man-preview+json"
       },
       "method": "GET",
       "params": {
@@ -1285,7 +1306,7 @@
     },
     "listSuitesForRef": {
       "headers": {
-        "accept": "application/vnd.github.antiope-preview+json"
+        "accept": "application/vnd.github.antiope-preview+json,application/vnd.github.machine-man-preview+json"
       },
       "method": "GET",
       "params": {
@@ -1338,7 +1359,7 @@
     },
     "setSuitesPreferences": {
       "headers": {
-        "accept": "application/vnd.github.antiope-preview+json"
+        "accept": "application/vnd.github.antiope-preview+json,application/vnd.github.machine-man-preview+json"
       },
       "method": "PATCH",
       "params": {
@@ -1366,7 +1387,7 @@
     },
     "update": {
       "headers": {
-        "accept": "application/vnd.github.antiope-preview+json"
+        "accept": "application/vnd.github.antiope-preview+json,application/vnd.github.machine-man-preview+json"
       },
       "method": "PATCH",
       "params": {
@@ -2461,6 +2482,9 @@
   "integrations": {
     "addRepoToInstallation": {
       "deprecated": "`integrations` has been renamed to `apps`",
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview+json"
+      },
       "method": "PUT",
       "params": {
         "installation_id": {
@@ -2476,6 +2500,9 @@
     },
     "createInstallationToken": {
       "deprecated": "`integrations` has been renamed to `apps`",
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview+json"
+      },
       "method": "POST",
       "params": {
         "installation_id": {
@@ -2487,12 +2514,18 @@
     },
     "getInstallationRepositories": {
       "deprecated": "`integrations` has been renamed to `apps`",
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview+json"
+      },
       "method": "GET",
       "params": {},
       "url": "/installation/repositories"
     },
     "getInstallations": {
       "deprecated": "`integrations` has been renamed to `apps`",
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview+json"
+      },
       "method": "GET",
       "params": {
         "page": {
@@ -2506,6 +2539,9 @@
     },
     "removeRepoFromInstallation": {
       "deprecated": "`integrations` has been renamed to `apps`",
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview+json"
+      },
       "method": "DELETE",
       "params": {
         "installation_id": {
@@ -9461,6 +9497,9 @@
       "url": "/user/emails"
     },
     "addRepoToInstallation": {
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview+json"
+      },
       "method": "PUT",
       "params": {
         "installation_id": {
@@ -9798,6 +9837,9 @@
       "url": "/user/installations/:installation_id/repositories"
     },
     "getInstallations": {
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview+json"
+      },
       "method": "GET",
       "params": {
         "page": {
@@ -9968,6 +10010,9 @@
       "url": "/users/:username/site_admin"
     },
     "removeRepoFromInstallation": {
+      "headers": {
+        "accept": "application/vnd.github.machine-man-preview+json"
+      },
       "method": "DELETE",
       "params": {
         "installation_id": {

--- a/test/integration/apps-test.js
+++ b/test/integration/apps-test.js
@@ -76,4 +76,22 @@ describe('apps', () => {
       }
     })
   })
+
+  it('adds "machine-man" preview header when authenticated as installation', () => {
+    nock('https://apps-test-host.com', {
+      reqheaders: {
+        authorization: 'token xyz-installation-token',
+        accept: 'application/vnd.github.machine-man-preview+json'
+      }
+    })
+      .get('/installation/repositories')
+      .reply(200, {})
+
+    client.authenticate({
+      type: 'token',
+      token: 'xyz-installation-token'
+    })
+
+    return client.apps.getInstallationRepositories({})
+  })
 })


### PR DESCRIPTION
https://github.com/octokit/rest.js/pull/870 introduced a regression where a client authenticated with an app installation token doesn't get the `machine-man-preview`.

This adds a test to expose the issue, and reverts the route changes.

cc https://github.com/probot/probot/issues/537