### PR TITLE
Guaranteed response type for .gitdata.getReference() & .gitdata.getReferences()

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Authentication](#authentication)
 - [API docs](#api-docs)
 - [API Previews](#api-previews)
+- [Request formats](#request-formats)
 - [Custom requests](#custom-requests)
 - [Pagination](#pagination)
 - [Hooks](#hooks)

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const CORE_PLUGINS = [
   require('./plugins/authentication-deprecated'), // deprecated: remove in v17
   require('./plugins/authentication'),
   require('./plugins/pagination'),
+  require('./plugins/normalize-git-reference-responses'),
   require('./plugins/register-endpoints'),
   require('./plugins/rest-api-endpoints'),
   require('./plugins/validate'),

--- a/plugins/normalize-git-reference-responses/index.js
+++ b/plugins/normalize-git-reference-responses/index.js
@@ -1,0 +1,51 @@
+module.exports = octokitRestNormalizeGitReferenceResponses
+
+const HttpError = require('@octokit/request/lib/http-error')
+
+function octokitRestNormalizeGitReferenceResponses (octokit) {
+  octokit.hook.wrap('request', (request, options) => {
+    const isGetOrListRefRequest = /\/repos\/:?\w+\/:?\w+\/git\/refs\/:?\w+/.test(options.url)
+
+    if (!isGetOrListRefRequest) {
+      return request(options)
+    }
+
+    const isGetRefRequest = 'ref' in options
+
+    return request(options)
+      .then(response => {
+        // request single reference
+        if (isGetRefRequest) {
+          if (Array.isArray(response.data)) {
+            throw new HttpError(`More than one reference found for "${options.ref}"`, 404, {}, options)
+          }
+
+          // ✅ received single reference
+          return response
+        }
+
+        // request list of references
+        if (!Array.isArray(response.data)) {
+          response.data = [response.data]
+        }
+
+        return response
+      })
+
+      .catch(error => {
+        if (isGetRefRequest) {
+          throw error
+        }
+
+        if (error.status === 404) {
+          return {
+            status: 200,
+            headers: error.headers,
+            data: []
+          }
+        }
+
+        throw error
+      })
+  })
+}

--- a/test/integration/normalize-git-reference-responses-test.js
+++ b/test/integration/normalize-git-reference-responses-test.js
@@ -1,0 +1,99 @@
+const nock = require('nock')
+
+const Octokit = require('../../')
+
+require('../mocha-node-setup')
+
+describe('normalize responses .git.getRef() / .git.listRefs()', () => {
+  let octokit
+
+  beforeEach(() => {
+    octokit = new Octokit({
+      baseUrl: 'https://normalize-ref-responses-test.com'
+    })
+  })
+
+  it('.git.getRef() returns single object', () => {
+    nock('https://normalize-ref-responses-test.com')
+      .get('/repos/owner/repo/git/refs/ref/foo')
+      .reply(200, { ok: true })
+
+    return octokit.git.getRef({ owner: 'owner', repo: 'repo', ref: 'ref/foo' })
+      .then((response) => {
+        expect(response.data).to.deep.equal({ ok: true })
+      })
+  })
+
+  it('.git.getRef() returns array', () => {
+    nock('https://normalize-ref-responses-test.com')
+      .get('/repos/owner/repo/git/refs/ref/foo')
+      .reply(200, [1, 2])
+
+    return octokit.git.getRef({ owner: 'owner', repo: 'repo', ref: 'ref/foo' })
+      .then((response) => {
+        expect.fail('should fail with 404')
+      })
+      .catch(error => {
+        expect(error.status).to.equal(404)
+      })
+  })
+
+  it('.git.getRef() returns 404', () => {
+    nock('https://normalize-ref-responses-test.com')
+      .get('/repos/owner/repo/git/refs/ref/foo')
+      .reply(404, {})
+
+    return octokit.git.getRef({ owner: 'owner', repo: 'repo', ref: 'ref/foo' })
+      .then((response) => {
+        expect.fail('should fail with 404')
+      })
+      .catch(error => {
+        expect(error.status).to.equal(404)
+      })
+  })
+
+  it('.git.listRefs() returns single object', () => {
+    nock('https://normalize-ref-responses-test.com')
+      .get('/repos/owner/repo/git/refs/ref/foo')
+      .reply(200, { ok: true })
+
+    return octokit.git.listRefs({ owner: 'owner', repo: 'repo', namespace: 'ref/foo' })
+      .then((response) => {
+        expect(response.data).to.deep.equal([{ ok: true }])
+      })
+  })
+
+  it('.git.listRefs() returns array', () => {
+    nock('https://normalize-ref-responses-test.com')
+      .get('/repos/owner/repo/git/refs/ref/foo')
+      .reply(200, [1, 2])
+
+    return octokit.git.listRefs({ owner: 'owner', repo: 'repo', namespace: 'ref/foo' })
+      .then((response) => {
+        expect(response.data).to.deep.equal([1, 2])
+      })
+  })
+
+  it('.git.listRefs() returns 404', () => {
+    nock('https://normalize-ref-responses-test.com')
+      .get('/repos/owner/repo/git/refs/ref/foo')
+      .reply(404, {})
+
+    return octokit.git.listRefs({ owner: 'owner', repo: 'repo', namespace: 'ref/foo' })
+      .then((response) => {
+        expect(response.data).to.deep.equal([])
+        expect(response.status).to.equal(200)
+      })
+  })
+
+  it('.git.listRefs() returns 500', () => {
+    nock('https://normalize-ref-responses-test.com')
+      .get('/repos/owner/repo/git/refs/ref/foo')
+      .reply(500, {})
+
+    return octokit.git.listRefs({ owner: 'owner', repo: 'repo', namespace: 'ref/foo' })
+      .catch((error) => {
+        expect(error.status).to.equal(500)
+      })
+  })
+})


### PR DESCRIPTION
closes #1061

-----
[View rendered README.md](https://github.com/octokit/rest.js/blob/1061/predictable-responses-for-references/README.md)