### PR TITLE
Remove references to 'head_branch' from Checks API

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -1135,10 +1135,6 @@
         "external_id": {
           "type": "string"
         },
-        "head_branch": {
-          "required": true,
-          "type": "string"
-        },
         "head_sha": {
           "required": true,
           "type": "string"
@@ -1241,9 +1237,6 @@
       },
       "method": "POST",
       "params": {
-        "head_branch": {
-          "type": "string"
-        },
         "head_sha": {
           "required": true,
           "type": "string"

--- a/test/issues/861-custom-accept-header-test.js
+++ b/test/issues/861-custom-accept-header-test.js
@@ -28,7 +28,6 @@ describe('https://github.com/octokit/rest.js/issues/861', () => {
       owner: 'swinton',
       repo: 'example',
       name: 'feedback',
-      head_branch: 'helloworld',
       head_sha: '2e3d00a6f14a667d50ad9ccd6f3dcfded52121e2',
       status: 'completed',
       started_at: (new Date()).toISOString(),

--- a/test/issues/922-create-check-with-empty-actions-array-test.js
+++ b/test/issues/922-create-check-with-empty-actions-array-test.js
@@ -15,7 +15,6 @@ describe('https://github.com/octokit/rest.js/issues/922', () => {
       repo: 'test',
       name: 'QA',
       head_sha: 'SHA',
-      head_branch: 'XXX',
       status: 'in_progress',
       started_at: '2018-01-01T06:00:00Z',
       output: {


### PR DESCRIPTION
I did not find any mention of `head_branch` in the Checks API documentation:
* https://developer.github.com/v3/checks/suites/ - except in the response examples
* https://developer.github.com/v3/checks/runs/

However, on the archived version of the page from the 8th of May, it does appear as a required parameter: https://web.archive.org/web/20180508231639/https://developer.github.com/v3/checks/suites/

So my guess is that this parameter was formerly required but has since been removed. Therefore, it should be safe to remove it as well from this client of the API.