### PR TITLE
parse `link` header if it exists, and create `links` field in `response`

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const CORE_PLUGINS = [
   require('./plugins/pagination'),
   require('./plugins/register-endpoints'),
   require('./plugins/rest-api-endpoints'),
+  require('./plugins/parse-links'),
   require('./plugins/validate'),
 
   // deprecated: remove in v17

--- a/plugins/parse-links/index.js
+++ b/plugins/parse-links/index.js
@@ -1,0 +1,7 @@
+module.exports = octokitParseLinks
+
+const parseLinks = require('./parseLinks')
+
+function octokitParseLinks (octokit) {
+  octokit.hook.after('request', parseLinks(octokit))
+}

--- a/plugins/parse-links/parseLinks.js
+++ b/plugins/parse-links/parseLinks.js
@@ -1,0 +1,20 @@
+'use strict'
+
+module.exports = parseLinks
+
+function parseLinks (octokit) {
+  return response => {
+    response.links = {};
+    (response.headers.link || '')
+      .split(/,\s*/)
+      .map(value => value.match(/^<([^>]+)>;\s*rel="([^"]+)"$/))
+      .forEach(value => {
+        if (value) {
+          response.links[value[2]] = {
+            href: value[1],
+            get: () => octokit.request('GET ' + value[1])
+          }
+        }
+      })
+  }
+}


### PR DESCRIPTION
Since many responses have a `link` header, it would be helpful to have this hook be standard.