### PR TITLE
`octokit.registerEndpoints()` should not remove existing endpoint methods on same scope

### DIFF
--- a/plugins/register-endpoints/register-endpoints.js
+++ b/plugins/register-endpoints/register-endpoints.js
@@ -2,7 +2,9 @@ module.exports = registerEndpoints
 
 function registerEndpoints (octokit, routes) {
   Object.keys(routes).forEach(namespaceName => {
-    octokit[namespaceName] = {}
+    if (!octokit[namespaceName]) {
+      octokit[namespaceName] = {}
+    }
 
     Object.keys(routes[namespaceName]).forEach(apiName => {
       let apiOptions = routes[namespaceName][apiName]

--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -76,16 +76,37 @@ declare namespace Octokit {
     request?: { [option: string]: any }
   }
 
+  export interface Endpoint {
+    (
+      Route: string,
+      EndpointOptions?: Octokit.EndpointOptions
+    ): Octokit.RequestOptions;
+    (EndpointOptions: Octokit.EndpointOptions): Octokit.RequestOptions;
+    /**
+     * Current default options
+     */
+    DEFAULTS: Octokit.EndpointOptions;
+    /**
+     * Get the defaulted endpoint options, but without parsing them into request options:
+     */
+    merge(Route: string, EndpointOptions?: Octokit.EndpointOptions): Octokit.RequestOptions;
+    merge(EndpointOptions: Octokit.EndpointOptions): Octokit.RequestOptions;
+    /**
+     * Stateless method to turn endpoint options into request options. Calling endpoint(options) is the same as calling endpoint.parse(endpoint.merge(options)).
+     */
+    parse(EndpointOptions: Octokit.EndpointOptions): Octokit.RequestOptions;
+    /**
+     * Merges existing defaults with passed options and returns new endpoint() method with new defaults
+     */
+    defaults(EndpointOptions: Octokit.EndpointOptions): Octokit.Endpoint
+  }
+
   export interface Request {
     (Route: string, EndpointOptions?: Octokit.EndpointOptions): Promise<
       Octokit.AnyResponse
     >;
     (EndpointOptions: Octokit.EndpointOptions): Promise<Octokit.AnyResponse>;
-    endpoint(
-      Route: string,
-      EndpointOptions?: Octokit.EndpointOptions
-    ): Octokit.RequestOptions;
-    endpoint(EndpointOptions: Octokit.EndpointOptions): Octokit.RequestOptions;
+    endpoint: Octokit.Endpoint
   };
 
   export interface AuthBasic {
@@ -246,7 +267,7 @@ declare class Octokit {
     {{method}}: {
       ({{#paramTypeName}}params?: Octokit.{{.}}{{/paramTypeName}}): Promise<{{&responseType}}>;
 
-      endpoint: any
+      endpoint: Octokit.Endpoint
     };
     {{/methods}}
   };

--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -231,7 +231,9 @@ declare class Octokit {
 
   static plugin(plugin: Octokit.Plugin | [Octokit.Plugin]): Octokit.Static;
 
-  registerEndpoints(routes: any): void;
+  registerEndpoints(endpoints: {
+    [scope: string]: Octokit.EndpointOptions
+  }): void;
 
   request: Octokit.Request;
 

--- a/test/integration/smoke-test.js
+++ b/test/integration/smoke-test.js
@@ -161,14 +161,17 @@ describe('smoke', () => {
     expect(octokit.registerEndpoints).to.be.a('function')
 
     octokit.registerEndpoints({
-      foo: {
-        bar: {
+      issues: {
+        fooBar: {
           method: 'GET',
           url: '/baz'
         }
       }
     })
 
-    return octokit.foo.bar()
+    // make sure .registerEndpoints does not remove other methods on the same scope
+    expect(octokit.issues.get).to.be.a('function')
+
+    return octokit.issues.fooBar()
   })
 })

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -1,5 +1,6 @@
 import * as Octokit from '../index'
 import {Agent} from 'http'
+import { request } from 'https';
 const http = require('http');
 
 // ************************************************************
@@ -64,6 +65,9 @@ export default async function() {
   requestOptions.headers
   requestOptions.body
   requestOptions.request.foo
+  const endpointOptions = octokit.issues.addLabels.endpoint.merge({
+    foo: 'bar'
+  })
 
   // hooks
   octokit.hook.before('request', async (options) => {
@@ -93,6 +97,9 @@ export default async function() {
   octokit.request.endpoint('/')
   octokit.request.endpoint('GET /repos/:owner/:repo/issues', { owner: 'octokit', repo: 'rest.js' })
   octokit.request.endpoint({ method: 'GET', url: '/repos/:owner/:repo/issues', owner: 'octokit', repo: 'rest.js' })
+  octokit.request.endpoint.merge({ foo: 'bar' })
+  octokit.request.endpoint.parse({ method: 'GET', url: '/repos/:owner/:repo/issues', owner: 'octokit', repo: 'rest.js' })
+  octokit.request.endpoint.defaults({ owner: 'octokit', repo: 'rest.js' }).merge({ method: 'GET', url: '/repos/:owner/:repo/issues' })
 
   // pagination
   octokit.paginate('GET /repos/:owner/:repo/issues', { owner: 'octokit', repo: 'rest.js' })

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -110,6 +110,17 @@ export default async function() {
     // do whatever you want with each response, break out of the loop, etc.
   }
 
+  // register endpoints
+  octokit.registerEndpoints({
+    funk: {
+      method: 'DELETE',
+      url: '/funk',
+      request: {
+        foo: 'bar'
+      }
+    }
+  })
+
   // Plugins
   const MyOctokit = Octokit.plugin((octokit, options) => {
     octokit.hook.wrap('request', async (request, options) => {


### PR DESCRIPTION
```js
octokit.registerEndpoints({
  issues: {
    fooBar: {
      method: GET,
      url: '/baz'
    }
  }
})
```

The above code currently removes all other endpoint methods on `octokit.issues.*`