### PR TITLE
Update TypeScript definitions for API functions

### DIFF
--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -214,7 +214,7 @@ declare class Github {
   {{namespace}}: {
     {{#methods}}
     {{&jsdoc}}
-    {{method}}({{#paramTypeName}}params?: Github.{{.}}): Promise<{{&responseType}}>;
+    {{method}}({{#paramTypeName}}params?: Github.{{.}}{{/paramTypeName}}): Promise<{{&responseType}}>;
     {{/methods}}
   };
   {{/namespaces}}

--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -215,7 +215,6 @@ declare class Github {
     {{#methods}}
     {{&jsdoc}}
     {{method}}({{#paramTypeName}}params?: Github.{{.}}): Promise<{{&responseType}}>;
-    {{method}}({{#paramTypeName}}params?: Github.{{.}}, {{/paramTypeName}}callback?: Github.Callback<{{&responseType}}>): void;
     {{/methods}}
   };
   {{/namespaces}}

--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -214,7 +214,8 @@ declare class Github {
   {{namespace}}: {
     {{#methods}}
     {{&jsdoc}}
-    {{method}}({{#paramTypeName}}params: Github.{{.}}, {{/paramTypeName}}callback?: Github.Callback<{{&responseType}}>): Promise<{{&responseType}}>;
+    {{method}}({{#paramTypeName}}params?: Github.{{.}}): Promise<{{&responseType}}>;
+    {{method}}({{#paramTypeName}}params?: Github.{{.}}, {{/paramTypeName}}callback?: Github.Callback<{{&responseType}}>): void;
     {{/methods}}
   };
   {{/namespaces}}


### PR DESCRIPTION
<!-- 
1. Push your changes to your topic branch on your fork of the repo.
2. Submit a pull request from your topic branch to the master branch on the `rest.js` repository.
3. Be sure to tag any issues your pull request is taking care of / contributing to.
4. Adding "Closes #123" to a pull request description will auto close the issue once the pull request is merged in. 
-->
~~This makes it easier to use the definitions so you can only see relevant information if you're using callbacks or Promise's.
Also allows for better understanding of the code by linters. Before, one could try to mix the 2 methods together and linters wouldn't catch it. Now they would~~
Removes the callback option from the TypeScript definitions as they are no longer supported, and marks the params as optional, since they aren't needed as per the docs