### PR TITLE
Add the namespace to the generated return types

### DIFF
--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -127,7 +127,7 @@ function generateTypes (languageName, templateFile, outputFile) {
       let responseType = 'Github.AnyResponse'
       if (entry[1].responses) {
         const typeName = 'Github.' + typeWriter.add(entry[1].responses.map(response => response.body || {}), {
-          rootTypeName: pascalcase(`${entry[0]}Response`)
+          rootTypeName: pascalcase(`${namespace}-${entry[0]}Response`)
         })
         responseType = 'Github.Response<' + typeName + '>'
       }

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -41,6 +41,15 @@ export default async function() {
   repo.headers.etag
   repo.headers.status
 
+  const user = await octokit.users.getForUser({username: 'octokit'})
+  // Check Response
+  user.data.login
+  user.data.type
+  
+  const userIssues = await octokit.issues.getForUser({state: 'open'})
+  // Check Response
+  userIssues.data[0].locked
+
   await octokit.issues.addLabels({
     owner: 'octokit',
     repo: 'rest.js',


### PR DESCRIPTION
This ensures each response type is unique, as there are cases where the
same function name exists under multiple namespaces - e.g.
`octokit.issues.getForUser` and `octokit.users.getForUser` (along with
many other getForUser functions).

Prior to this commit a single type `GetForUserResponse` was created,
which was resulted in multiple functions using this one type, and
type being wrong for many of those functions.

Now multiple types are defined - `IssuesGetForUserResponse` and
`UsersGetForUserResponse` etc - one for each function-in-a-namespace and there is no
overlap.

//cc @gimenete and @gr2m


