### PR TITLE
Fix nullable params in TypeScript

### DIFF
--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -35,7 +35,8 @@ function parameterize (definition) {
     required: !definition.deprecated && definition.required,
     type: enums || type,
     alias: definition.alias,
-    deprecated: definition.deprecated
+    deprecated: definition.deprecated,
+    allowNull: definition.allowNull
   }
 }
 

--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -149,7 +149,7 @@ declare namespace Github {
        * @deprecated "{{key}}" has been renamed to "{{alias}}"
        */
        {{/deprecated}}
-      "{{key}}"{{^required}}?{{/required}}: {{{type}}};
+      "{{key}}"{{^required}}?{{/required}}: {{{type}}}{{#allowNull}} | null{{/allowNull}};
     {{/params}}
     };
     {{/ownParams}}


### PR DESCRIPTION
Closes https://github.com/octokit/rest.js/issues/1009

There were a total of 5 params that had `allowNull: true` in the routes file but that information was not being used when generating the type definitions file.