### PR TITLE
Fix installation authentication example

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,9 @@ The `auth` option can be
 
    const app = new App({ id: process.env.APP_ID, privateKey: process.env.PRIVATE_KEY })
    const octokit = new Octokit({
-     auth () {
-       return app.getInstallationAccessToken({ process.env.INSTALLATION_ID })
+     async auth () {
+       const installationAccessToken = await app.getInstallationAccessToken({ process.env.INSTALLATION_ID });
+       return `token ${installationAccessToken}`;
      }
    })
    ```


### PR DESCRIPTION
The README shows an incorrect example of authentication using a function.

`app.getInstallationAccessToken()` returns just the token, whereas `auth` expects the token to be preceded by `"token "`.

-----
[View rendered README.md](https://github.com/pascal-giguere/rest.js/blob/fix-installation-auth-doc/README.md)