### PR TITLE
useragent, previews and request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,14 @@
 Install with `npm install @octokit/rest`.
 
 ```js
-const octokit = require('@octokit/rest')()
+const Octokit = require('@octokit/rest')
+const octokit = new Octokit ()
 
 // Compare: https://developer.github.com/v3/repos/#list-organization-repositories
 octokit.repos.listForOrg({
   org: 'octokit',
   type: 'public'
-}).then(({ data, headers, status }) => {
+}).then(({ data, status, headers }) => {
   // handle data
 })
 ```
@@ -76,21 +77,30 @@ octokit.repos.listForOrg({
 
 All available client options with default values
 
-<!-- HEADS UP: when changing the options for the constructor, make sure to also
-     update the type definition templates in scripts/templates/* -->
 ```js
-const octokit = require('@octokit/rest')({
-  timeout: 0, // 0 means no request timeout
-  headers: {
-    accept: 'application/vnd.github.v3+json',
-    'user-agent': 'octokit/rest.js v1.2.3' // v1.2.3 will be current version
-  },
+const Octokit = require('@octokit/rest')
+const octokit = new Octokit({
+  // setting a user agent is required: https://developer.github.com/v3/#user-agent-required
+  // v1.2.3 will be current @octokit/rest version
+  userAgent: 'octokit/rest.js v1.2.3',
 
-  // custom GitHub Enterprise URL
+  // add list of previews you’d like to enable globally,
+  // see https://developer.github.com/v3/previews/.
+  // Example: ['jean-grey-preview', 'symmetra-preview']
+  previews: []
+  
+  // set custom URL for on-premise GitHub Enterprise installations
   baseUrl: 'https://api.github.com',
 
-  // Node only: advanced request options can be passed as http(s) agent
-  agent: undefined
+  request: {
+    // Node.js only: advanced request options can be passed as http(s) agent,
+    // such as custom SSL certificate or proxy settings. 
+    // See https://nodejs.org/api/http.html#http_class_http_agent
+    agent: undefined,
+    
+    // request timeout in ms. 0 means no timeout
+    timeout: 0
+  }
 })
 ```
 

--- a/lib/parse-client-options.js
+++ b/lib/parse-client-options.js
@@ -18,19 +18,33 @@ function parseOptions (options) {
 
   const clientDefaults = {
     headers: options.headers || {},
-    request: {}
+    request: options.request || {}
   }
 
   if (options.baseUrl) {
     clientDefaults.baseUrl = options.baseUrl
   }
 
+  if (options.userAgent) {
+    clientDefaults.headers['user-agent'] = options.userAgent
+  }
+
+  if (options.previews) {
+    clientDefaults.headers.accept = options.previews.map(preview => `application/vnd.github.${preview}+json`)
+  }
+
   if (options.timeout) {
+    console.warn(new Error('new Octokit({timout}) is deprecated. Use {request: {agent}} instead. See https://github.com/octokit/rest.js#client-options'))
     clientDefaults.request.timeout = options.timeout
   }
 
   if (options.agent) {
+    console.warn(new Error('new Octokit({agent}) is deprecated. Use {request: {agent}} instead. See https://github.com/octokit/rest.js#client-options'))
     clientDefaults.request.agent = options.agent
+  }
+
+  if (options.headers) {
+    console.warn(new Error('new Octokit({headers}) is deprecated. Use {userAgent, previews} instead. See https://github.com/octokit/rest.js#client-options'))
   }
 
   const userAgentOption = clientDefaults.headers['user-agent']

--- a/lib/parse-client-options.js
+++ b/lib/parse-client-options.js
@@ -1,30 +1,20 @@
 module.exports = parseOptions
 
 const getUserAgent = require('universal-user-agent')
-const pick = require('lodash.pick')
 
 const pkg = require('../package.json')
 
-const OPTION_NAMES = [
-  'timeout',
-  'baseUrl',
-  'agent',
-  'headers'
-]
-
-function parseOptions (userOptions) {
-  if (!userOptions) {
-    userOptions = {}
+function parseOptions (options) {
+  if (!options) {
+    options = {}
   }
 
-  if (userOptions.headers) {
-    userOptions.headers = Object.keys(userOptions.headers).reduce((newObj, key) => {
-      newObj[key.toLowerCase()] = userOptions.headers[key]
+  if (options.headers) {
+    options.headers = Object.keys(options.headers).reduce((newObj, key) => {
+      newObj[key.toLowerCase()] = options.headers[key]
       return newObj
     }, {})
   }
-
-  const options = pick(userOptions, OPTION_NAMES)
 
   const clientDefaults = {
     headers: options.headers || {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -7519,7 +7519,8 @@
     "lodash.pick": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "dev": true
     },
     "lodash.set": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "before-after-hook": "^1.2.0",
     "btoa-lite": "^1.0.0",
     "lodash.get": "^4.4.2",
-    "lodash.pick": "^4.4.0",
     "lodash.set": "^4.3.2",
     "lodash.uniq": "^4.5.0",
     "octokit-pagination-methods": "^1.1.0",

--- a/test/integration/agent-ca/agent-ca-test.js
+++ b/test/integration/agent-ca/agent-ca-test.js
@@ -31,7 +31,7 @@ describe('custom client certificate', () => {
     })
     const octokit = new Octokit({
       baseUrl: 'https://localhost:' + server.address().port,
-      agent
+      request: { agent }
     })
 
     return octokit.repos.get({
@@ -47,7 +47,7 @@ describe('custom client certificate', () => {
     })
     const octokit = new Octokit({
       baseUrl: 'https://localhost:' + server.address().port,
-      agent
+      request: { agent }
     })
 
     return octokit.repos.get({

--- a/test/integration/agent-proxy/agent-proxy-test.js
+++ b/test/integration/agent-proxy/agent-proxy-test.js
@@ -40,7 +40,7 @@ describe('client proxy', function () {
     })
 
     return getInstance('get-organization', {
-      agent: new HttpProxyAgent(proxyUrl)
+      request: { agent: new HttpProxyAgent(proxyUrl) }
     })
 
       .then(octokit => {

--- a/test/integration/authentication-test.js
+++ b/test/integration/authentication-test.js
@@ -63,6 +63,38 @@ describe('authentication', () => {
     return octokit.orgs.get({ org: 'myorg' })
   })
 
+  it('basic with async 2fa', () => {
+    nock('https://authentication-test-host.com', {
+      reqheaders: {
+        authorization: 'Basic dXNlcm5hbWU6cGFzc3dvcmQ='
+      }
+    })
+      .get('/orgs/myorg')
+      .reply(401, {}, {
+        'x-github-otp': 'required; app'
+      })
+
+    nock('https://authentication-test-host.com', {
+      reqheaders: {
+        authorization: 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+        'x-github-otp': '123456'
+      }
+    })
+      .get('/orgs/myorg')
+      .reply(200, {})
+
+    octokit.authenticate({
+      type: 'basic',
+      username: 'username',
+      password: 'password',
+      on2fa () {
+        return Promise.resolve(123456)
+      }
+    })
+
+    return octokit.orgs.get({ org: 'myorg' })
+  })
+
   it('basic with 2fa and invalid one-time-password', () => {
     nock('https://authentication-test-host.com', {
       reqheaders: {

--- a/test/integration/deprecations-test.js
+++ b/test/integration/deprecations-test.js
@@ -1,5 +1,7 @@
 const Octokit = require('../../')
 
+require('../mocha-node-setup')
+
 const Mocktokit = Octokit
   .plugin((octokit) => {
     octokit.hook.wrap('request', () => null)
@@ -16,6 +18,87 @@ describe('deprecations', () => {
     return octokit.search.issues({ q: 'foo' })
       .then(() => {
         expect(console.warn.callCount).to.equal(1)
+      })
+  })
+
+  it('agent option', () => {
+    const octokit = new Octokit({
+      agent: 'agent'
+    })
+
+    octokit.hook.wrap('request', (request, options) => {
+      expect(options.request.agent).to.equal('agent')
+      return 'ok'
+    })
+
+    expect(console.warn.callCount).to.equal(1)
+
+    return octokit.request('/')
+
+      .then(response => {
+        expect(response).to.equal('ok')
+      })
+  })
+
+  it('timeout option', () => {
+    const octokit = new Octokit({
+      timeout: 123
+    })
+
+    octokit.hook.wrap('request', (request, options) => {
+      expect(options.request.timeout).to.equal(123)
+      return 'ok'
+    })
+
+    expect(console.warn.callCount).to.equal(1)
+
+    return octokit.request('/')
+
+      .then(response => {
+        expect(response).to.equal('ok')
+      })
+  })
+
+  it('headers["User-Agent"] option', () => {
+    const octokit = new Octokit({
+      baseUrl: 'https://smoke-test.com',
+      headers: {
+        'User-Agent': 'blah'
+      }
+    })
+
+    octokit.hook.wrap('request', (request, options) => {
+      expect(options.headers['user-agent']).to.match(/^blah octokit\.js\/0\.0\.0-semantically-released /)
+      return 'ok'
+    })
+
+    expect(console.warn.callCount).to.equal(1)
+
+    return octokit.request('/')
+
+      .then(response => {
+        expect(response).to.equal('ok')
+      })
+  })
+
+  it('headers.accept option', () => {
+    const octokit = new Octokit({
+      headers: {
+        accept: 'application/vnd.github.jean-grey-preview+json,application/vnd.github.symmetra-preview+json'
+      }
+    })
+
+    octokit.hook.wrap('request', (request, options) => {
+      expect(options.headers.accept).to.equal('application/vnd.github.jean-grey-preview+json,application/vnd.github.symmetra-preview+json')
+      return 'ok'
+    })
+
+    expect(console.warn.callCount).to.equal(1)
+
+    return octokit.request('/')
+
+      .then(response => {
+        expect(response).to.equal('ok')
       })
   })
 })

--- a/test/integration/request-errors-test.js
+++ b/test/integration/request-errors-test.js
@@ -7,21 +7,27 @@ require('../mocha-node-setup')
 describe('request errors', () => {
   it('timeout', () => {
     nock('https://request-errors-test.com')
-      .get('/orgs/myorg')
-      .socketDelay(2000)
+      .get('/')
+      .delay(2000)
       .reply(200, {})
 
     const octokit = new Octokit({
       baseUrl: 'https://request-errors-test.com',
-      timeout: 1000
+      request: {
+        timeout: 100
+      }
     })
 
-    return octokit.orgs.get({ org: 'myorg' })
+    return octokit.request('/')
+
+      .then(() => {
+        throw new Error('should not resolve')
+      })
 
       .catch(error => {
         expect(error.name).to.equal('HttpError')
-        expect(error.status).to.equal(504)
-        expect(error).to.have.property('stack')
+        expect(error.status).to.equal(500)
+        expect(error.message).to.match(/timeout/)
       })
   })
 
@@ -49,8 +55,7 @@ describe('request errors', () => {
       .reply(404, 'not found')
 
     const octokit = new Octokit({
-      baseUrl: 'https://request-errors-test.com',
-      timeout: 1000
+      baseUrl: 'https://request-errors-test.com'
     })
 
     return octokit.orgs.get({ org: 'myorg' })
@@ -68,8 +73,7 @@ describe('request errors', () => {
       .reply(401)
 
     const octokit = new Octokit({
-      baseUrl: 'https://request-errors-test.com',
-      timeout: 1000
+      baseUrl: 'https://request-errors-test.com'
     })
 
     return octokit.orgs.get({ org: 'myorg' })
@@ -89,8 +93,7 @@ describe('request errors', () => {
       })
 
     const octokit = new Octokit({
-      baseUrl: 'https://request-errors-test.com',
-      timeout: 1000
+      baseUrl: 'https://request-errors-test.com'
     })
 
     return octokit.orgs.get({ org: 'myorg' })

--- a/test/integration/smoke-test.js
+++ b/test/integration/smoke-test.js
@@ -22,46 +22,59 @@ describe('smoke', () => {
     return octokit.orgs.get({ org: 'myorg' })
   })
 
-  it('headers["User-Agent"] option', () => {
+  it('userAgent option', () => {
     nock('https://smoke-test.com', {
       reqheaders: {
         'user-agent': `blah octokit.js/0.0.0-semantically-released ${getUserAgent()}`
       }
     })
-      .get('/orgs/octokit')
+      .get('/')
       .reply(200, {})
 
     const octokit = new Octokit({
       baseUrl: 'https://smoke-test.com',
-      headers: {
-        'User-Agent': 'blah'
-      }
+      userAgent: 'blah'
     })
-
-    return octokit.orgs.get({
-      org: 'octokit'
-    })
+    return octokit.request('/')
   })
 
-  it('headers.accept option', () => {
+  it('previews option', () => {
     nock('https://smoke-test.com', {
       reqheaders: {
-        'accept': 'foo'
+        'accept': 'application/vnd.github.jean-grey-preview+json,application/vnd.github.symmetra-preview+json'
       }
     })
-      .get('/orgs/octokit')
+      .get('/')
       .reply(200, {})
 
     const octokit = new Octokit({
       baseUrl: 'https://smoke-test.com',
-      headers: {
-        accept: 'foo'
+      previews: [
+        'jean-grey-preview',
+        'symmetra-preview'
+      ]
+    })
+
+    return octokit.request('/')
+  })
+
+  it('request option', () => {
+    const octokit = new Octokit({
+      request: {
+        foo: 'bar'
       }
     })
 
-    return octokit.orgs.get({
-      org: 'octokit'
+    octokit.hook.wrap('request', (request, options) => {
+      expect(options.request.foo).to.equal('bar')
+      return 'ok'
     })
+
+    return octokit.request('/')
+
+      .then(response => {
+        expect(response).to.equal('ok')
+      })
   })
 
   it('response.status & response.headers', () => {

--- a/test/integration/smoke-test.js
+++ b/test/integration/smoke-test.js
@@ -10,7 +10,7 @@ describe('smoke', () => {
     Octokit()
   })
 
-  it('host & pathPrefix options', () => {
+  it('baseUrl option', () => {
     nock('http://myhost.com')
       .get('/my/api/orgs/myorg')
       .reply(200, {})
@@ -22,24 +22,7 @@ describe('smoke', () => {
     return octokit.orgs.get({ org: 'myorg' })
   })
 
-  it('response.status & response.headers', () => {
-    nock('http://myhost.com')
-      .get('/my/api/orgs/myorg')
-      .reply(200, {}, { 'x-foo': 'bar' })
-
-    const octokit = new Octokit({
-      baseUrl: 'http://myhost.com/my/api'
-    })
-
-    return octokit.orgs.get({ org: 'myorg' })
-
-      .then(response => {
-        expect(response.headers['x-foo']).to.equal('bar')
-        expect(response.status).to.equal(200)
-      })
-  })
-
-  it('custom user agent header as client option', () => {
+  it('headers["User-Agent"] option', () => {
     nock('https://smoke-test.com', {
       reqheaders: {
         'user-agent': `blah octokit.js/0.0.0-semantically-released ${getUserAgent()}`
@@ -60,28 +43,7 @@ describe('smoke', () => {
     })
   })
 
-  it('custom user agent header as request option', () => {
-    nock('https://smoke-test.com', {
-      reqheaders: {
-        'user-agent': `blah`
-      }
-    })
-      .get('/orgs/octokit')
-      .reply(200, {})
-
-    const octokit = new Octokit({
-      baseUrl: 'https://smoke-test.com'
-    })
-
-    return octokit.orgs.get({
-      org: 'octokit',
-      headers: {
-        'User-Agent': 'blah'
-      }
-    })
-  })
-
-  it('custom accept header', () => {
+  it('headers.accept option', () => {
     nock('https://smoke-test.com', {
       reqheaders: {
         'accept': 'foo'
@@ -89,26 +51,34 @@ describe('smoke', () => {
     })
       .get('/orgs/octokit')
       .reply(200, {})
-      .persist()
 
     const octokit = new Octokit({
-      baseUrl: 'https://smoke-test.com'
+      baseUrl: 'https://smoke-test.com',
+      headers: {
+        accept: 'foo'
+      }
     })
 
-    return Promise.all([
-      octokit.orgs.get({
-        org: 'octokit',
-        headers: {
-          accept: 'foo'
-        }
-      }),
-      octokit.orgs.get({
-        org: 'octokit',
-        headers: {
-          Accept: 'foo'
-        }
+    return octokit.orgs.get({
+      org: 'octokit'
+    })
+  })
+
+  it('response.status & response.headers', () => {
+    nock('http://myhost.com')
+      .get('/my/api/orgs/myorg')
+      .reply(200, {}, { 'x-foo': 'bar' })
+
+    const octokit = new Octokit({
+      baseUrl: 'http://myhost.com/my/api'
+    })
+
+    return octokit.orgs.get({ org: 'myorg' })
+
+      .then(response => {
+        expect(response.headers['x-foo']).to.equal('bar')
+        expect(response.status).to.equal(200)
       })
-    ])
   })
 
   it('.request("GET /")', () => {
@@ -143,14 +113,7 @@ describe('smoke', () => {
     })
   })
 
-  it('global defaults', () => {
-    const github1 = new Octokit()
-    const github2 = new Octokit()
-
-    expect(github1.request.endpoint.DEFAULTS).to.deep.equal(github2.request.endpoint.DEFAULTS)
-  })
-
-  it('registerEndpoints', () => {
+  it('.registerEndpoints()', () => {
     nock('https://smoke-test.com')
       .get('/baz')
       .reply(200, {})


### PR DESCRIPTION
In preparation for v17, instead of

```js
const octokit = new Octokit({
  headers: {
    accept: 'application/vnd.github.jean-grey-preview+json,application/vnd.github.symmetra-preview+json',
    'user-agent': 'octokit/rest.js v1.2.3' // v1.2.3 will be current version
  },
  timeout: 0,
  agent: undefined
})
```

the new options will be

```js
const octokit = new Octokit({
  userAgent: 'myapp v1.2.3',
  previews: [
    'jean-grey-preview',
    'symmetra-preview'
  ],
  request: {
    timeout: 0,
    agent: undefined
  }
})
```

The old options will continue to work, but will be deprecated. The `baseUrl` option will remain the same.

-----
[View rendered README.md](https://github.com/octokit/rest.js/blob/useragent-previews-options/README.md)