### PR TITLE
Mark deprecated properties as optional in typescript typings, fixes #933

### DIFF
--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -29,7 +29,7 @@ function parameterize (key, definition) {
   return {
     name: pascalcase(key),
     key: key,
-    required: definition.required,
+    required: !definition.deprecated && definition.required,
     type: enums || type,
     alias: definition.alias,
     deprecated: definition.deprecated
@@ -63,7 +63,7 @@ function toParamAlias (param, i, params) {
   }
 
   const actualParam = params.find(({key}) => key === param.alias)
-  param.required = actualParam.required
+  param.required = !param.deprecated && actualParam.required
   param.type = actualParam.type
   return param
 }

--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -142,7 +142,7 @@ declare namespace Github {
     {{#params}}
       {{#deprecated}}
       /**
-       * @deprecated {{{.}}}
+       * @deprecated "{{key}}" has been renamed to "{{alias}}"
        */
        {{/deprecated}}
       "{{key}}"{{^required}}?{{/required}}: {{{type}}};
@@ -162,7 +162,7 @@ declare namespace Github {
     {{#params}}
       {{#deprecated}}
       /**
-       * @deprecated {{{.}}}
+       * @deprecated "{{key}}" has been renamed to "{{alias}}"
        */
        {{/deprecated}}
       "{{key}}"{{^required}}?{{/required}}: {{{type}}};


### PR DESCRIPTION
fixes https://github.com/octokit/rest.js/issues/933, marks properties that are deprecated as optional within the generated typings file

For example

```ts
  export type ActivityCheckNotificationThreadSubscriptionParams =
    & {
      /**
       * @deprecated [object Object]
       */
      "id": string;
      "thread_id": string;
    };
```

becomes

```ts
  export type ActivityCheckNotificationThreadSubscriptionParams =
    & {
      /**
       * @deprecated "id" has been renamed to "thread_id"
       */
      "id"?: string;
      "thread_id": string;
    };
```