### PR TITLE
fix(docs): typo in usage.md

### DIFF
--- a/docs/src/pages/api/00_usage.md
+++ b/docs/src/pages/api/00_usage.md
@@ -38,7 +38,7 @@ Learn more about [API Previews](#previews).
   previews: ['jean-grey', 'symmetra'],
 ```
 
-In order to use Ocotkit with GitHub Enterprise, set the `baseUrl` option.
+In order to use Octokit with GitHub Enterprise, set the `baseUrl` option.
 
 ```js
   baseUrl: 'https://api.github.com',


### PR DESCRIPTION
Fix this typo :

![preview](https://i.imgur.com/tPsieiG.png)

-----
[View rendered docs/src/pages/api/00_usage.md](https://github.com/KeziahForks/rest.js/blob/fix-typo/docs/src/pages/api/00_usage.md)