### PR TITLE
`log` client option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [Register custom endpoint methods](#register-custom-endpoint-methods)
 - [Throttling](#throttling)
 - [Automatic retries](#automatic-retries)
+- [Logging](#logging)
 - [Debug](#debug)
 - [Contributing](#contributing)
 - [Credits](#credits)
@@ -94,6 +95,14 @@ const octokit = new Octokit({
 
   // set custom URL for on-premise GitHub Enterprise installations
   baseUrl: 'https://api.github.com',
+  
+  // pass custom methods for debug, info, warn and error
+  log: {
+    debug: () => {},
+    info: () => {},
+    warn: console.warn,
+    error: console.error
+  },
 
   request: {
     // Node.js only: advanced request options can be passed as http(s) agent,
@@ -360,13 +369,15 @@ module.exports = (octokit, options = { greeting: 'Hello' }) => {
   octokit.hook.wrap('request', async (request, options) => {
     const time = Date.now()
     const response = await request(options)
-    console.log(`${options.method} ${options.url} – ${response.status} in ${Date.now() - time}ms`)
+    octokit.log.info(`${options.method} ${options.url} – ${response.status} in ${Date.now() - time}ms`)
     return response
   })
 }
 ```
 
 `.plugin` accepts a function or an array of functions.
+
+We recommend using [Octokit’s log methods](#logging) to help users of your plugin with debugging.
 
 You can add new methods to the `octokit` instance passed as the first argument to
 the plugin function. The 2nd argument is the options object passed to the
@@ -441,7 +452,7 @@ const octokit = new Octokit({
   auth: 'token ' + process.env.TOKEN,
   throttle: {
     onRateLimit: (retryAfter, options) => {
-      console.warn(`Request quota exhausted for request ${options.method} ${options.url}`)
+      octokit.log.warn(`Request quota exhausted for request ${options.method} ${options.url}`)
 
       if (options.request.retryCount === 0) { // only retries once
         console.log(`Retrying after ${retryAfter} seconds!`)
@@ -450,7 +461,7 @@ const octokit = new Octokit({
     },
     onAbuseLimit: (retryAfter, options) => {
       // does not retry, only logs a warning
-      console.warn(`Abuse detected for request ${options.method} ${options.url}`)
+      octokit.log.warn(`Abuse detected for request ${options.method} ${options.url}`)
     }
   }
 })
@@ -469,9 +480,60 @@ const octokit = new Octokit()
 // all requests sent with the `octokit` instance are now retried up to 3 times for recoverable errors.
 ```
 
+## Logging
+
+`Octokit` has 4 built in log methods
+
+1. `octokit.log.debug(message[, additionalInfo])`
+1. `octokit.log.info(message[, additionalInfo])`
+1. `octokit.log.warn(message[, additionalInfo])`
+1. `octokit.log.error(message[, additionalInfo])`
+
+They can be configured using the [`log` client option](client-options). By default, `octokit.log.debug()` and `octokit.log.info()` are no-ops, while the other two call `console.warn()` and `console.error()` respectively.
+
+This is useful if you build reusable [plugins](#plugins).
+
 ## Debug
 
-Set `DEBUG=octokit:rest*` for additional debug logs.
+The simplest way to receive debug information is to set the [`log` client option](client-options) to `console`.
+
+```js
+const octokit = require('@octokit/rest')({
+  log: console
+})
+
+console.request('/')
+```
+
+This will log
+
+```
+request { method: 'GET',
+  baseUrl: 'https://api.github.com',
+  headers:
+   { accept: 'application/vnd.github.v3+json',
+     'user-agent':
+      'octokit.js/0.0.0-semantically-released Node.js/10.15.0 (macOS Mojave; x64)' },
+  request: {},
+  url: '/' }
+GET / - 200 in 514ms
+```
+
+If you like to support a configurable log level, we recommend using the [console-log-level](https://github.com/watson/console-log-level) module
+
+```js
+const octokit = require('@octokit/rest')({
+  log: require('console-log-level')({ level: 'info' })
+})
+
+console.request('/')
+```
+
+This will only log
+
+```
+GET / - 200 in 514ms
+```
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const Octokit = require('./lib/core')
 
 const CORE_PLUGINS = [
+  require('./plugins/log'),
   require('./plugins/authentication-deprecated'), // deprecated: remove in v17
   require('./plugins/authentication'),
   require('./plugins/pagination'),

--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -9,9 +9,16 @@ const requestWithDefaults = require('./request-with-defaults')
 function Octokit (plugins, options) {
   options = options || {}
   const hook = new Hook()
+  const log = Object.assign({
+    'debug': () => {},
+    'info': () => {},
+    'warn': console.warn,
+    'error': console.error
+  }, options && options.log)
   const api = {
     hook,
-    request: requestWithDefaults(hook, endpoint, parseClientOptions(options))
+    log,
+    request: requestWithDefaults(hook, endpoint, parseClientOptions(options, log))
   }
 
   plugins.forEach(pluginFunction => pluginFunction(api, options))

--- a/lib/parse-client-options.js
+++ b/lib/parse-client-options.js
@@ -4,7 +4,7 @@ const getUserAgent = require('universal-user-agent')
 
 const pkg = require('../package.json')
 
-function parseOptions (options) {
+function parseOptions (options, log) {
   if (options.headers) {
     options.headers = Object.keys(options.headers).reduce((newObj, key) => {
       newObj[key.toLowerCase()] = options.headers[key]
@@ -30,17 +30,17 @@ function parseOptions (options) {
   }
 
   if (options.timeout) {
-    console.warn(new Error('new Octokit({timout}) is deprecated. Use {request: {agent}} instead. See https://github.com/octokit/rest.js#client-options'))
+    log.warn(new Error('new Octokit({timout}) is deprecated. Use {request: {agent}} instead. See https://github.com/octokit/rest.js#client-options'))
     clientDefaults.request.timeout = options.timeout
   }
 
   if (options.agent) {
-    console.warn(new Error('new Octokit({agent}) is deprecated. Use {request: {agent}} instead. See https://github.com/octokit/rest.js#client-options'))
+    log.warn(new Error('new Octokit({agent}) is deprecated. Use {request: {agent}} instead. See https://github.com/octokit/rest.js#client-options'))
     clientDefaults.request.agent = options.agent
   }
 
   if (options.headers) {
-    console.warn(new Error('new Octokit({headers}) is deprecated. Use {userAgent, previews} instead. See https://github.com/octokit/rest.js#client-options'))
+    log.warn(new Error('new Octokit({headers}) is deprecated. Use {userAgent, previews} instead. See https://github.com/octokit/rest.js#client-options'))
   }
 
   const userAgentOption = clientDefaults.headers['user-agent']

--- a/plugins/authentication-deprecated/authenticate.js
+++ b/plugins/authentication-deprecated/authenticate.js
@@ -1,7 +1,7 @@
 module.exports = authenticate
 
 function authenticate (state, options) {
-  console.warn(new Error('octokit.authenticate() is deprecated. Use "auth" constructor option instead.'))
+  state.octokit.log.warn(new Error('octokit.authenticate() is deprecated. Use "auth" constructor option instead.'))
 
   if (!options) {
     state.auth = false

--- a/plugins/authentication-deprecated/index.js
+++ b/plugins/authentication-deprecated/index.js
@@ -7,7 +7,7 @@ const requestError = require('./request-error')
 function authenticationPlugin (octokit, options) {
   if (options.auth) {
     octokit.authenticate = () => {
-      console.warn(new Error('octokit.authenticate() is deprecated and has no effect when "auth" option is set on Octokit constructor'))
+      octokit.log.warn(new Error('octokit.authenticate() is deprecated and has no effect when "auth" option is set on Octokit constructor'))
     }
     return
   }

--- a/plugins/log/index.js
+++ b/plugins/log/index.js
@@ -1,0 +1,22 @@
+module.exports = octokitDebug
+
+function octokitDebug (octokit) {
+  octokit.hook.wrap('request', (request, options) => {
+    octokit.log.debug(`request`, options)
+    const start = Date.now()
+    const requestOptions = octokit.request.endpoint.parse(options)
+    const path = requestOptions.url.replace(options.baseUrl, '')
+
+    return request(options)
+
+      .then(response => {
+        octokit.log.info(`${requestOptions.method} ${path} - ${response.status} in ${Date.now() - start}ms`)
+        return response
+      })
+
+      .catch(error => {
+        octokit.log.info(`${requestOptions.method} ${path} - ${error.status} in ${Date.now() - start}ms`)
+        throw error
+      })
+  })
+}

--- a/plugins/register-endpoints/register-endpoints.js
+++ b/plugins/register-endpoints/register-endpoints.js
@@ -25,7 +25,7 @@ function registerEndpoints (octokit, routes) {
 
       if (apiOptions.deprecated) {
         octokit[namespaceName][apiName] = function () {
-          console.warn(apiOptions.deprecated)
+          octokit.log.warn(apiOptions.deprecated)
           octokit[namespaceName][apiName] = request
           return request.apply(null, arguments)
         }

--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -47,6 +47,12 @@ declare namespace Octokit {
     userAgent?: string;
     previews?: string[];
     baseUrl?: string;
+    log?: {
+      debug?: (message: string, info?: object) => void
+      info?: (message: string, info?: object) => void
+      warn?: (message: string, info?: object) => void
+      error?: (message: string, info?: object) => void
+    };
     request?: {
       agent?: http.Agent;
       timeout?: number
@@ -82,6 +88,13 @@ declare namespace Octokit {
     body?:  any
     request?: { [option: string]: any }
   }
+
+  export interface Log {
+    debug: (message: string, additionalInfo?: object) => void
+    info: (message: string, additionalInfo?: object) => void
+    warn: (message: string, additionalInfo?: object) => void
+    error: (message: string, additionalInfo?: object) => void
+  };
 
   export interface Endpoint {
     (
@@ -266,6 +279,8 @@ declare class Octokit {
   request: Octokit.Request;
 
   paginate: Octokit.Paginate;
+
+  log: Octokit.Log;
 
   {{#namespaces}}
   {{namespace}}: {

--- a/test/integration/deprecations-test.js
+++ b/test/integration/deprecations-test.js
@@ -10,17 +10,19 @@ const Mocktokit = Octokit
   })
 
 describe('deprecations', () => {
-  beforeEach(() => {
-    cy.stub(console, 'warn')
-  })
-
-  // deprecated methods
   it('octokit.search.issues() has been renamed to octokit.search.issuesAndPullRequests() (2018-12-27)', () => {
-    const octokit = new Mocktokit()
+    let warnCalled = false
+    const octokit = new Mocktokit({
+      log: {
+        warn: () => {
+          warnCalled = true
+        }
+      }
+    })
 
     return octokit.search.issues({ q: 'foo' })
       .then(() => {
-        expect(console.warn.callCount).to.equal(1)
+        expect(warnCalled).to.equal(true)
       })
   })
 
@@ -33,7 +35,15 @@ describe('deprecations', () => {
       .get('/orgs/myorg')
       .reply(200, {})
 
-    const octokit = new Octokit({ baseUrl: 'https://authentication-test-host.com' })
+    let warnCalled = false
+    const octokit = new Octokit({
+      baseUrl: 'https://authentication-test-host.com',
+      log: {
+        warn: () => {
+          warnCalled = true
+        }
+      }
+    })
 
     octokit.authenticate({
       type: 'basic',
@@ -41,7 +51,7 @@ describe('deprecations', () => {
       password: 'password'
     })
 
-    expect(console.warn.callCount).to.equal(1)
+    expect(warnCalled).to.equal(true)
 
     return octokit.orgs.get({ org: 'myorg' })
   })
@@ -66,7 +76,15 @@ describe('deprecations', () => {
       .get('/orgs/myorg')
       .reply(200, {})
 
-    const octokit = new Octokit({ baseUrl: 'https://authentication-test-host.com' })
+    let warnCalled = false
+    const octokit = new Octokit({
+      baseUrl: 'https://authentication-test-host.com',
+      log: {
+        warn: () => {
+          warnCalled = true
+        }
+      }
+    })
 
     octokit.authenticate({
       type: 'basic',
@@ -77,7 +95,7 @@ describe('deprecations', () => {
       }
     })
 
-    expect(console.warn.callCount).to.equal(1)
+    expect(warnCalled).to.equal(true)
 
     return octokit.orgs.get({ org: 'myorg' })
   })
@@ -102,7 +120,15 @@ describe('deprecations', () => {
       .get('/orgs/myorg')
       .reply(200, {})
 
-    const octokit = new Octokit({ baseUrl: 'https://authentication-test-host.com' })
+    let warnCalled = false
+    const octokit = new Octokit({
+      baseUrl: 'https://authentication-test-host.com',
+      log: {
+        warn: () => {
+          warnCalled = true
+        }
+      }
+    })
 
     octokit.authenticate({
       type: 'basic',
@@ -113,7 +139,7 @@ describe('deprecations', () => {
       }
     })
 
-    expect(console.warn.callCount).to.equal(1)
+    expect(warnCalled).to.equal(true)
 
     return octokit.orgs.get({ org: 'myorg' })
   })
@@ -140,7 +166,15 @@ describe('deprecations', () => {
         'x-github-otp': 'required; app'
       })
 
-    const octokit = new Octokit({ baseUrl: 'https://authentication-test-host.com' })
+    let warnCalled = false
+    const octokit = new Octokit({
+      baseUrl: 'https://authentication-test-host.com',
+      log: {
+        warn: () => {
+          warnCalled = true
+        }
+      }
+    })
 
     octokit.authenticate({
       type: 'basic',
@@ -151,7 +185,7 @@ describe('deprecations', () => {
       }
     })
 
-    expect(console.warn.callCount).to.equal(1)
+    expect(warnCalled).to.equal(true)
 
     return octokit.orgs.get({ org: 'myorg' })
 
@@ -175,7 +209,15 @@ describe('deprecations', () => {
         'x-github-otp': 'required; app'
       })
 
-    const octokit = new Octokit({ baseUrl: 'https://authentication-test-host.com' })
+    let warnCalled = false
+    const octokit = new Octokit({
+      baseUrl: 'https://authentication-test-host.com',
+      log: {
+        warn: () => {
+          warnCalled = true
+        }
+      }
+    })
 
     octokit.authenticate({
       type: 'basic',
@@ -183,7 +225,7 @@ describe('deprecations', () => {
       password: 'password'
     })
 
-    expect(console.warn.callCount).to.equal(1)
+    expect(warnCalled).to.equal(true)
 
     return octokit.orgs.get({ org: 'myorg' })
       .then(() => {
@@ -206,14 +248,22 @@ describe('deprecations', () => {
       .get('/orgs/myorg')
       .reply(200, {})
 
-    const octokit = new Octokit({ baseUrl: 'https://authentication-test-host.com' })
+    let warnCalled = false
+    const octokit = new Octokit({
+      baseUrl: 'https://authentication-test-host.com',
+      log: {
+        warn: () => {
+          warnCalled = true
+        }
+      }
+    })
 
     octokit.authenticate({
       type: 'token',
       token: 'abc4567'
     })
 
-    expect(console.warn.callCount).to.equal(1)
+    expect(warnCalled).to.equal(true)
 
     return octokit.orgs.get({ org: 'myorg' })
   })
@@ -224,14 +274,22 @@ describe('deprecations', () => {
       .query({ access_token: 'abc4567' })
       .reply(200, {})
 
-    const octokit = new Octokit({ baseUrl: 'https://authentication-test-host.com' })
+    let warnCalled = false
+    const octokit = new Octokit({
+      baseUrl: 'https://authentication-test-host.com',
+      log: {
+        warn: () => {
+          warnCalled = true
+        }
+      }
+    })
 
     octokit.authenticate({
       type: 'oauth',
       token: 'abc4567'
     })
 
-    expect(console.warn.callCount).to.equal(1)
+    expect(warnCalled).to.equal(true)
 
     return octokit.orgs.get({ org: 'myorg' })
   })
@@ -242,14 +300,22 @@ describe('deprecations', () => {
       .query({ per_page: 1, access_token: 'abc4567' })
       .reply(200, [])
 
-    const octokit = new Octokit({ baseUrl: 'https://authentication-test-host.com' })
+    let warnCalled = false
+    const octokit = new Octokit({
+      baseUrl: 'https://authentication-test-host.com',
+      log: {
+        warn: () => {
+          warnCalled = true
+        }
+      }
+    })
 
     octokit.authenticate({
       type: 'oauth',
       token: 'abc4567'
     })
 
-    expect(console.warn.callCount).to.equal(1)
+    expect(warnCalled).to.equal(true)
 
     return octokit.repos.listForOrg({ org: 'myorg', per_page: 1 })
   })
@@ -260,7 +326,15 @@ describe('deprecations', () => {
       .query({ client_id: 'oauthkey', client_secret: 'oauthsecret' })
       .reply(200, {})
 
-    const octokit = new Octokit({ baseUrl: 'https://authentication-test-host.com' })
+    let warnCalled = false
+    const octokit = new Octokit({
+      baseUrl: 'https://authentication-test-host.com',
+      log: {
+        warn: () => {
+          warnCalled = true
+        }
+      }
+    })
 
     octokit.authenticate({
       type: 'oauth',
@@ -268,7 +342,7 @@ describe('deprecations', () => {
       secret: 'oauthsecret'
     })
 
-    expect(console.warn.callCount).to.equal(1)
+    expect(warnCalled).to.equal(true)
 
     return octokit.orgs.get({ org: 'myorg' })
   })
@@ -279,7 +353,15 @@ describe('deprecations', () => {
       .query({ foo: 'bar', client_id: 'oauthkey', client_secret: 'oauthsecret' })
       .reply(200, [])
 
-    const octokit = new Octokit({ baseUrl: 'https://authentication-test-host.com' })
+    let warnCalled = false
+    const octokit = new Octokit({
+      baseUrl: 'https://authentication-test-host.com',
+      log: {
+        warn: () => {
+          warnCalled = true
+        }
+      }
+    })
 
     octokit.authenticate({
       type: 'oauth',
@@ -287,7 +369,7 @@ describe('deprecations', () => {
       secret: 'oauthsecret'
     })
 
-    expect(console.warn.callCount).to.equal(1)
+    expect(warnCalled).to.equal(true)
 
     return octokit.request('/?foo=bar')
   })
@@ -301,26 +383,49 @@ describe('deprecations', () => {
       .get('/orgs/myorg')
       .reply(200, {})
 
-    const octokit = new Octokit({ baseUrl: 'https://authentication-test-host.com' })
+    let warnCalled = false
+    const octokit = new Octokit({
+      baseUrl: 'https://authentication-test-host.com',
+      log: {
+        warn: () => {
+          warnCalled = true
+        }
+      }
+    })
 
     octokit.authenticate({
       type: 'app',
       token: 'abc4567'
     })
 
-    expect(console.warn.callCount).to.equal(1)
+    expect(warnCalled).to.equal(true)
 
     return octokit.orgs.get({ org: 'myorg' })
   })
 
   it('octokit.authenticate(): without options', () => {
-    const octokit = new Octokit()
+    let warnCalled = false
+    const octokit = new Octokit({
+      log: {
+        warn: () => {
+          warnCalled = true
+        }
+      }
+    })
+
     octokit.authenticate()
-    expect(console.warn.callCount).to.equal(1)
+    expect(warnCalled).to.equal(true)
   })
 
   it('octokit.authenticate(): errors', () => {
-    const octokit = new Octokit()
+    let warnCalledCount = 0
+    const octokit = new Octokit({
+      log: {
+        warn: () => {
+          warnCalledCount++
+        }
+      }
+    })
 
     expect(() => {
       octokit.authenticate({})
@@ -338,12 +443,18 @@ describe('deprecations', () => {
       octokit.authenticate({ type: 'token' })
     }).to.throw(Error)
 
-    expect(console.warn.callCount).to.equal(4)
+    expect(warnCalledCount).to.equal(4)
   })
 
   it('octokit.authenticate() when "auth" option is set', () => {
+    let warnCalledWith
     const octokit = new Octokit({
-      auth: 'token secret123'
+      auth: 'token secret123',
+      log: {
+        warn: (message) => {
+          warnCalledWith = message
+        }
+      }
     })
 
     octokit.authenticate({
@@ -351,14 +462,19 @@ describe('deprecations', () => {
       token: 'secret123'
     })
 
-    expect(console.warn.callCount).to.equal(1)
-    expect(console.warn.lastCall.lastArg).to.match(/octokit\.authenticate\(\) is deprecated and has no effect/)
+    expect(warnCalledWith).to.match(/octokit\.authenticate\(\) is deprecated and has no effect/)
   })
 
   // deprecated client options
   it('agent option', () => {
+    let warnCalled = false
     const octokit = new Octokit({
-      agent: 'agent'
+      agent: 'agent',
+      log: {
+        warn: () => {
+          warnCalled = true
+        }
+      }
     })
 
     octokit.hook.wrap('request', (request, options) => {
@@ -366,7 +482,7 @@ describe('deprecations', () => {
       return 'ok'
     })
 
-    expect(console.warn.callCount).to.equal(1)
+    expect(warnCalled).to.equal(true)
 
     return octokit.request('/')
 
@@ -376,8 +492,14 @@ describe('deprecations', () => {
   })
 
   it('timeout option', () => {
+    let warnCalled = false
     const octokit = new Octokit({
-      timeout: 123
+      timeout: 123,
+      log: {
+        warn: () => {
+          warnCalled = true
+        }
+      }
     })
 
     octokit.hook.wrap('request', (request, options) => {
@@ -385,7 +507,7 @@ describe('deprecations', () => {
       return 'ok'
     })
 
-    expect(console.warn.callCount).to.equal(1)
+    expect(warnCalled).to.equal(true)
 
     return octokit.request('/')
 
@@ -395,10 +517,15 @@ describe('deprecations', () => {
   })
 
   it('headers["User-Agent"] option', () => {
+    let warnCalled = false
     const octokit = new Octokit({
-      baseUrl: 'https://smoke-test.com',
       headers: {
         'User-Agent': 'blah'
+      },
+      log: {
+        warn: () => {
+          warnCalled = true
+        }
       }
     })
 
@@ -407,7 +534,7 @@ describe('deprecations', () => {
       return 'ok'
     })
 
-    expect(console.warn.callCount).to.equal(1)
+    expect(warnCalled).to.equal(true)
 
     return octokit.request('/')
 
@@ -417,9 +544,15 @@ describe('deprecations', () => {
   })
 
   it('headers.accept option', () => {
+    let warnCalled = false
     const octokit = new Octokit({
       headers: {
         accept: 'application/vnd.github.jean-grey-preview+json,application/vnd.github.symmetra-preview+json'
+      },
+      log: {
+        warn: () => {
+          warnCalled = true
+        }
       }
     })
 
@@ -428,7 +561,7 @@ describe('deprecations', () => {
       return 'ok'
     })
 
-    expect(console.warn.callCount).to.equal(1)
+    expect(warnCalled).to.equal(true)
 
     return octokit.request('/')
 

--- a/test/integration/smoke-test.js
+++ b/test/integration/smoke-test.js
@@ -150,4 +150,45 @@ describe('smoke', () => {
 
     return octokit.issues.fooBar()
   })
+
+  it('options.log', () => {
+    // console.debug not implemented in Node 6
+    // cy.stub(console, 'debug')
+    cy.stub(console, 'info')
+    cy.stub(console, 'warn')
+    cy.stub(console, 'error')
+    const octokit1 = new Octokit()
+
+    octokit1.log.debug('foo')
+    octokit1.log.info('bar')
+    octokit1.log.warn('baz')
+    octokit1.log.error('daz')
+
+    // expect(console.debug.callCount).to.equal(0)
+    expect(console.info.callCount).to.equal(0)
+    expect(console.warn.callCount).to.equal(1)
+    expect(console.error.callCount).to.equal(1)
+
+    const calls2 = []
+    const octokit2 = new Octokit({
+      log: {
+        debug: calls2.push.bind(calls2),
+        info: calls2.push.bind(calls2),
+        warn: calls2.push.bind(calls2),
+        error: calls2.push.bind(calls2)
+      }
+    })
+
+    octokit2.log.debug('foo')
+    octokit2.log.info('bar')
+    octokit2.log.warn('baz')
+    octokit2.log.error('daz')
+
+    expect(calls2).to.deep.equal([
+      'foo',
+      'bar',
+      'baz',
+      'daz'
+    ])
+  })
 })


### PR DESCRIPTION
This pull request introduces 4 new methods

1. `octokit.log.debug()`
1. `octokit.log.info()`
1. `octokit.log.warn()`
1. `octokit.log.error()`

They can be configured using the `log` client option. By default, `octokit.log.debug()` and `octokit.log.info()` are no-ops, while the other two call `console.warn()` and `console.error()` respectively.

This can be used for debugging. The simplest way is to set the `log` option to `console`

```js
const octokit = require("@octokit/rest")({
  log: console
})

console.request("/")
```

This will log

```
request { method: "GET",
  baseUrl: "https://api.github.com",
  headers:
   { accept: "application/vnd.github.v3+json",
     "user-agent":
      "octokit.js/0.0.0-semantically-released Node.js/10.15.0 (macOS Mojave; x64)" },
  request: {},
  url: "/" }
GET / - 200 in 514ms
```

If you like to support a configurable log level, we recommend using the [console-log-level](https://github.com/watson/console-log-level) module

```js
const octokit = require("@octokit/rest")({
  log: require("console-log-level")({ level: "info" })
})

console.request("/")
```

This will only log

```
GET / - 200 in 514ms
```

The motivation to implement logging/debuging this way is to limit the bundle size for browser usage to a minimum. Please let me know what you think!

closes #779 

-----
[View rendered README.md](https://github.com/octokit/rest.js/blob/779/debugging/README.md)

