### PR TITLE
Add preview header to rerequestSuite

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -1481,6 +1481,9 @@
       "url": "/repos/:owner/:repo/check-suite-requests"
     },
     "rerequestSuite": {
+      "headers": {
+        "accept": "application/vnd.github.antiope-preview+json"
+      },
       "method": "POST",
       "params": {
         "check_suite_id": {


### PR DESCRIPTION
Adds missing preview header needed by `const result = await octokit.checks.rerequestSuite({owner, repo, check_suite_id})`

Closes #1032 