### PR TITLE
Docs: Position sticky navigation below the header

### DIFF
--- a/docs/src/components/api.js
+++ b/docs/src/components/api.js
@@ -59,7 +59,7 @@ export default class Api extends Component {
           <ol className={this.props.isMenuActive() ? "" : apiStyles.hidden}>
             {this.props.data.staticMethods.edges.map(({ node }) => {
               return <li key={node.id}>
-                <a href={`#octokit-${node.fields.idName}`}>{node.frontmatter.title}</a>
+                <a href={`#${node.fields.idName}`}>{node.frontmatter.title}</a>
               </li>
             })}
             {this.props.data.endpointScopes.edges.map(({ node }) => {
@@ -74,7 +74,7 @@ export default class Api extends Component {
         <main className={apiStyles.container}>
           {this.props.data.staticMethods.edges.map(({ node }) => {
             return <React.Fragment key={node.id}>
-              <h2>{node.frontmatter.title}</h2>
+              <h2 id={node.fields.idName}>{node.frontmatter.title}</h2>
               <div dangerouslySetInnerHTML={{ __html: node.html }} />
             </React.Fragment>
           })}

--- a/docs/src/components/api.module.css
+++ b/docs/src/components/api.module.css
@@ -38,11 +38,11 @@ main h2:first-child {
 
 .nav {
   position: sticky;
-  top: 0;
+  top: 5em;
   background: hsla(0, 0%, 100%, 0.95);
 
   /* Give the navigation a maximum height, so the “stickyness” will have an effect. */
-  max-height: 100vh;
+  max-height: calc(100vh - 5em);
   overflow-y: auto;
 
   /* TBD: Would it better to limit the navigation height so that all of the items
@@ -74,6 +74,7 @@ main h2:first-child {
   text-shadow: none;
   background-image: none;
   text-decoration: none;
+  display: block;
 }
 
 .nav ol,

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -13,7 +13,7 @@ export default ({ data }) => (
 
 export const query = graphql`
   query {
-    staticMethods: allMarkdownRemark {
+    staticMethods: allMarkdownRemark(sort:{ fields: fields___slug }) {
       edges {
         node {
           id


### PR DESCRIPTION
cherry-picking fix from https://github.com/gr2m/octokit-rest-documentation/pull/41/ by @jimthoburn