### PR TITLE
deprecate options.input

### DIFF
--- a/lib/endpoint/index.js
+++ b/lib/endpoint/index.js
@@ -10,6 +10,7 @@ const urlTemplate = require('url-template')
 const getUserAgent = require('universal-user-agent')
 
 const addQueryParameters = require('./add-query-parameters')
+const deprecate = require('../deprecate')
 const extractUrlVariableNames = require('./extract-url-variable-names')
 const pkg = require('../../package.json')
 
@@ -57,7 +58,13 @@ function restEndpoint (options) {
     url = addQueryParameters(url, remainingOptions)
   } else {
     if ('input' in remainingOptions) {
-      body = remainingOptions.input
+      deprecate('"input" option has been renamed to "data"')
+      remainingOptions.data = remainingOptions.input
+      delete remainingOptions.input
+    }
+
+    if ('data' in remainingOptions) {
+      body = remainingOptions.data
     } else {
       body = Object.keys(remainingOptions).length ? remainingOptions : undefined
     }

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -1768,7 +1768,7 @@
       "method": "PATCH",
       "params": {
         "hook": {
-          "mapTo": "input",
+          "mapTo": "data",
           "required": true,
           "type": "object"
         },
@@ -2690,7 +2690,7 @@
       "method": "POST",
       "params": {
         "labels": {
-          "mapTo": "input",
+          "mapTo": "data",
           "required": true,
           "type": "string[]"
         },
@@ -3687,7 +3687,7 @@
       "method": "PUT",
       "params": {
         "labels": {
-          "mapTo": "input",
+          "mapTo": "data",
           "required": true,
           "type": "string[]"
         },
@@ -4337,7 +4337,7 @@
       "method": "POST",
       "params": {
         "data": {
-          "mapTo": "input",
+          "mapTo": "data",
           "required": true,
           "type": "string"
         }
@@ -7227,7 +7227,7 @@
           "type": "string"
         },
         "contexts": {
-          "mapTo": "input",
+          "mapTo": "data",
           "required": true,
           "type": "string[]"
         },
@@ -7258,7 +7258,7 @@
           "type": "string"
         },
         "teams": {
-          "mapTo": "input",
+          "mapTo": "data",
           "required": true,
           "type": "string[]"
         }
@@ -7281,7 +7281,7 @@
           "type": "string"
         },
         "users": {
-          "mapTo": "input",
+          "mapTo": "data",
           "required": true,
           "type": "string[]"
         }
@@ -9672,7 +9672,7 @@
           "type": "string"
         },
         "contexts": {
-          "mapTo": "input",
+          "mapTo": "data",
           "required": true,
           "type": "string[]"
         },
@@ -9721,7 +9721,7 @@
           "type": "string"
         },
         "teams": {
-          "mapTo": "input",
+          "mapTo": "data",
           "required": true,
           "type": "string[]"
         }
@@ -9744,7 +9744,7 @@
           "type": "string"
         },
         "users": {
-          "mapTo": "input",
+          "mapTo": "data",
           "required": true,
           "type": "string[]"
         }
@@ -9759,7 +9759,7 @@
           "type": "string"
         },
         "contexts": {
-          "mapTo": "input",
+          "mapTo": "data",
           "required": true,
           "type": "string[]"
         },
@@ -9790,7 +9790,7 @@
           "type": "string"
         },
         "teams": {
-          "mapTo": "input",
+          "mapTo": "data",
           "required": true,
           "type": "string[]"
         }
@@ -9813,7 +9813,7 @@
           "type": "string"
         },
         "users": {
-          "mapTo": "input",
+          "mapTo": "data",
           "required": true,
           "type": "string[]"
         }
@@ -10202,7 +10202,7 @@
           "deprecated": true
         },
         "file": {
-          "mapTo": "input",
+          "mapTo": "data",
           "required": true,
           "type": "string | object"
         },

--- a/scripts/routes-for-api-docs.json
+++ b/scripts/routes-for-api-docs.json
@@ -16310,7 +16310,7 @@
       "name": "Render a Markdown document in raw mode",
       "params": [
         {
-          "mapTo": "input",
+          "mapTo": "data",
           "name": "data",
           "type": "string",
           "required": true,
@@ -26874,7 +26874,7 @@
           "location": "url"
         },
         {
-          "mapTo": "input",
+          "mapTo": "data",
           "name": "contexts",
           "type": "string[]",
           "required": true,
@@ -26931,7 +26931,7 @@
           "location": "url"
         },
         {
-          "mapTo": "input",
+          "mapTo": "data",
           "name": "teams",
           "type": "string[]",
           "required": true,
@@ -27005,7 +27005,7 @@
           "location": "url"
         },
         {
-          "mapTo": "input",
+          "mapTo": "data",
           "name": "users",
           "type": "string[]",
           "required": true,
@@ -36119,7 +36119,7 @@
           "location": "url"
         },
         {
-          "mapTo": "input",
+          "mapTo": "data",
           "name": "contexts",
           "type": "string[]",
           "required": true,
@@ -36207,7 +36207,7 @@
           "location": "url"
         },
         {
-          "mapTo": "input",
+          "mapTo": "data",
           "name": "teams",
           "type": "string[]",
           "required": true,
@@ -36281,7 +36281,7 @@
           "location": "url"
         },
         {
-          "mapTo": "input",
+          "mapTo": "data",
           "name": "users",
           "type": "string[]",
           "required": true,
@@ -36356,7 +36356,7 @@
           "location": "url"
         },
         {
-          "mapTo": "input",
+          "mapTo": "data",
           "name": "contexts",
           "type": "string[]",
           "required": true,
@@ -36412,7 +36412,7 @@
           "location": "url"
         },
         {
-          "mapTo": "input",
+          "mapTo": "data",
           "name": "teams",
           "type": "string[]",
           "required": true,
@@ -36486,7 +36486,7 @@
           "location": "url"
         },
         {
-          "mapTo": "input",
+          "mapTo": "data",
           "name": "users",
           "type": "string[]",
           "required": true,
@@ -37925,7 +37925,7 @@
           "description": "",
           "required": true,
           "location": "body",
-          "mapTo": "input"
+          "mapTo": "data"
         }
       ],
       "path": ":url",

--- a/test/integration/deprecations-test.js
+++ b/test/integration/deprecations-test.js
@@ -183,4 +183,21 @@ describe('deprecations', () => {
         expect(console.warn.callCount).to.equal(1)
       })
   })
+
+  it('deprecated options.input', () => {
+    nock('https://deprecations-test.com')
+      .post('/markdown/raw')
+      .reply(201, '<h1>Test</h1>')
+
+    return github.request({
+      method: 'POST',
+      url: '/markdown/raw',
+      input: '# Test'
+    })
+
+      .then(response => {
+        expect(response.data).to.deep.equal('<h1>Test</h1>')
+        expect(console.warn.callCount).to.equal(1)
+      })
+  })
 })


### PR DESCRIPTION
Nobody should be affected by this, it’s an internal refactoring. But just in case, why not. Part of #1052.