### PR TITLE
Update typings templates to fix issue with incorrect Link type

### DIFF
--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -120,7 +120,7 @@ declare namespace Github {
 
   export type Link =
     | { link: string; }
-    | { meta: { link: string; }; }
+    | { headers: { link: string; }; }
     | string;
 
   export interface Callback<T> {

--- a/scripts/templates/index.js.flow.tpl
+++ b/scripts/templates/index.js.flow.tpl
@@ -61,7 +61,7 @@ declare module "github" {
 
   declare type Link =
     | { link: string; }
-    | { meta: { link: string; }; }
+    | { headers: { link: string; }; }
     | string
     | any;
 


### PR DESCRIPTION
**Issue:** closes #1014 

**Changes:**
- `meta` property in typings templates was replaced with `headers`.

**Tested on:**
- TypeScript: 2.9.2
- Node: 8.11.2
- @octokit/rest: 15.11.0