### PR TITLE
fix(otp-header): persist otp code only if valid

### DIFF
--- a/test/issues/1279-store-otp-send-header-all-requests-test.js
+++ b/test/issues/1279-store-otp-send-header-all-requests-test.js
@@ -46,4 +46,68 @@ describe('https://github.com/octokit/rest.js/issues/1279', () => {
         return octokit.authorization.listAuthorizations({ per_page: 100 })
       })
   })
+
+  it('prompts for OTP again once OTP code becomes invalid', () => {
+    nock('https://authentication-test-host.com', {
+      reqheaders: {
+        authorization: 'Basic dXNlcm5hbWU6cGFzc3dvcmQ='
+      }
+    })
+      .get('/')
+      .reply(401, {}, {
+        'x-github-otp': 'required; app'
+      })
+
+    nock('https://authentication-test-host.com', {
+      reqheaders: {
+        authorization: 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+        'x-github-otp': '123456'
+      }
+    })
+      .get('/')
+      .reply(200, {})
+
+    // OTP code now becomes invalid
+    nock('https://authentication-test-host.com', {
+      reqheaders: {
+        authorization: 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+        'x-github-otp': '123456'
+      }
+    })
+      .get('/authorizations?per_page=100')
+      .reply(401, {}, {
+        'x-github-otp': 'required; app'
+      })
+
+    nock('https://authentication-test-host.com', {
+      reqheaders: {
+        authorization: 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+        'x-github-otp': '123456'
+      }
+    })
+      .get('/authorizations?per_page=100')
+      .reply(200, {})
+
+    let on2faCalledCounter = 0
+    const octokit = new Octokit({
+      baseUrl: 'https://authentication-test-host.com',
+      auth: {
+        username: 'username',
+        password: 'password',
+        on2fa () {
+          on2faCalledCounter++
+          return Promise.resolve(123456)
+        }
+      }
+    })
+
+    return octokit.request('/')
+      .then(() => {
+        expect(on2faCalledCounter).to.equal(1)
+        return octokit.authorization.listAuthorizations({ per_page: 100 })
+          .then(() => {
+            expect(on2faCalledCounter).to.equal(2)
+          })
+      })
+  })
 })


### PR DESCRIPTION
Following up on https://github.com/octokit/rest.js/pull/1281#issuecomment-472710162, I followed your suggestions @gr2m but I must confess I'm not sure how to finish this. I started one way (https://github.com/ruxandrafed/rest.js/commit/5cda835952adcb1a45fe78c892db3f891de36495), but realized that's not exactly what you meant.

Now, I'm not sure how to fix this test and get back to full coverage 😬 Thanks for your patience!