### PR TITLE
Expose mapped parameters in routes-for-api-docs.json

### DIFF
--- a/scripts/generate-routes.js
+++ b/scripts/generate-routes.js
@@ -234,6 +234,12 @@ Object.keys(CURRENT_ROUTES).sort().forEach(scope => {
       if (currentParams[name].alias || currentParams[name].mapTo) {
         currentEndpoint.params[name] = currentParams[name]
       }
+
+      // Add the mapped name to the newEndpoint so that we expose the
+      // mapped parameter in the documentation (and the typescript types)
+      if (currentParams[name].mapTo) {
+        newEndpoint.params.push({...currentParams[name], name: name})
+      }
     })
 
     // DEPRECATED: workaround to leave "validation" property. We won’t be able

--- a/scripts/routes-for-api-docs.json
+++ b/scripts/routes-for-api-docs.json
@@ -8793,6 +8793,12 @@
           "required": true,
           "description": "",
           "location": "url"
+        },
+        {
+          "mapTo": "input",
+          "required": true,
+          "type": "string[]",
+          "name": "labels"
         }
       ],
       "path": "/repos/:owner/:repo/issues/:number/labels",
@@ -13053,6 +13059,12 @@
           "required": true,
           "description": "",
           "location": "url"
+        },
+        {
+          "mapTo": "input",
+          "required": true,
+          "type": "string[]",
+          "name": "labels"
         }
       ],
       "path": "/repos/:owner/:repo/issues/:number/labels",
@@ -15485,7 +15497,14 @@
       "enabledForApps": true,
       "method": "POST",
       "name": "Render a Markdown document in raw mode",
-      "params": [],
+      "params": [
+        {
+          "mapTo": "input",
+          "required": true,
+          "type": "string",
+          "name": "data"
+        }
+      ],
       "path": "/markdown/raw",
       "responses": [
         {
@@ -25551,6 +25570,12 @@
           "required": true,
           "description": "",
           "location": "url"
+        },
+        {
+          "mapTo": "input",
+          "required": true,
+          "type": "string[]",
+          "name": "contexts"
         }
       ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
@@ -25599,6 +25624,12 @@
           "required": true,
           "description": "",
           "location": "url"
+        },
+        {
+          "mapTo": "input",
+          "required": true,
+          "type": "string[]",
+          "name": "teams"
         }
       ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
@@ -25658,6 +25689,12 @@
           "required": true,
           "description": "",
           "location": "url"
+        },
+        {
+          "mapTo": "input",
+          "required": true,
+          "type": "string[]",
+          "name": "users"
         }
       ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
@@ -34483,6 +34520,12 @@
           "required": true,
           "description": "",
           "location": "url"
+        },
+        {
+          "mapTo": "input",
+          "required": true,
+          "type": "string[]",
+          "name": "contexts"
         }
       ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
@@ -34561,6 +34604,12 @@
           "required": true,
           "description": "",
           "location": "url"
+        },
+        {
+          "mapTo": "input",
+          "required": true,
+          "type": "string[]",
+          "name": "teams"
         }
       ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
@@ -34620,6 +34669,12 @@
           "required": true,
           "description": "",
           "location": "url"
+        },
+        {
+          "mapTo": "input",
+          "required": true,
+          "type": "string[]",
+          "name": "users"
         }
       ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
@@ -34686,6 +34741,12 @@
           "required": true,
           "description": "",
           "location": "url"
+        },
+        {
+          "mapTo": "input",
+          "required": true,
+          "type": "string[]",
+          "name": "contexts"
         }
       ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts",
@@ -34733,6 +34794,12 @@
           "required": true,
           "description": "",
           "location": "url"
+        },
+        {
+          "mapTo": "input",
+          "required": true,
+          "type": "string[]",
+          "name": "teams"
         }
       ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams",
@@ -34792,6 +34859,12 @@
           "required": true,
           "description": "",
           "location": "url"
+        },
+        {
+          "mapTo": "input",
+          "required": true,
+          "type": "string[]",
+          "name": "users"
         }
       ],
       "path": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users",
@@ -36080,6 +36153,12 @@
           "description": "An alternate short description of the asset. Used in place of the filename. This should be set in a URI query parameter.",
           "required": false,
           "location": "query"
+        },
+        {
+          "mapTo": "input",
+          "required": true,
+          "type": "string | object",
+          "name": "file"
         }
       ],
       "path": ":url"
@@ -36953,7 +37032,14 @@
       "enabledForApps": false,
       "method": "POST",
       "name": "Add email address(es)",
-      "params": [],
+      "params": [
+        {
+          "mapTo": "input",
+          "required": true,
+          "type": "string[]",
+          "name": "emails"
+        }
+      ],
       "path": "/user/emails",
       "requests": [
         [
@@ -37255,7 +37341,14 @@
       "enabledForApps": false,
       "method": "DELETE",
       "name": "Delete email address(es)",
-      "params": [],
+      "params": [
+        {
+          "mapTo": "input",
+          "required": true,
+          "type": "string[]",
+          "name": "emails"
+        }
+      ],
       "path": "/user/emails",
       "requests": [
         [

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -40,4 +40,11 @@ export default async function() {
   repo.headers.link
   repo.headers.etag
   repo.headers.status
+
+  await octokit.issues.addLabels({
+    owner: 'octokit',
+    repo: 'rest.js',
+    number: 10,
+    labels: ['label'],
+  });
 }


### PR DESCRIPTION
Previously items with mapTo properties were not exposed in the API docs,
this means that when looking at the API docs you didn't know you had to
pass in a "labels" property to issues.addLabels.

This also means these properties will be exposed in the typescript
definitions, thus fixing @kkweon's issue in https://github.com/octokit/rest.js/issues/997#issuecomment-417406493

Compare https://octokit.github.io/rest.js/#api-Issues-addLabels with the following from running the docs locally after making this change, noting the extra "labels" field:

<img width="859" alt="screen shot 2018-09-04 at 4 44 15 pm" src="https://user-images.githubusercontent.com/227292/45063375-7de14900-b062-11e8-9deb-d92aae0d6a4b.png">

