### PR TITLE
User Agent: don’t replace but amend

### DIFF
--- a/lib/endpoint/README.md
+++ b/lib/endpoint/README.md
@@ -32,7 +32,7 @@ const options = octokitRestEndpoint({
   method: 'GET',
   url: 'https://api.github.com/orgs/octokit/repos?type=private',
   headers: {
-    'user-agent': 'octokit/rest.js v1.2.3',
+    'user-agent': 'myApp v1.2.3',
     accept: 'application/vnd.github.v3+json'
   }
 }
@@ -58,7 +58,7 @@ e.g. `/orgs/:org/repos`. The `url` is parsed using
 | **method**             | `'get'`                                                                             |
 | **baseUrl**            | `'https://api.github.com'`                                                          |
 | **headers.accept**     | `'application/vnd.github.v3+json'`                                                  |
-| **headers.user-agent** | `'octokit/rest.js v1.2.3'` (1.2.3 being the current `@octokit.rest` version number) |
+| **headers.user-agent** | `'octokit/rest.js v1.2.3'` (1.2.3 being the current `@octokit/rest` version number) plus what ever [universal-user-agent](https://www.npmjs.com/package/universal-user-agent) returns. If you pass a custom value such as `myApp v1.2.3` then it will be used as prefix |
 
 _To be done_: change defaults with
 

--- a/lib/endpoint/defaults.js
+++ b/lib/endpoint/defaults.js
@@ -1,11 +1,8 @@
-const pkg = require('../../package.json')
-
 module.exports = {
   method: 'get',
   baseUrl: 'https://api.github.com',
   headers: {
-    accept: 'application/vnd.github.v3+json',
-    'user-agent': `octokit/rest.js v${pkg.version}`
+    accept: 'application/vnd.github.v3+json'
   },
   request: {}
 }

--- a/lib/endpoint/index.js
+++ b/lib/endpoint/index.js
@@ -7,9 +7,11 @@ const intersection = require('lodash/intersection')
 const mapKeys = require('lodash/mapKeys')
 const omit = require('lodash/omit')
 const urlTemplate = require('url-template')
+const getUserAgent = require('universal-user-agent')
 
 const addQueryParameters = require('./add-query-parameters')
 const extractUrlVariableNames = require('./extract-url-variable-names')
+const pkg = require('../../package.json')
 
 const DEFAULTS = module.exports.DEFAULTS = require('./defaults')
 const NON_PARAMETERS = [
@@ -20,6 +22,12 @@ const NON_PARAMETERS = [
 function restEndpoint (options) {
   // lowercase header names (#760)
   options.headers = mapKeys(options.headers, (value, key) => key.toLowerCase())
+
+  let userAgent = `octokit.js/${pkg.version} ${getUserAgent()}`
+  if (options.headers['user-agent']) {
+    userAgent = `${options.headers['user-agent']} ${userAgent}`
+  }
+  options.headers['user-agent'] = userAgent
 
   options = defaultsDeep({}, options, DEFAULTS)
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "https-proxy-agent": "^2.2.0",
     "lodash": "^4.17.4",
     "node-fetch": "^2.1.1",
+    "universal-user-agent": "^2.0.0",
     "url-template": "^2.0.8"
   },
   "devDependencies": {

--- a/test/integration/pagination-test.js
+++ b/test/integration/pagination-test.js
@@ -8,8 +8,7 @@ describe('pagination', () => {
   it('first / previous / next / last', (done) => {
     nock('https://pagination-test.com', {
       reqheaders: {
-        authorization: 'token secrettoken123',
-        'user-agent': `octokit/rest.js v0.0.0-semantically-released`
+        authorization: 'token secrettoken123'
       }
     })
       .get('/organizations')

--- a/test/integration/smoke-test.js
+++ b/test/integration/smoke-test.js
@@ -1,4 +1,5 @@
 const nock = require('nock')
+const getUserAgent = require('universal-user-agent')
 
 const GitHub = require('../../')
 
@@ -53,7 +54,7 @@ describe('smoke', () => {
   it('custom header', () => {
     nock('https://smoke-test.com', {
       reqheaders: {
-        'user-agent': 'blah'
+        'user-agent': `blah octokit.js/0.0.0-semantically-released ${getUserAgent()}`
       }
     })
       .get('/orgs/octokit')
@@ -63,7 +64,7 @@ describe('smoke', () => {
       baseUrl: 'https://smoke-test.com'
     })
 
-    github.orgs.get({
+    return github.orgs.get({
       org: 'octokit',
       headers: {
         'User-Agent': 'blah'


### PR DESCRIPTION
Closes #907.

This change aligns with the implementations of other Octokit libraries. Technically, this is a breaking change. But we decided to ship it as a feature release because

1. It’s very unlikely to break anyone’s code. If anything it might break some tests
2. GitHub is very interested to understand how the Octokit libraries are being used, and ideally we want to know for the current version and the past few versions as well.

The resulting user agent header will now look like this in browsers

- default: `octokit.js/15.12.0 Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36`
- with `headers['user-agent']` set to 'myApp 4.5.6' in the [constructor client options](https://github.com/octokit/rest.js/tree/ff3fb7d9fa06e86a290916257a2f5f98e2cce5e2#client-options): `myApp 4.5.6 octokit.js/15.12.0 Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36`

And in Node

- default: `octokit.js/15.12.0 Node.js/8.9.4 (macOS High Sierra; x64)`
- with `headers['user-agent']` set to 'myApp 4.5.6' in the [constructor client options](https://github.com/octokit/rest.js/tree/ff3fb7d9fa06e86a290916257a2f5f98e2cce5e2#client-options): `myApp 4.5.6 octokit.js/15.12.0 Node.js/8.9.4 (macOS High Sierra; x64)`

where `15.12.0` will be the respective `@octokit/rest` version, and later the `octokit` version once we release the main package (probably with v17)