### PR TITLE
Greenkeeper/@octokit/routes 9.0.2

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -3843,6 +3843,9 @@
       "url": "/repos/:owner/:repo/import"
     },
     "deleteArchiveForAuthenticatedUser": {
+      "headers": {
+        "accept": "application/vnd.github.wyandotte-preview+json"
+      },
       "method": "DELETE",
       "params": {
         "migration_id": {
@@ -3874,6 +3877,9 @@
       "url": "/orgs/:org/migrations/:migration_id/archive"
     },
     "getArchiveForAuthenticatedUser": {
+      "headers": {
+        "accept": "application/vnd.github.wyandotte-preview+json"
+      },
       "method": "GET",
       "params": {
         "migration_id": {
@@ -4003,6 +4009,9 @@
       "url": "/orgs/:org/migrations"
     },
     "getStatusForAuthenticatedUser": {
+      "headers": {
+        "accept": "application/vnd.github.wyandotte-preview+json"
+      },
       "method": "GET",
       "params": {
         "migration_id": {
@@ -4013,6 +4022,9 @@
       "url": "/user/migrations/:migration_id"
     },
     "listForAuthenticatedUser": {
+      "headers": {
+        "accept": "application/vnd.github.wyandotte-preview+json"
+      },
       "method": "GET",
       "params": {
         "page": {
@@ -4081,6 +4093,9 @@
       "url": "/repos/:owner/:repo/import/lfs"
     },
     "startForAuthenticatedUser": {
+      "headers": {
+        "accept": "application/vnd.github.wyandotte-preview+json"
+      },
       "method": "POST",
       "params": {
         "exclude_attachments": {
@@ -4159,6 +4174,9 @@
       "url": "/orgs/:org/migrations"
     },
     "unlockRepoForAuthenticatedUser": {
+      "headers": {
+        "accept": "application/vnd.github.wyandotte-preview+json"
+      },
       "method": "DELETE",
       "params": {
         "migration_id": {

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -3842,6 +3842,16 @@
       },
       "url": "/repos/:owner/:repo/import"
     },
+    "deleteArchiveForAuthenticatedUser": {
+      "method": "DELETE",
+      "params": {
+        "migration_id": {
+          "required": true,
+          "type": "string"
+        }
+      },
+      "url": "/user/migrations/:migration_id/archive"
+    },
     "deleteMigrationArchive": {
       "headers": {
         "accept": "application/vnd.github.wyandotte-preview+json"
@@ -3862,6 +3872,16 @@
         }
       },
       "url": "/orgs/:org/migrations/:migration_id/archive"
+    },
+    "getArchiveForAuthenticatedUser": {
+      "method": "GET",
+      "params": {
+        "migration_id": {
+          "required": true,
+          "type": "string"
+        }
+      },
+      "url": "/user/migrations/:migration_id/archive"
     },
     "getImportCommitAuthors": {
       "headers": {
@@ -3982,6 +4002,28 @@
       },
       "url": "/orgs/:org/migrations"
     },
+    "getStatusForAuthenticatedUser": {
+      "method": "GET",
+      "params": {
+        "migration_id": {
+          "required": true,
+          "type": "string"
+        }
+      },
+      "url": "/user/migrations/:migration_id"
+    },
+    "listForAuthenticatedUser": {
+      "method": "GET",
+      "params": {
+        "page": {
+          "type": "integer"
+        },
+        "per_page": {
+          "type": "integer"
+        }
+      },
+      "url": "/user/migrations"
+    },
     "mapImportCommitAuthor": {
       "headers": {
         "accept": "application/vnd.github.barred-rock-preview"
@@ -4037,6 +4079,22 @@
         }
       },
       "url": "/repos/:owner/:repo/import/lfs"
+    },
+    "startForAuthenticatedUser": {
+      "method": "POST",
+      "params": {
+        "exclude_attachments": {
+          "type": "boolean"
+        },
+        "lock_repositories": {
+          "type": "boolean"
+        },
+        "repositories": {
+          "required": true,
+          "type": "string[]"
+        }
+      },
+      "url": "/user/migrations"
     },
     "startImport": {
       "headers": {
@@ -4099,6 +4157,20 @@
         }
       },
       "url": "/orgs/:org/migrations"
+    },
+    "unlockRepoForAuthenticatedUser": {
+      "method": "DELETE",
+      "params": {
+        "migration_id": {
+          "required": true,
+          "type": "string"
+        },
+        "repo_name": {
+          "required": true,
+          "type": "string"
+        }
+      },
+      "url": "/user/migrations/:migration_id/repos/:repo_name/lock"
     },
     "unlockRepoLockedForMigration": {
       "headers": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@gr2m/node-fetch": "^2.0.0",
     "@octokit/fixtures-server": "^2.0.1",
-    "@octokit/routes": "9.0.0",
+    "@octokit/routes": "9.0.2",
     "@types/node": "^10.1.2",
     "apidoc": "^0.17.6",
     "bundlesize": "^0.17.0",

--- a/scripts/routes-for-api-docs.json
+++ b/scripts/routes-for-api-docs.json
@@ -13283,14 +13283,14 @@
           "location": "url"
         },
         {
-          "name": "name",
+          "name": "repo",
           "type": "string",
           "required": true,
           "description": "",
           "location": "url"
         }
       ],
-      "path": "/repos/:owner/:name/community/profile"
+      "path": "/repos/:owner/:repo/community/profile"
     },
     "getContent": {
       "description": "This method returns the contents of a file or directory in a repository.\n\nFiles and symlinks support [a custom media type](#custom-media-types) for retrieving the raw content or rendered HTML (when supported). All content types support [a custom media type](#custom-media-types) to ensure the content is returned in a consistent object format.\n\n**Note**:\n\n*   To get a repository's contents recursively, you can [recursively get the tree](https://developer.github.com/v3/git/trees/).\n*   This API has an upper limit of 1,000 files for a directory. If you need to retrieve more files, use the [Git Trees API](https://developer.github.com/v3/git/trees/#get-a-tree).\n*   This API supports files up to 1 megabyte in size.\n\nThe response will be an array of objects, one object for each item in the directory.\n\nWhen listing the contents of a directory, submodules have their \"type\" specified as \"file\". Logically, the value _should_ be \"submodule\". This behavior exists in API v3 [for backwards compatibility purposes](https://git.io/v1YCW). In the next major version of the API, the type will be returned as \"submodule\".\n\nIf the requested `:path` points to a symlink, and the symlink's target is a normal file in the repository, then the API responds with the content of the file (in the [format shown above](#response-if-content-is-a-file)).\n\nOtherwise, the API responds with an object describing the symlink itself:\n\nThe `submodule_git_url` identifies the location of the submodule repository, and the `sha` identifies a specific commit within the submodule repository. Git uses the given URL when cloning the submodule repository, and checks out the submodule at that specific commit.\n\nIf the submodule repository is not hosted on github.com, the Git URLs (`git_url` and `_links[\"git\"]`) and the github.com URLs (`html_url` and `_links[\"html\"]`) will have null values.",

--- a/scripts/routes-for-api-docs.json
+++ b/scripts/routes-for-api-docs.json
@@ -5869,6 +5869,23 @@
       ],
       "path": "/repos/:owner/:repo/import"
     },
+    "deleteArchiveForAuthenticatedUser": {
+      "description": "Deletes a previous migration archive. Downloadable migration archives are automatically deleted after seven days. Migration metadata, which is returned in the [Get a list of user migrations](#get-a-list-of-user-migrations) and [Get the status of a user migration](#get-the-status-of-a-user-migration) endpoints, will continue to be available even after an archive is deleted.",
+      "documentationUrl": "https://developer.github.com/v3/migrations/users/#delete-a-user-migration-archive",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Delete a user migration archive",
+      "params": [
+        {
+          "name": "migration_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "path": "/user/migrations/:migration_id/archive"
+    },
     "deleteMigrationArchive": {
       "description": "Deletes a previous migration archive. Migration archives are automatically deleted after seven days.",
       "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#delete-a-migration-archive",
@@ -5892,6 +5909,23 @@
         }
       ],
       "path": "/orgs/:org/migrations/:migration_id/archive"
+    },
+    "getArchiveForAuthenticatedUser": {
+      "description": "Fetches the URL to download the migration archive as a `tar.gz` file. Depending on the resources your repository uses, the migration archive can contain JSON files with data for these objects:\n\n*   attachments\n*   bases\n*   commit_comments\n*   issue_comments\n*   issue_events\n*   issues\n*   milestones\n*   organizations\n*   projects\n*   protected_branches\n*   pull\\_request\\_reviews\n*   pull_requests\n*   releases\n*   repositories\n*   review_comments\n*   schema\n*   users\n\nThe archive will also contain an `attachments` directory that includes all attachment files uploaded to GitHub.com and a `repositories` directory that contains the repository's Git data.\n\n",
+      "documentationUrl": "https://developer.github.com/v3/migrations/users/#download-a-user-migration-archive",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Download a user migration archive",
+      "params": [
+        {
+          "name": "migration_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "path": "/user/migrations/:migration_id/archive"
     },
     "getImportCommitAuthors": {
       "description": "Each type of source control system represents authors in a different way. For example, a Git commit author has a display name and an email address, but a Subversion commit author just has a username. The GitHub Importer will make the author information valid, but the author might not be correct. For example, it will change the bare Subversion username `hubot` into something like `hubot <hubot@12341234-abab-fefe-8787-fedcba987654>`.\n\nThis API method and the \"Map a commit author\" method allow you to provide correct Git author information.",
@@ -6053,6 +6087,49 @@
       ],
       "path": "/orgs/:org/migrations"
     },
+    "getStatusForAuthenticatedUser": {
+      "description": "Fetches a single user migration. The response includes the `state` of the migration, which can be one of the following values:\n\n*   `pending` \\- the migration hasn't started yet.\n*   `exporting` \\- the migration is in progress.\n*   `exported` \\- the migration finished successfully.\n*   `failed` \\- the migration failed.\n\nOnce the migration has been `exported` you can [download the migration archive](#download-a-user-migration-archive).",
+      "documentationUrl": "https://developer.github.com/v3/migrations/users/#get-the-status-of-a-user-migration",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get the status of a user migration",
+      "params": [
+        {
+          "name": "migration_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "path": "/user/migrations/:migration_id"
+    },
+    "listForAuthenticatedUser": {
+      "description": "Lists all migrations a user has started.",
+      "documentationUrl": "https://developer.github.com/v3/migrations/users/#get-a-list-of-user-migrations",
+      "enabledForApps": false,
+      "method": "GET",
+      "name": "Get a list of user migrations",
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "path": "/user/migrations"
+    },
     "mapImportCommitAuthor": {
       "description": "Update an author's identity for the import. Your application can continue updating authors any time before you push new commits to the repository.",
       "documentationUrl": "https://developer.github.com/v3/migrations/source_imports/#map-a-commit-author",
@@ -6132,6 +6209,39 @@
         }
       ],
       "path": "/repos/:owner/:repo/import/lfs"
+    },
+    "startForAuthenticatedUser": {
+      "description": "Initiates the generation of a user migration archive.",
+      "documentationUrl": "https://developer.github.com/v3/migrations/users/#start-a-user-migration",
+      "enabledForApps": false,
+      "method": "POST",
+      "name": "Start a user migration",
+      "params": [
+        {
+          "name": "repositories",
+          "type": "string[]",
+          "description": "An array of repositories to include in the migration.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "lock_repositories",
+          "type": "boolean",
+          "description": "Locks the `repositories` to prevent changes during the migration when set to `true`.",
+          "default": false,
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "exclude_attachments",
+          "type": "boolean",
+          "description": "Does not include attachments uploaded to GitHub.com in the migration data when set to `true`. Excluding attachments will reduce the migration archive file size.",
+          "default": false,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "path": "/user/migrations"
     },
     "startImport": {
       "description": "Start a source import to a GitHub repository using GitHub Importer.",
@@ -6237,6 +6347,30 @@
         }
       ],
       "path": "/orgs/:org/migrations"
+    },
+    "unlockRepoForAuthenticatedUser": {
+      "description": "Unlocks a repository. You can lock repositories when you [start a user migration](#start-a-user-migration). Once the migration is complete you can unlock each repository to begin using it again or [delete the repository](https://developer.github.com/v3/repos/#delete-a-repository) if you no longer need the source data. Returns a status of `404 Not Found` if the repository is not locked.",
+      "documentationUrl": "https://developer.github.com/v3/migrations/users/#unlock-a-user-repository",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "name": "Unlock a user repository",
+      "params": [
+        {
+          "name": "migration_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo_name",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "path": "/user/migrations/:migration_id/repos/:repo_name/lock"
     },
     "unlockRepoLockedForMigration": {
       "description": "Unlocks a repository that was locked for migration. You should unlock each migrated repository and [delete them](https://developer.github.com/v3/repos/#delete-a-repository) when the migration is complete and you no longer need the source data.",


### PR DESCRIPTION
closes https://github.com/octokit/rest.js/pull/914, closes https://github.com/octokit/rest.js/pull/920

ping @bitsol this PR introduces the missing methods for user migrations. Could you double check if they work for you?

The methods are

- `octokit.migrations.deleteArchiveForAuthenticatedUser()`
- `octokit.migrations.getArchiveForAuthenticatedUser()`
- `octokit.migrations.getStatusForAuthenticatedUser()`
- `octokit.migrations.listForAuthenticatedUser()`
- `octokit.migrations.startForAuthenticatedUser()`
- `octokit.migrations.unlockRepoForAuthenticatedUser()`