### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ octokit.paginate(options)
 If your runtime environment supports async iterators (such as Node 10+), you can iterate through each response
 
 ```js
-for await (const response of octokit.paginate.iterator(options) {
+for await (const response of octokit.paginate.iterator(options)) {
   // do whatever you want with each response, break out of loop, etc.
 }
 ```


### PR DESCRIPTION
Fix missing paren in pagination example


-----
[View rendered README.md](https://github.com/leifdreizler/rest.js/blob/readme-pagination/README.md)