### PR TITLE
feat: allow to escape a + in a query

### DIFF
--- a/lib/endpoint/add-query-parameters.js
+++ b/lib/endpoint/add-query-parameters.js
@@ -11,7 +11,7 @@ function addQueryParameters (url, parameters) {
   return url + separator + names
     .map(name => {
       if (name === 'q') {
-        return 'q=' + parameters.q.split('+')
+        return 'q=' + escapedSplit(parameters.q, '+')
           .map(encodeURIComponent)
           .join('+')
       }
@@ -19,4 +19,29 @@ function addQueryParameters (url, parameters) {
       return `${name}=${encodeURIComponent(parameters[name])}`
     })
     .join('&')
+}
+
+function escapedSplit(s, splitChar) {
+  if (!s.includes('\\')) {
+    return s.split(splitChar)
+  }
+
+  let escaped = false
+  let res = ['']
+  for (let char of s) {
+    if (escaped) {
+      res[res.length-1] += char
+      escaped = false
+    } else {
+      if (char === '\\') {
+        escaped = true
+      } else if (char === '+') {
+        res.push('')
+      } else {
+        res[res.length-1] += char
+      }
+    }
+  }
+
+  return res
 }

--- a/lib/endpoint/add-query-parameters.js
+++ b/lib/endpoint/add-query-parameters.js
@@ -21,7 +21,7 @@ function addQueryParameters (url, parameters) {
     .join('&')
 }
 
-function escapedSplit(s, splitChar) {
+function escapedSplit (s, splitChar) {
   if (!s.includes('\\')) {
     return s.split(splitChar)
   }
@@ -30,7 +30,7 @@ function escapedSplit(s, splitChar) {
   let res = ['']
   for (let char of s) {
     if (escaped) {
-      res[res.length-1] += char
+      res[res.length - 1] += char
       escaped = false
     } else {
       if (char === '\\') {
@@ -38,7 +38,7 @@ function escapedSplit(s, splitChar) {
       } else if (char === '+') {
         res.push('')
       } else {
-        res[res.length-1] += char
+        res[res.length - 1] += char
       }
     }
   }

--- a/lib/endpoint/add-query-parameters.js
+++ b/lib/endpoint/add-query-parameters.js
@@ -35,7 +35,7 @@ function escapedSplit (s, splitChar) {
     } else {
       if (char === '\\') {
         escaped = true
-      } else if (char === '+') {
+      } else if (char === splitChar) {
         res.push('')
       } else {
         res[res.length - 1] += char


### PR DESCRIPTION
Previously, cases such as

```javascript
octokit.search.repos({ q: 'language:"C++"' })
```
Got an error with the message: `None of the search qualifiers apply to this search type`. It was because [lib/endpoint/add-query-parameters.js](/octokit/rest.js/blob/master/lib/endpoint/add-query-parameters.js) treated the `q` parameter differently, by splitting it at each  `+`. At first, I started fixing this by escaping every `+` in quotes. But this felt too specific to my use case and complicated for no reason, so I preferred introducing escaping through the `\` character. Now:

```javascript
octokit.search.repos({ q: 'language:"C\\+\\+"' })
```

Works as intended.

Meaning: now, when you put data that might have a `+` in it into a query, you can replace it by `s.replace(/\+/g, `\\+')` whereas before it was just broken.

Do you guys have a better implementation idea? Another syntax?

Great lib!