### PR TITLE
Update getForOrg to listForOrg in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ octokit.repos.listForOrg({
    const octokit = new Octokit()
 
    // Compare: https://developer.github.com/v3/repos/#list-organization-repositories
-   octokit.repos.getForOrg({
+   octokit.repos.listForOrg({
      org: 'octokit',
      type: 'public'
    }).then(({data, headers, status}) => {


### PR DESCRIPTION
Update the browser example in the README to reflect the changes to the API method name

Fixes #1209


-----
[View rendered README.md](https://github.com/BarbourSmith/rest.js/blob/update-readme-example-topic/README.md)