### PR TITLE
Update authentication examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ The `auth` option can be
 
    ```js
    const App = require('@octokit/app')
-   const Octokit = require('octokit')
+   const Octokit = require('@octokit/rest')
 
    const app = new App({ id: process.env.APP_ID, privateKey: process.env.PRIVATE_KEY })
    const octokit = new Octokit({


### PR DESCRIPTION
The doc is pointing to the package `octokit`, which is not recommended yet.

Also updated the examples with proper format for the Authorization header.


-----
[View rendered README.md](https://github.com/hudovisk/rest.js/blob/patch-1/README.md)