### PR TITLE
throw 400 Bad Request error when `octokit.issues.get()` without parameters

### DIFF
--- a/plugins/register-endpoints/register-endpoints.js
+++ b/plugins/register-endpoints/register-endpoints.js
@@ -62,6 +62,10 @@ function registerEndpoints (octokit, routes) {
 
 function patchForDeprecation (octokit, apiOptions, method, methodName) {
   const patchedMethod = (options) => {
+    if (!options) {
+      return method(options)
+    }
+
     Object.keys(options).forEach(key => {
       if (apiOptions.params[key] && apiOptions.params[key].deprecated) {
         const aliasKey = apiOptions.params[key].alias

--- a/test/integration/deprecations-test.js
+++ b/test/integration/deprecations-test.js
@@ -78,6 +78,15 @@ describe('deprecations', () => {
       })
   })
 
+  it('deprecated parameter: passing no options', () => {
+    const octokit = new Octokit()
+
+    return octokit.issues.get()
+      .catch((error) => {
+        expect(error.status).to.equal(400)
+      })
+  })
+
   it('octokit.issues.get.endpoint({owner, repo, number}) returns correct URL and logs deprecation', () => {
     let warnCalledCount = 0
     const octokit = new Octokit({


### PR DESCRIPTION
closes #1338