### PR TITLE
refactor generate-types script to support multiple parameter types

### DIFF
--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -133,11 +133,11 @@ function generateTypes (languageName, templateFile, outputFile) {
 
         return methods.concat({
           method: methodName,
+          responseType,
+          jsdoc: jsdoc(entry.description),
           paramTypeName,
           ownParams: params.length > 0 && { params },
-          exclude: !hasParams,
-          responseType,
-          jsdoc: jsdoc(entry.description)
+          hasParams: hasParams
         })
       }, [])
 

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -127,17 +127,13 @@ function generateTypes (languageName, templateFile, outputFile) {
 
         const hasParams = params.length > 0
 
-        let paramTypeName = hasParams
-          ? namespacedParamsName
-          : 'EmptyParams'
-
         return methods.concat({
           method: methodName,
           responseType,
           jsdoc: jsdoc(entry.description),
-          paramTypeName,
-          ownParams: params.length > 0 && { params },
-          hasParams: hasParams
+          paramTypeName: hasParams ? namespacedParamsName : 'EmptyParams',
+          params,
+          hasParams
         })
       }, [])
 

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -125,15 +125,20 @@ function generateTypes (languageName, templateFile, outputFile) {
           })
           .filter(Boolean)
 
+        // prepare functions to accept multiple parameter types in order to support deprecations
+        // https://github.com/octokit/rest.js/issues/1317
         const hasParams = params.length > 0
+        const paramTypes = [{
+          type: hasParams ? namespacedParamsName : 'EmptyParams',
+          params,
+          hasParams
+        }]
 
         return methods.concat({
           method: methodName,
           responseType,
           jsdoc: jsdoc(entry.description),
-          paramTypeName: hasParams ? namespacedParamsName : 'EmptyParams',
-          params,
-          hasParams
+          paramTypes
         })
       }, [])
 

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -89,6 +89,14 @@ function generateTypes (languageName, templateFile, outputFile) {
       const methods = ROUTES[namespace].reduce((methods, entry) => {
         const methodName = normalize(entry.idName)
         const namespacedParamsName = pascalcase(`${namespace}.${methodName}.Params`)
+        let responseType = 'Octokit.AnyResponse'
+        if (entry.responses) {
+          const typeName = 'Octokit.' + typeWriter.add(entry.responses.map(response => response.body || {}), {
+            rootTypeName: pascalcase(`${namespace}.${entry.idName}.Response`)
+          })
+          responseType = 'Octokit.Response<' + typeName + '>'
+        }
+
         const params = entry.params
           .reduce(toCombineParams, [])
           .map(toParamAlias)
@@ -121,15 +129,7 @@ function generateTypes (languageName, templateFile, outputFile) {
 
         let paramTypeName = hasParams
           ? namespacedParamsName
-          : pascalcase('EmptyParams')
-
-        let responseType = 'Octokit.AnyResponse'
-        if (entry.responses) {
-          const typeName = 'Octokit.' + typeWriter.add(entry.responses.map(response => response.body || {}), {
-            rootTypeName: pascalcase(`${namespace}.${entry.idName}.Response`)
-          })
-          responseType = 'Octokit.Response<' + typeName + '>'
-        }
+          : 'EmptyParams'
 
         return methods.concat({
           method: methodName,

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -88,7 +88,7 @@ function generateTypes (languageName, templateFile, outputFile) {
     .reduce((namespaces, namespace) => {
       const methods = ROUTES[namespace].reduce((methods, entry) => {
         const methodName = normalize(entry.idName)
-        const namespacedParamsName = pascalcase(`${namespace}-${methodName}Params`)
+        const namespacedParamsName = pascalcase(`${namespace}.${methodName}.Params`)
         const params = entry.params
           .reduce(toCombineParams, [])
           .map(toParamAlias)
@@ -126,7 +126,7 @@ function generateTypes (languageName, templateFile, outputFile) {
         let responseType = 'Octokit.AnyResponse'
         if (entry.responses) {
           const typeName = 'Octokit.' + typeWriter.add(entry.responses.map(response => response.body || {}), {
-            rootTypeName: pascalcase(`${namespace}-${entry.idName}Response`)
+            rootTypeName: pascalcase(`${namespace}.${entry.idName}.Response`)
           })
           responseType = 'Octokit.Response<' + typeName + '>'
         }

--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -219,20 +219,12 @@ declare namespace Octokit {
   {{#methods}}
   {{#hasParams}}
   export type {{paramTypeName}} =
-    {{#unionTypeNames}}
-    & {{.}}
-    {{/unionTypeNames}}
-    {{#ownParams}}
     & {
     {{#params}}
       {{&jsdoc}}
       "{{key}}"{{^required}}?{{/required}}: {{{type}}}{{#allowNull}} | null{{/allowNull}};
     {{/params}}
     };
-    {{/ownParams}}
-    {{^ownParams}}
-    ;
-    {{/ownParams}}
   {{/hasParams}}
   {{/methods}}
   {{/namespaces}}

--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -222,7 +222,7 @@ declare namespace Octokit {
   {{#namespaces}}
   {{#methods}}
   {{#paramTypeName}}
-  {{^exclude}}
+  {{#hasParams}}
   export type {{paramTypeName}} =
     {{#unionTypeNames}}
     & {{.}}
@@ -238,7 +238,7 @@ declare namespace Octokit {
     {{^ownParams}}
     ;
     {{/ownParams}}
-  {{/exclude}}
+  {{/hasParams}}
   {{/paramTypeName}}
   {{/methods}}
   {{/namespaces}}

--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -217,8 +217,9 @@ declare namespace Octokit {
 
   {{#namespaces}}
   {{#methods}}
+  {{#paramTypes}}
   {{#hasParams}}
-  export type {{paramTypeName}} =
+  export type {{type}} =
     & {
     {{#params}}
       {{&jsdoc}}
@@ -226,6 +227,7 @@ declare namespace Octokit {
     {{/params}}
     };
   {{/hasParams}}
+  {{/paramTypes}}
   {{/methods}}
   {{/namespaces}}
   {{#childParams}}
@@ -270,7 +272,9 @@ declare class Octokit {
     {{#methods}}
     {{&jsdoc}}
     {{method}}: {
-      ({{#paramTypeName}}params?: Octokit.{{.}}{{/paramTypeName}}): Promise<{{&responseType}}>;
+      {{#paramTypes}}
+      (params?: Octokit.{{type}}): Promise<{{&responseType}}>;
+      {{/paramTypes}}
 
       endpoint: Octokit.Endpoint
     };

--- a/scripts/templates/index.d.ts.tpl
+++ b/scripts/templates/index.d.ts.tpl
@@ -215,13 +215,8 @@ declare namespace Octokit {
 
   {{&responseTypes}}
 
-  {{#params}}
-  export interface {{name}} { {{key}}{{^required}}?{{/required}}: {{{type}}}; }
-  {{/params}}
-
   {{#namespaces}}
   {{#methods}}
-  {{#paramTypeName}}
   {{#hasParams}}
   export type {{paramTypeName}} =
     {{#unionTypeNames}}
@@ -239,18 +234,12 @@ declare namespace Octokit {
     ;
     {{/ownParams}}
   {{/hasParams}}
-  {{/paramTypeName}}
   {{/methods}}
   {{/namespaces}}
   {{#childParams}}
   export type {{paramTypeName}} =
     & {
     {{#params}}
-      {{#deprecated}}
-      /**
-       * @deprecated "{{key}}" has been renamed to "{{alias}}"
-       */
-       {{/deprecated}}
       "{{key}}"{{^required}}?{{/required}}: {{{type}}};
     {{/params}}
     };


### PR DESCRIPTION
This is needed to support deprecated parameters, closes #1317