### PR TITLE
fix(typescript): accept `{ auth: () =>  }` constructor option

### DIFF
--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -43,7 +43,7 @@ declare namespace Octokit {
   }
 
   export interface Options {
-    auth?: string | { username: string; password: string; on2fa: () => Promise<string> } | { client_id: string; client_secret: string; } | { auth: () => (string | Promise<string>) };
+    auth?: string | { username: string; password: string; on2fa: () => Promise<string> } | { client_id: string; client_secret: string; } | { (): (string | Promise<string>) };
     userAgent?: string;
     previews?: string[];
     baseUrl?: string;


### PR DESCRIPTION
Instead of `{ auth: { auth: () =>  } }`