### PR TITLE
docs(examples): update removeAssigneesFromIssue example

### DIFF
--- a/examples/removeAssigneesFromIssue.js
+++ b/examples/removeAssigneesFromIssue.js
@@ -11,5 +11,5 @@ octokit.issues.removeAssigneesFromIssue({
   owner: 'octokit',
   repo: 'rest.js',
   number: '4',
-  body: { 'assignees': ['first9890'] }
+  assignees: ['first9890']
 })


### PR DESCRIPTION
Current documentation example incorrectly describes the `assignees` parameter; this commit corrects it.

Fixes #943
