### PR TITLE
fix(routes): update `check_run_id` and `check_suite_id` to integers (#1001)

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -1263,7 +1263,7 @@
       "params": {
         "check_run_id": {
           "required": true,
-          "type": "string"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -1284,7 +1284,7 @@
       "params": {
         "check_suite_id": {
           "required": true,
-          "type": "string"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -1305,7 +1305,7 @@
       "params": {
         "check_run_id": {
           "required": true,
-          "type": "string"
+          "type": "integer"
         },
         "owner": {
           "required": true,
@@ -1380,7 +1380,7 @@
         },
         "check_suite_id": {
           "required": true,
-          "type": "string"
+          "type": "integer"
         },
         "filter": {
           "enum": [
@@ -1522,7 +1522,7 @@
         },
         "check_run_id": {
           "required": true,
-          "type": "string"
+          "type": "integer"
         },
         "completed_at": {
           "type": "string"

--- a/scripts/routes-for-api-docs.json
+++ b/scripts/routes-for-api-docs.json
@@ -4370,7 +4370,7 @@
         },
         {
           "name": "check_run_id",
-          "type": "string",
+          "type": "integer",
           "required": true,
           "description": "",
           "location": "url"
@@ -4480,7 +4480,7 @@
         },
         {
           "name": "check_suite_id",
-          "type": "string",
+          "type": "integer",
           "required": true,
           "description": "",
           "location": "url"
@@ -4659,7 +4659,7 @@
         },
         {
           "name": "check_run_id",
-          "type": "string",
+          "type": "integer",
           "required": true,
           "description": "",
           "location": "url"
@@ -4887,7 +4887,7 @@
         },
         {
           "name": "check_suite_id",
-          "type": "string",
+          "type": "integer",
           "required": true,
           "description": "",
           "location": "url"
@@ -5495,7 +5495,7 @@
         },
         {
           "name": "check_run_id",
-          "type": "string",
+          "type": "integer",
           "required": true,
           "description": "",
           "location": "url"


### PR DESCRIPTION
<!-- 
1. Push your changes to your topic branch on your fork of the repo.
2. Submit a pull request from your topic branch to the master branch on the `rest.js` repository.
3. Be sure to tag any issues your pull request is taking care of / contributing to.
4. Adding "Closes #123" to a pull request description will auto close the issue once the pull request is merged in. 
-->
This PR addresses the issue of incorrect interface's being generated from the routes (`scripts/routes-for-api-docs.json`).

`check_run_id` - `string` => `integer`
`check_suite_id` - `string` => `integer`

Closes #1001 