### PR TITLE
Adds date field to response headers

### DIFF
--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -17,6 +17,7 @@ declare namespace Github {
 
     /** Response headers */
     headers:{
+      date: string,
       'x-ratelimit-limit': string,
       'x-ratelimit-remaining': string,
       'x-ratelimit-reset': string,


### PR DESCRIPTION
It would be nice to have this type available from typescript. I assume this is the correct way to add it?

Date appears to be in all github responses ie https://developer.github.com/v3/#schema

Could add some more fields if required