### PR TITLE
Update createFromIssue

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -6104,6 +6104,10 @@
           "required": true,
           "type": "string"
         },
+        "issue": {
+          "required": true,
+          "type": "integer"
+        },
         "maintainer_can_modify": {
           "type": "boolean"
         },
@@ -6112,10 +6116,6 @@
           "type": "string"
         },
         "repo": {
-          "required": true,
-          "type": "string"
-        },
-        "title": {
           "required": true,
           "type": "string"
         }


### PR DESCRIPTION
It seems more logical to run `pullRequests.createFromIssue()` with an issue number and because `title` was a mandatory field, it could never work without throwing an error like this

> ERROR event: {"message":"You may only provide an issue number or a title string, but not both.","documentation_url":"https://developer.github.com/v3/pulls/#create-a-pull-request"}

