### PR TITLE
Add listTopics preview header

### DIFF
--- a/plugins/rest-api-endpoints/routes.json
+++ b/plugins/rest-api-endpoints/routes.json
@@ -8376,6 +8376,9 @@
       "url": "/repos/:owner/:repo/teams"
     },
     "listTopics": {
+      "headers": {
+        "accept": "application/vnd.github.mercy-preview+json"
+      },
       "method": "GET",
       "params": {
         "owner": {


### PR DESCRIPTION
This PR adds the required [preview header](https://developer.github.com/v3/repos/#list-all-topics-for-a-repository) to the [repos.listTopics](https://octokit.github.io/rest.js/#api-Repos-listTopics) function.

While using the `@octokit/rest` package, I noticed I was getting `415`s on the `repos.listTopics` request. After reviewing the docs, I changed my local copy of the `@octokit/rest` package to include the `mercy-preview` header, and the requests completed as expected.