### PR TITLE
(fix) webpack default export issues in lambda

### DIFF
--- a/lib/request/request.js
+++ b/lib/request/request.js
@@ -2,7 +2,7 @@
 
 module.exports = request
 
-const fetch = require('node-fetch')
+const fetch = require('node-fetch').default
 const debug = require('debug')('octokit:rest')
 const defaults = require('lodash/defaults')
 const isPlainObject = require('lodash/isPlainObject')


### PR DESCRIPTION
Hi @gr2m , finally got back onto this.  

I've added the default export on the require call for node-fetch in request.js.  As per https://github.com/bitinn/node-fetch/issues/450#issuecomment-387045223 this seems to fix the fetch undefined issue when using webpack and lambda.  

Looks like unit and browser tests are all ok too. closes #830 
