### PR TITLE
docs: add support for searching with api.github.com's url in gh-pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -275,6 +275,10 @@ pre code.sample-request-response-json {
   font-size: 14px;
 }
 
+.sidenav > li > span {
+  display: none;
+}
+
 .sidenav > li.nav-header {
   margin-top: 8px;
   margin-bottom: 8px;

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
       {{else}}
         <li class="{{#if hidden}}hide {{/if}}" data-group="{{group}}" data-name="{{name}}" data-version="{{version}}">
           <a href="#api-{{group}}-{{name}}" class="nav-list-item">{{title}}</a>
+          <span class="nav-list-item-url">{{url}}</span>
         </li>
       {{/if}}
     {{/if}}

--- a/main.js
+++ b/main.js
@@ -186,6 +186,7 @@ require([
                         group: group,
                         name: entry.name,
                         type: entry.type,
+                        url: entry.url,
                         version: entry.version
                     });
                 } else {
@@ -195,6 +196,7 @@ require([
                         hidden: true,
                         name: entry.name,
                         type: entry.type,
+                        url: entry.url,
                         version: entry.version
                     });
                 }
@@ -527,7 +529,7 @@ require([
      * Initialize search
      */
     var options = {
-      valueNames: [ 'nav-list-item' ]
+      valueNames: [ 'nav-list-item', 'nav-list-item-url' ]
     };
     var endpointsList = new List('scrollingNav', options);
 


### PR DESCRIPTION
Since there are so many endpoints in GitHub API, it's pretty annoying to me for finding correct endpoints.
When I type `repo` in [https://octokit.github.io/rest.js/](https://octokit.github.io/rest.js/) to get interface of `/user/repo`, plenty of items are displayed like below.  (about 30 ~ 40 items are in search result)  
<img width="617" alt="2019-01-25 8 00 00" src="https://user-images.githubusercontent.com/5436405/51742053-fad99180-20db-11e9-88b9-2d6bf8ca6ac7.png">

  
  
  
I think it would be comfortable if searching with GitHub's API url (ex. `/user/repo`) is possible.
<img width="541" alt="2019-01-25 8 11 24" src="https://user-images.githubusercontent.com/5436405/51742567-7556e100-20dd-11e9-9595-63e22f861a9f.png">



