### PR TITLE
Fix README case format for clientId, clientSecret

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ The `auth` option can be
    })
    ```
 
-3. An object with the properties `client_id` and `client_secret`
+3. An object with the properties `clientId` and `clientSecret`
 
-   OAuth applications can authenticate using their `client_id` and `client_secret`
+   OAuth applications can authenticate using their `clientId` and `clientSecret`
    in order to [increase the unauthenticated rate limit](https://developer.github.com/v3/#increasing-the-unauthenticated-rate-limit-for-oauth-applications).
 
 4. A function

--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -43,7 +43,7 @@ declare namespace Octokit {
   }
 
   export interface Options {
-    auth?: string | { username: string; password: string; on2fa: () => Promise<string> } | { client_id: string; client_secret: string; } | { (): (string | Promise<string>) };
+    auth?: string | { username: string; password: string; on2fa: () => Promise<string> } | { clientId: string; clientSecret: string; } | { (): (string | Promise<string>) };
     userAgent?: string;
     previews?: string[];
     baseUrl?: string;


### PR DESCRIPTION
Code usage in [authentication/validate.js](https://github.com/octokit/rest.js/blob/master@%7B2019-01-27%7D/plugins/authentication/validate.js#L16) and [authentication/before-request.js](https://github.com/octokit/rest.js/blob/master@%7B2019-01-27%7D/plugins/authentication/before-request.js#L25).

[View rendered README.md](https://github.com/cooperka/rest.js/blob/patch-1/README.md)