### PR TITLE
Add mercy-preview header to apps.getInstallationRepositories

### DIFF
--- a/lib/routes.json
+++ b/lib/routes.json
@@ -692,7 +692,7 @@
     },
     "getInstallationRepositories": {
       "headers": {
-        "accept": "application/vnd.github.machine-man-preview+json"
+        "accept": "application/vnd.github.mercy-preview+json,application/vnd.github.machine-man-preview+json"
       },
       "method": "GET",
       "params": {

--- a/test/integration/apps-test.js
+++ b/test/integration/apps-test.js
@@ -77,11 +77,11 @@ describe('apps', () => {
     })
   })
 
-  it('adds "machine-man" preview header when authenticated as installation', () => {
+  it('adds "mercy" and "machine-man" preview headers when authenticated as installation', () => {
     nock('https://apps-test-host.com', {
       reqheaders: {
         authorization: 'token xyz-installation-token',
-        accept: 'application/vnd.github.machine-man-preview+json'
+        accept: 'application/vnd.github.mercy-preview+json,application/vnd.github.machine-man-preview+json'
       }
     })
       .get('/installation/repositories')


### PR DESCRIPTION
Enables the `topics` properties to be returned in the response of calls to `apps.getInstallationRepositories`.

See https://developer.github.com/v3/apps/installations/#installations for more information.

Resolves https://github.com/probot/probot/issues/760, though it's a round-about way.
