### PR TITLE
two-factor authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,16 @@ octokit.authenticate({
   password: 'password'
 })
 
+// basic + two-factor
+octokit.authenticate({
+  type: 'basic',
+  username: 'yourusername',
+  password: 'password'
+  on2fa () {
+    // must return or resolve with a two-factor code
+  }
+})
+
 // oauth
 octokit.authenticate({
   type: 'oauth',

--- a/plugins/authentication/index.js
+++ b/plugins/authentication/index.js
@@ -2,11 +2,14 @@ module.exports = authenticationPlugin
 
 const authenticate = require('./authenticate')
 const beforeRequest = require('./before-request')
+const requestError = require('./request-error')
 
 function authenticationPlugin (octokit) {
   const state = {
+    octokit,
     auth: false
   }
   octokit.authenticate = authenticate.bind(null, state)
   octokit.hook.before('request', beforeRequest.bind(null, state))
+  octokit.hook.error('request', requestError.bind(null, state))
 }

--- a/plugins/authentication/request-error.js
+++ b/plugins/authentication/request-error.js
@@ -1,0 +1,25 @@
+module.exports = authenticationRequestError
+
+const HttpError = require('@octokit/request/lib/http-error')
+
+function authenticationRequestError (state, error, options) {
+  // handle "2FA required" error only
+  if (error.status !== 401 || !/required/.test(error.headers['x-github-otp'] || '')) {
+    throw error
+  }
+
+  if (typeof state.auth.on2fa !== 'function') {
+    throw new HttpError('2FA required, but options.on2fa is not a function. See https://github.com/octokit/rest.js#authentication', 401, error.headers, options)
+  }
+
+  return Promise.resolve()
+    .then(() => {
+      return state.auth.on2fa()
+    })
+    .then((oneTimePassword) => {
+      const newOptions = Object.assign(options, {
+        headers: Object.assign({ 'x-github-otp': oneTimePassword }, options.headers)
+      })
+      return state.octokit.request(newOptions)
+    })
+}


### PR DESCRIPTION
You can now pass a `on2fa` method to `octokit.authenticate` which gets called when a 2FA code is requested

```js
// basic + two-factor
octokit.authenticate({
  type: 'basic',
  username: 'yourusername',
  password: 'password'
  on2fa () {
    // must return or resolve with a two-factor code
  }
})
```

closes #669

-----
[View rendered README.md](https://github.com/octokit/rest.js/blob/two-factor-auth/README.md)