### PR TITLE
add type for basic auth

### DIFF
--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -45,7 +45,7 @@ declare namespace Octokit {
   }
 
   export interface Options {
-    auth?: string | { username: string; password: string; on2fa: () => Promise<string> } | { clientId: string; clientSecret: string; } | { (): (string | Promise<string>) };
+    auth?: string | { username: string; password: string; } | { username: string; password: string; on2fa: () => Promise<string> } | { clientId: string; clientSecret: string; } | { (): (string | Promise<string>) };
     userAgent?: string;
     previews?: string[];
     baseUrl?: string;


### PR DESCRIPTION
Fixes error: 

```
node_modules/@octokit/rest/index.d.ts:47:5
    47     auth?:
           ~~~~
    The expected type comes from property 'auth' which is declared here on type 'Options'
```