### PR TITLE
docs(README): fix two-factor async function mistype

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ The `auth` option can be
    - GitHub App bearer tokens
    - GitHub App installation tokens
 
-2. As object with the properties `username`, `password`, `on2Fa`.
+2. As object with the properties `username`, `password`, `on2fa`.
 
-   `on2Fa` is an asynchronous function that must resolve with two-factor
+   `on2fa` is an asynchronous function that must resolve with two-factor
    authentication code sent to the user.
 
    ```js
@@ -152,7 +152,7 @@ The `auth` option can be
      auth: {
        username: 'octocat',
        password: 'secret',
-       async on2Fa () {
+       async on2fa () {
          // example: ask the user
          return prompt('Two-factor authentication Code:')
        }

--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -43,7 +43,7 @@ declare namespace Octokit {
   }
 
   export interface Options {
-    auth?: string | { username: string; password: string; on2Fa: () => Promise<string> } | { client_id: string; client_secret: string; } | { auth: () => (string | Promise<string>) };
+    auth?: string | { username: string; password: string; on2fa: () => Promise<string> } | { client_id: string; client_secret: string; } | { auth: () => (string | Promise<string>) };
     userAgent?: string;
     previews?: string[];
     baseUrl?: string;


### PR DESCRIPTION
Async function for Authenticating via two-factor auth should be `async on2fa()` not `async on2Fa`.

Related discussion: https://github.com/octokit/rest.js/issues/1207#issuecomment-457098225
<!-- 
1. Push your changes to your topic branch on your fork of the repo.
2. Submit a pull request from your topic branch to the master branch on the `rest.js` repository.
3. Be sure to tag any issues your pull request is taking care of / contributing to.
4. Adding "Closes #123" to a pull request description will auto close the issue once the pull request is merged in. 
-->


-----
[View rendered README.md](https://github.com/TimDurward/rest.js/blob/master/README.md)