### PR TITLE
Using custom http-client for request sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ const octokit = require('@octokit/rest')({
   baseUrl: 'https://api.github.com',
 
   // Node only: advanced request options can be passed as http(s) agent
-  agent: undefined
+  agent: undefined,
+
+  // User function to make http calls can be passed
+  httpClient: undefined
 })
 ```
 

--- a/lib/parse-client-options.js
+++ b/lib/parse-client-options.js
@@ -65,6 +65,11 @@ function parseOptions (userOptions) {
       clientDefaults.baseUrl += '/' + userOptions.pathPrefix.replace(/(^[/]+|[/]+$)/g, '')
     }
   }
+
+  if (userOptions.httpClient) {
+    clientDefaults.request.client = userOptions.httpClient
+  }
+
   /* istanbul ignore else */
 
   if (!process.browser) {

--- a/lib/request/request.js
+++ b/lib/request/request.js
@@ -38,9 +38,8 @@ function request (requestOptions) {
 
   let headers = {}
   let status
-
-  return fetch(requestOptions.url, pick(requestOptions, 'method', 'body', 'headers', 'timeout', 'agent'))
-
+  const sendRequest = requestOptions.client || fetch
+  return sendRequest(requestOptions.url, pick(requestOptions, 'method', 'body', 'headers', 'timeout', 'agent'))
     .then(response => {
       status = response.status
       for (const keyAndValue of response.headers.entries()) {

--- a/test/unit/parse-client-options-test.js
+++ b/test/unit/parse-client-options-test.js
@@ -1,0 +1,14 @@
+require('../mocha-node-setup')
+
+const parseOptions = require('../../lib/parse-client-options')
+
+describe('parseOptions(options)', () => {
+  it('options.httpClient)', () => {
+    const options = parseOptions({
+      httpClient: 'foo',
+      url: '/'
+    })
+
+    expect(options.request.client).to.equal('foo')
+  })
+})


### PR DESCRIPTION
Allows you to pass custom http client via user options.

```javascript
const got = require('got'); //for example

const github = new GitHubApi({
    httpClient: got,
    baseUrl: makeUrl()
});
```

We need the ability to pass our own module to make network calls. Used ```node-fetch``` unfortunately does not satisfy us, because in our case there is a complex logic of request retries in an unstable network environment, as well as own logging.



<!-- 
1. Push your changes to your topic branch on your fork of the repo.
2. Submit a pull request from your topic branch to the master branch on the `rest.js` repository.
3. Be sure to tag any issues your pull request is taking care of / contributing to.
4. Adding "Closes #123" to a pull request description will auto close the issue once the pull request is merged in. 
-->