### PR TITLE
fix: do not load the same plugin again

### DIFF
--- a/lib/register-plugin.js
+++ b/lib/register-plugin.js
@@ -3,5 +3,5 @@ module.exports = registerPlugin
 const factory = require('./factory')
 
 function registerPlugin (plugins, pluginFunction) {
-  return factory(plugins.concat(pluginFunction))
+  return factory(plugins.includes(pluginFunction) ? plugins : plugins.concat(pluginFunction))
 }

--- a/test/integration/plugins-test.js
+++ b/test/integration/plugins-test.js
@@ -11,7 +11,7 @@ describe('plugins', () => {
     expect(myClient.foo).to.equal('bar')
   })
 
-  it('it does not override plugins of original constructor', () => {
+  it('does not override plugins of original constructor', () => {
     const MyOctokit = Octokit.plugin((octokit) => {
       octokit.foo = 'bar'
     })
@@ -27,5 +27,17 @@ describe('plugins', () => {
       expect(options.foo).to.equal('bar')
     })
     MyOctokit({ foo: 'bar' })
+  })
+
+  it('does not load the same plugin more than once', () => {
+    const myPlugin = (octokit, options) => {
+      if (octokit.customKey) {
+        throw new Error('Boom!')
+      } else {
+        octokit.customKey = true
+      }
+    }
+    const MyOctokit = Octokit.plugin(myPlugin).plugin(myPlugin)
+    expect(MyOctokit).to.not.throw()
   })
 })


### PR DESCRIPTION
At the moment, users of the throttling and retry plugins are installing and loading them manually. Once we include those plugins into the core library, it's going to cause issues. For example, having the retry plugin loaded twice would mean failed requests would be retried 6 times instead of 3.

This PR simply skips a plugin if it's already present. Should it also display a warning?