### PR TITLE
Address typo in Debug section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ const octokit = require('@octokit/rest')({
   log: console
 })
 
-console.request('/')
+octokit.request('/')
 ```
 
 This will log
@@ -529,7 +529,7 @@ const octokit = require('@octokit/rest')({
   log: require('console-log-level')({ level: 'info' })
 })
 
-console.request('/')
+octokit.request('/')
 ```
 
 This will only log


### PR DESCRIPTION
I think there are a couple of typos in [the Debug section of the README](https://github.com/octokit/rest.js/blob/4045f1a35da16e65a4ccc87637b097fb158cedfb/README.md#debug) :bow: