### PR TITLE
chore(package): Move @gimenete/type-writer to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "node": ">=4"
   },
   "dependencies": {
-    "@gimenete/type-writer": "^0.1.3",
     "before-after-hook": "^1.1.0",
     "btoa-lite": "^1.0.0",
     "debug": "^3.1.0",
@@ -47,6 +46,7 @@
     "url-template": "^2.0.8"
   },
   "devDependencies": {
+    "@gimenete/type-writer": "^0.1.3",
     "@gr2m/node-fetch": "^2.0.0",
     "@octokit/fixtures-server": "^2.1.5",
     "@octokit/routes": "11.4.2",


### PR DESCRIPTION
I asked about this in https://github.com/octokit/rest.js/pull/948#discussion_r213400451, but thought I'd open a PR to discuss. It looks like this is only used in the build process, so I don't think it needs to be a runtime dependency.

cc @gimenete @gr2m 

closes https://github.com/octokit/rest.js/issues/1004