### PR TITLE
Add authentication as a GitHub app

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,23 @@ octokit.authenticate({
   type: 'app',
   token: 'secrettoken123'
 })
+
+// GitHub app, authenticating as the application
+// Allowing access to the endpoints marked as requiring a JWT at https://developer.github.com/v3/apps/
+octokit.authenticate({
+  type: 'app',
+  appId: 'your_app_id',
+  privateKey: 'your_private_key'
+})
+
+// GitHub app, authenticating as an installation
+// Allowing access to the endpoints at https://developer.github.com/v3/apps/available-endpoints/
+octokit.authenticate({
+  type: 'app',
+  appId: 'your_app_id',
+  installationId: 'installation_id',
+  privateKey: 'your_private_key'
+})
 ```
 
 Note: `authenticate` is synchronous because it only sets the credentials

--- a/README.md
+++ b/README.md
@@ -141,13 +141,32 @@ octokit.authenticate({
   type: 'app',
   token: 'secrettoken123'
 })
+```
+
+Authenticating as a Github App is slightly more involved. It is up to you to
+provide a JSON Web Token, as this process differs between node and browsers.
+On node we recommend using the `jsonwebtoken` package.
+
+```javascript
+const jsonwebtoken = require('jsonwebtoken')
+
+function jwt (id, pem) {
+  const payload = {
+    iat: Math.floor(Date.now() / 1000), // Issued at time
+    exp: Math.floor(Date.now() / 1000) + 60, // JWT expiration time
+    iss: id // Integration's GitHub id
+  }
+
+  // Sign with RSA SHA256
+  return jsonwebtoken.sign(payload, pem, {algorithm: 'RS256'})
+}
 
 // GitHub app, authenticating as the application
 // Allowing access to the endpoints marked as requiring a JWT at https://developer.github.com/v3/apps/
 octokit.authenticate({
   type: 'app',
   appId: 'your_app_id',
-  privateKey: 'your_private_key'
+  appTokenGenerator: (id) => jwt(id, 'your_private_key')
 })
 
 // GitHub app, authenticating as an installation
@@ -156,7 +175,7 @@ octokit.authenticate({
   type: 'app',
   appId: 'your_app_id',
   installationId: 'installation_id',
-  privateKey: 'your_private_key'
+  appTokenGenerator: (id) => jwt(id, 'your_private_key')
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -165,8 +165,7 @@ function jwt (id, pem) {
 // Allowing access to the endpoints marked as requiring a JWT at https://developer.github.com/v3/apps/
 octokit.authenticate({
   type: 'app',
-  appId: 'your_app_id',
-  appTokenGenerator: (id) => jwt(id, 'your_private_key')
+  appTokenGenerator: () => jwt('your_app_id', 'your_private_key')
 })
 
 // GitHub app, authenticating as an installation
@@ -175,7 +174,7 @@ octokit.authenticate({
   type: 'app',
   appId: 'your_app_id',
   installationId: 'installation_id',
-  appTokenGenerator: (id) => jwt(id, 'your_private_key')
+  appTokenGenerator: () => jwt('your_app_id', 'your_private_key')
 })
 ```
 

--- a/lib/plugins/authentication/authenticate.js
+++ b/lib/plugins/authentication/authenticate.js
@@ -1,8 +1,8 @@
-const Lru = require('lru-cache')
-
 module.exports = authenticate
 
 function authenticate (state, options) {
+  state.tokenCache = null
+
   if (!options) {
     state.auth = false
     return
@@ -26,10 +26,6 @@ function authenticate (state, options) {
     case 'app':
       if (!options.token && !options.appTokenGenerator) {
         throw new Error('App authentication requires a token or appTokenGenerator to be set')
-      }
-      if (options.appTokenGenerator) {
-        // Max age of 55 mins, default token expiry is 1 hour
-        state.credentialCache = new Lru({max: 1000, maxAge: 3300})
       }
       break
 

--- a/lib/plugins/authentication/authenticate.js
+++ b/lib/plugins/authentication/authenticate.js
@@ -1,3 +1,5 @@
+const Lru = require('lru-cache')
+
 module.exports = authenticate
 
 function authenticate (state, options) {
@@ -22,8 +24,12 @@ function authenticate (state, options) {
     case 'token':
     case 'integration':
     case 'app':
-      if (!options.token) {
-        throw new Error('Token authentication requires a token to be set')
+      if (!options.token && !(options.appId && options.privateKey)) {
+        throw new Error('App authentication requires a token or appId & privateKey to be set')
+      }
+      if (options.appId) {
+        // Max age of 55 mins, default token expiry is 1 hour
+        state.credentialCache = new Lru({max: 1000, maxAge: 3300})
       }
       break
 

--- a/lib/plugins/authentication/authenticate.js
+++ b/lib/plugins/authentication/authenticate.js
@@ -24,10 +24,10 @@ function authenticate (state, options) {
     case 'token':
     case 'integration':
     case 'app':
-      if (!options.token && !(options.appId && options.privateKey)) {
-        throw new Error('App authentication requires a token or appId & privateKey to be set')
+      if (!options.token && !options.appTokenGenerator) {
+        throw new Error('App authentication requires a token or appTokenGenerator to be set')
       }
-      if (options.appId) {
+      if (options.appTokenGenerator) {
         // Max age of 55 mins, default token expiry is 1 hour
         state.credentialCache = new Lru({max: 1000, maxAge: 3300})
       }

--- a/lib/plugins/authentication/before-request.js
+++ b/lib/plugins/authentication/before-request.js
@@ -1,11 +1,12 @@
 module.exports = authenticationBeforeRequest
 
 const btoa = require('btoa-lite')
+const jsonwebtoken = require('jsonwebtoken')
 const uniq = require('lodash/uniq')
 
 const deprecate = require('../../deprecate')
 
-function authenticationBeforeRequest (state, options) {
+function authenticationBeforeRequest (state, octokit, options) {
   if (!state.auth.type) {
     return
   }
@@ -28,11 +29,56 @@ function authenticationBeforeRequest (state, options) {
   }
 
   if (state.auth.type === 'app') {
-    options.headers['authorization'] = `Bearer ${state.auth.token}`
-    const acceptHeaders = options.headers['accept'].split(',')
-      .concat('application/vnd.github.machine-man-preview+json')
-    options.headers['accept'] = uniq(acceptHeaders).filter(Boolean).join(',')
-    return
+    // If you set your own authorization header then you're on your own.
+    // This avoids infinite loops when we want to request per-installation
+    // access tokens when authorized as the app down below
+    if (options.headers.authorization) {
+      return
+    }
+
+    // If we have a token then use it
+    if (state.auth.token) {
+      options = optionsForAppToken(options, state.auth.token)
+      return
+    }
+
+    // If we have an appId but no installationId then authenticate as the app,
+    // using a token generated from the private key
+    if (!state.auth.installationId) {
+      options = optionsForAppToken(options, jwt(state.auth.appId, state.auth.privateKey))
+      return
+    }
+
+    // If we're dealing with a particular installation then we have use the
+    // token for that installation
+
+    // If we have a token stored in the cache then use it
+    const cacheKey = state.auth.appId + ':' + state.auth.installationId
+    const token = state.credentialCache.get(cacheKey)
+    if (token) {
+      options = optionsForAppToken(options, token)
+      return
+    }
+
+    // Otherwise we have to get an installation token while authed as the
+    // application, use it for the current request and store it to avoid
+    // rerequesting it on future requests
+    return (octokit.apps.createInstallationToken({
+      installation_id: state.auth.installationId,
+      headers: {
+        'accept': 'application/vnd.github.machine-man-preview+json',
+        'authorization': `Bearer ${jwt(state.auth.appId, state.auth.privateKey)}`
+      }
+    }).then(response => {
+      const token = response.data.token
+      // Cache for one minute (60000ms) less than how long the response says the
+      // token is valid for. This reduces the risk of using an expired token
+      const tokenDurationInMs = new Date(response.data.expires_at) - new Date()
+      const cacheDurationInMs = tokenDurationInMs - 60000
+
+      state.credentialCache.set(cacheKey, token, cacheDurationInMs)
+      options = optionsForAppToken(options, token)
+    }))
   }
 
   options.url += options.url.indexOf('?') === -1 ? '?' : '&'
@@ -45,4 +91,24 @@ function authenticationBeforeRequest (state, options) {
   const key = encodeURIComponent(state.auth.key)
   const secret = encodeURIComponent(state.auth.secret)
   options.url += `client_id=${key}&client_secret=${secret}`
+}
+
+function jwt (id, pem) {
+  const payload = {
+    iat: Math.floor(new Date() / 1000), // Issued at time
+    exp: Math.floor(new Date() / 1000) + 60, // JWT expiration time
+    iss: id // Integration's GitHub id
+  }
+
+  // Sign with RSA SHA256
+  return jsonwebtoken.sign(payload, pem, {algorithm: 'RS256'})
+}
+
+function optionsForAppToken (options, token) {
+  options.headers['authorization'] = `Bearer ${token}`
+  const acceptHeaders = options.headers['accept'].split(',')
+    .concat('application/vnd.github.machine-man-preview+json')
+  options.headers['accept'] = uniq(acceptHeaders).filter(Boolean).join(',')
+
+  return options
 }

--- a/lib/plugins/authentication/before-request.js
+++ b/lib/plugins/authentication/before-request.js
@@ -1,7 +1,6 @@
 module.exports = authenticationBeforeRequest
 
 const btoa = require('btoa-lite')
-const jsonwebtoken = require('jsonwebtoken')
 const uniq = require('lodash/uniq')
 
 const deprecate = require('../../deprecate')
@@ -38,14 +37,13 @@ function authenticationBeforeRequest (state, octokit, options) {
 
     // If we have a token then use it
     if (state.auth.token) {
-      options = optionsForAppToken(options, state.auth.token)
+      setBearerToken(options, state.auth.token)
       return
     }
 
-    // If we have an appId but no installationId then authenticate as the app,
-    // using a token generated from the private key
+    // If we have no installationId then authenticate as the app
     if (!state.auth.installationId) {
-      options = optionsForAppToken(options, jwt(state.auth.appId, state.auth.privateKey))
+      setBearerToken(options, state.auth.appTokenGenerator())
       return
     }
 
@@ -53,10 +51,9 @@ function authenticationBeforeRequest (state, octokit, options) {
     // token for that installation
 
     // If we have a token stored in the cache then use it
-    const cacheKey = state.auth.appId + ':' + state.auth.installationId
-    const token = state.credentialCache.get(cacheKey)
+    const token = state.credentialCache.get(state.auth.installationId)
     if (token) {
-      options = optionsForAppToken(options, token)
+      setBearerToken(options, token)
       return
     }
 
@@ -67,17 +64,17 @@ function authenticationBeforeRequest (state, octokit, options) {
       installation_id: state.auth.installationId,
       headers: {
         'accept': 'application/vnd.github.machine-man-preview+json',
-        'authorization': `Bearer ${jwt(state.auth.appId, state.auth.privateKey)}`
+        'authorization': `Bearer ${state.auth.appTokenGenerator()}`
       }
     }).then(response => {
       const token = response.data.token
       // Cache for one minute (60000ms) less than how long the response says the
       // token is valid for. This reduces the risk of using an expired token
-      const tokenDurationInMs = new Date(response.data.expires_at) - new Date()
+      const tokenDurationInMs = new Date(response.data.expires_at) - Date.now()
       const cacheDurationInMs = tokenDurationInMs - 60000
 
-      state.credentialCache.set(cacheKey, token, cacheDurationInMs)
-      options = optionsForAppToken(options, token)
+      state.credentialCache.set(state.auth.installationId, token, cacheDurationInMs)
+      setBearerToken(options, token)
     }))
   }
 
@@ -93,22 +90,9 @@ function authenticationBeforeRequest (state, octokit, options) {
   options.url += `client_id=${key}&client_secret=${secret}`
 }
 
-function jwt (id, pem) {
-  const payload = {
-    iat: Math.floor(new Date() / 1000), // Issued at time
-    exp: Math.floor(new Date() / 1000) + 60, // JWT expiration time
-    iss: id // Integration's GitHub id
-  }
-
-  // Sign with RSA SHA256
-  return jsonwebtoken.sign(payload, pem, {algorithm: 'RS256'})
-}
-
-function optionsForAppToken (options, token) {
+function setBearerToken (options, token) {
   options.headers['authorization'] = `Bearer ${token}`
   const acceptHeaders = options.headers['accept'].split(',')
     .concat('application/vnd.github.machine-man-preview+json')
   options.headers['accept'] = uniq(acceptHeaders).filter(Boolean).join(',')
-
-  return options
 }

--- a/lib/plugins/authentication/before-request.js
+++ b/lib/plugins/authentication/before-request.js
@@ -51,9 +51,8 @@ function authenticationBeforeRequest (state, octokit, options) {
     // token for that installation
 
     // If we have a token stored in the cache then use it
-    const token = state.credentialCache.get(state.auth.installationId)
-    if (token) {
-      setBearerToken(options, token)
+    if (state.tokenCache && state.tokenCache.expiresAt > Date.now()) {
+      setBearerToken(options, state.tokenCache.token)
       return
     }
 
@@ -67,14 +66,16 @@ function authenticationBeforeRequest (state, octokit, options) {
         'authorization': `Bearer ${state.auth.appTokenGenerator()}`
       }
     }).then(response => {
-      const token = response.data.token
-      // Cache for one minute (60000ms) less than how long the response says the
-      // token is valid for. This reduces the risk of using an expired token
-      const tokenDurationInMs = new Date(response.data.expires_at) - Date.now()
-      const cacheDurationInMs = tokenDurationInMs - 60000
+      // Store the token in the cache for next time
+      // Claim the token expires one minute (60000ms) earlier than when the
+      // response says the token expires. This reduces the risk of using an
+      // expired token in case our local time is a bit out
+      state.tokenCache = {
+        token: response.data.token,
+        expiresAt: new Date(response.data.expires_at).getTime() - 60000
+      }
 
-      state.credentialCache.set(state.auth.installationId, token, cacheDurationInMs)
-      setBearerToken(options, token)
+      setBearerToken(options, response.data.token)
     }))
   }
 

--- a/lib/plugins/authentication/index.js
+++ b/lib/plugins/authentication/index.js
@@ -6,7 +6,7 @@ const beforeRequest = require('./before-request')
 function authenticationPlugin (octokit) {
   const state = {
     auth: false,
-    credentialCache: null
+    tokenCache: null
   }
   octokit.authenticate = authenticate.bind(null, state)
   octokit.hook.before('request', beforeRequest.bind(null, state, octokit))

--- a/lib/plugins/authentication/index.js
+++ b/lib/plugins/authentication/index.js
@@ -5,8 +5,9 @@ const beforeRequest = require('./before-request')
 
 function authenticationPlugin (octokit) {
   const state = {
-    auth: false
+    auth: false,
+    credentialCache: null
   }
   octokit.authenticate = authenticate.bind(null, state)
-  octokit.hook.before('request', beforeRequest.bind(null, state))
+  octokit.hook.before('request', beforeRequest.bind(null, state, octokit))
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "debug": "^3.1.0",
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.0",
+    "jsonwebtoken": "^8.3.0",
     "lodash": "^4.17.4",
+    "lru-cache": "^4.1.3",
     "node-fetch": "^2.1.1",
     "url-template": "^2.0.8"
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.0",
     "lodash": "^4.17.4",
-    "lru-cache": "^4.1.3",
     "node-fetch": "^2.1.1",
     "url-template": "^2.0.8"
   },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "debug": "^3.1.0",
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.0",
-    "jsonwebtoken": "^8.3.0",
     "lodash": "^4.17.4",
     "lru-cache": "^4.1.3",
     "node-fetch": "^2.1.1",

--- a/test/integration/authentication-test.js
+++ b/test/integration/authentication-test.js
@@ -106,7 +106,7 @@ describe('authentication', () => {
     return github.repos.getForOrg({org: 'myorg', per_page: 1})
   })
 
-  it('app', () => {
+  it('app with token', () => {
     nock('https://authentication-test-host.com', {
       reqheaders: {
         authorization: 'Bearer abc4567'
@@ -121,6 +121,132 @@ describe('authentication', () => {
     })
 
     return github.orgs.get({org: 'myorg'})
+  })
+
+  it('app with appTokenGenerator', () => {
+    const tokenGenerator = () => 'abcdef'
+
+    nock('https://authentication-test-host.com', {
+      reqheaders: {
+        accept: 'application/vnd.github.machine-man-preview+json',
+        authorization: 'Bearer abcdef'
+      }
+    })
+      .get('/app/installations')
+      .reply(200, {})
+
+    nock('https://authentication-test-host.com', {
+      reqheaders: {
+        authorization: 'Bearer v.xyx789'
+      }
+    })
+      .get('/orgs/myorg')
+      .reply(200, {})
+
+    github.authenticate({
+      type: 'app',
+      appTokenGenerator: tokenGenerator
+    })
+
+    return github.apps.getInstallations({})
+  })
+
+  it('app with appTokenGenerator and installationId - reusing cached token', () => {
+    const tokenGenerator = () => 'abcdef'
+
+    nock('https://authentication-test-host.com', {
+      reqheaders: {
+        accept: 'application/vnd.github.machine-man-preview+json',
+        authorization: 'Bearer abcdef'
+      }
+    })
+      .post('/app/installations/456/access_tokens')
+      .once()
+      .reply(201, {
+        'token': 'v.xyx789',
+        'expires_at': '2118-09-01T00:00:00Z'
+      })
+
+    nock('https://authentication-test-host.com', {
+      reqheaders: {
+        authorization: 'Bearer v.xyx789'
+      }
+    })
+      .get('/orgs/myorg')
+      .twice()
+      .reply(200, {})
+
+    github.authenticate({
+      type: 'app',
+      appTokenGenerator: tokenGenerator,
+      installationId: 456
+    })
+
+    return github.orgs.get({org: 'myorg'}).then(() => {
+      // Make a second request to prove that the token is reused
+      github.orgs.get({org: 'myorg'})
+    })
+  })
+
+  it('app with appTokenGenerator and installationId - requesting new token after expiry', () => {
+    const tokenGenerator = () => {
+      return 'abcdef'
+    }
+
+    nock('https://authentication-test-host.com', {
+      reqheaders: {
+        accept: 'application/vnd.github.machine-man-preview+json',
+        authorization: 'Bearer abcdef'
+      }
+    })
+      .post('/app/installations/456/access_tokens')
+      .once()
+      .reply(201, {
+        'token': 'v.xyx789',
+        'expires_at': '2008-09-01T00:00:00Z'
+      })
+
+    nock('https://authentication-test-host.com', {
+      reqheaders: {
+        accept: 'application/vnd.github.machine-man-preview+json',
+        authorization: 'Bearer abcdef'
+      }
+    })
+      .post('/app/installations/456/access_tokens')
+      .once()
+      .reply(201, {
+        'token': 'v.ghj567',
+        'expires_at': '2008-09-01T00:00:00Z'
+      })
+
+    nock('https://authentication-test-host.com', {
+      reqheaders: {
+        authorization: 'Bearer v.xyx789'
+      }
+    })
+      .get('/orgs/myorg')
+      .once()
+      .reply(200, {})
+
+    nock('https://authentication-test-host.com', {
+      reqheaders: {
+        authorization: 'Bearer v.ghj567'
+      }
+    })
+      .get('/orgs/myorg')
+      .once()
+      .reply(200, {})
+
+    github.authenticate({
+      type: 'app',
+      appTokenGenerator: tokenGenerator,
+      installationId: 456
+    })
+
+    return github.orgs.get({org: 'myorg'}).then(() => {
+      // Make a second request to prove that the token is rerequested
+      github.orgs.get({org: 'myorg'})
+    }).catch(() => {})
   })
 
   it('authenticate without options', () => {


### PR DESCRIPTION
Allows you to pass in an `appId` and `privateKey` to the authenticate
method to authenticate as an app

Allows you to pass in an `appId`, `privateKey` and `installationId` to
the authenticate method to authenticate as an installation of an app.

When passing `installationId` it will request an access token for that
installation, cache the token and use it for subsequent requests.
Shortly before the token for the installation expires a new token shall
be automatically requested.

---

Here's the implementation. I've not wrote tests just yet in case people have feedback about the approach.

This solves the usecase for private apps where there is only ever one installation.
For public apps where the consumer of octokit needs to act on behalf of multiple installations they shall need to create multiple instances of octokit - one for each installation.

You can see this in action:

Save the following examples (replacing appId and installationId as appropriate) as `testing.js` within the root of the octokit repo and run them with: `DEBUG=octokit:rest* node ./testing.js` to see API requests 

### Authenticating as an application:

```js
const fs = require('fs')

const keyPath = 'filepath_to_an_application_private_key'
const octokit = require('.')({debug: true})
const appId = 14631 // Change to your app ID 
const installationId = 312666 // Change to your installation ID

octokit.authenticate({
  type: 'app',
  appId: appId,
  privateKey: fs.readFileSync(keyPath, 'utf8')
})

octokit.apps.getInstallations().then(console.log)
```

### Authenticating as an installation

```js
const fs = require('fs')

const keyPath = 'filepath_to_an_application_private_key'
const octokit = require('.')({debug: true})
const appId = 14631 // Change to your app ID 
const installationId = 312666 // Change to your installation ID

octokit.authenticate({
  type: 'app',
  appId: appId,
  installationId: installationId,
  privateKey: fs.readFileSync(keyPath, 'utf8')
})

octokit.apps.getInstallationRepositories().then((response) => {
  console.log(response);

  octokit.apps.getInstallationRepositories().then((response) => {
    console.log('A second request, note it reusing installation tokens rather than requesting them every time');
    console.log(response);
  })
})
```


