### PR TITLE
If the auth method throws the exception gets lost

### DIFF
--- a/plugins/authentication/request-error.js
+++ b/plugins/authentication/request-error.js
@@ -3,6 +3,7 @@ module.exports = authenticationRequestError
 const HttpError = require('@octokit/request/lib/http-error')
 
 function authenticationRequestError (state, error, options) {
+  if (!error.headers) throw error
   const otpRequired = /required/.test(error.headers['x-github-otp'] || '')
   // handle "2FA required" error only
   if (error.status !== 401 || !otpRequired) {

--- a/test/integration/authentication-test.js
+++ b/test/integration/authentication-test.js
@@ -272,6 +272,22 @@ describe('authentication', () => {
     return octokit.request('/')
   })
 
+  it.only('auth function throws error', () => {
+    const octokit = new Octokit({
+      auth () {
+        throw new Error('test')
+      }
+    })
+
+    return octokit.request('/')
+      .then(() => {
+        throw new Error('should not resolve')
+      })
+      .catch(error => {
+        expect(error.message).to.equal('test')
+      })
+  })
+
   /**
    * There is a special case for OAuth applications, when `clientId` and `clientSecret` is passed as
    * Basic Authorization instead of query parameters. The only routes where that applies share the same


### PR DESCRIPTION
Since the `authenticate` method was deprecated, I updated my code to use an `auth` method to provide the token, like so:

```js
const octokit = new Octokit( {
  baseUrl,
  auth() { return `token ${this.getAuthToken()}`; },
} );
```

Unfortunately, this new version had a subtle bug (wrong `this` context) that took some time to track down because if the `auth` function throws an exception it gets hidden, because the error gets passed to `authenticationRequestError` which assumes that it will have a `headers` object, so any error thrown from the auth function gets turned into `TypeError: Cannot read property 'x-github-otp' of undefined`.

This one-line fix to just rethrow the error if it doesn't have headers seems to solve the problem for me, and it looks to me like this was the intended behavior of this function, so hopefully this helps.