### PR TITLE
Deprecation warning text edits for request options

### DIFF
--- a/lib/parse-client-options.js
+++ b/lib/parse-client-options.js
@@ -40,17 +40,17 @@ function parseOptions (options, log, hook) {
   }
 
   if (options.timeout) {
-    deprecateOptionsTimeout(log, new Deprecation('[@octokit/rest] new Octokit({timeout}) is deprecated. Use {request: {timeout}} instead. See https://github.com/octokit/rest.js#client-options'))
+    deprecateOptionsTimeout(log, new Deprecation('[@octokit/rest] new Octokit({timeout}) is deprecated. Use {request: {timeout}} instead. See https://github.com/octokit/request.js#request'))
     clientDefaults.request.timeout = options.timeout
   }
 
   if (options.agent) {
-    deprecateOptionsAgent(log, new Deprecation('[@octokit/rest] new Octokit({agent}) is deprecated. Use {request: {agent}} instead. See https://github.com/octokit/rest.js#client-options'))
+    deprecateOptionsAgent(log, new Deprecation('[@octokit/rest] new Octokit({agent}) is deprecated. Use {request: {agent}} instead. See https://github.com/octokit/request.js#request'))
     clientDefaults.request.agent = options.agent
   }
 
   if (options.headers) {
-    deprecateOptionsHeaders(log, new Deprecation('[@octokit/rest] new Octokit({headers}) is deprecated. Use {userAgent, previews} instead. See https://github.com/octokit/rest.js#client-options'))
+    deprecateOptionsHeaders(log, new Deprecation('[@octokit/rest] new Octokit({headers}) is deprecated. Use {userAgent, previews} instead. See https://github.com/octokit/request.js#request'))
   }
 
   const userAgentOption = clientDefaults.headers['user-agent']

--- a/lib/parse-client-options.js
+++ b/lib/parse-client-options.js
@@ -40,7 +40,7 @@ function parseOptions (options, log, hook) {
   }
 
   if (options.timeout) {
-    deprecateOptionsTimeout(log, new Deprecation('[@octokit/rest] new Octokit({timout}) is deprecated. Use {request: {agent}} instead. See https://github.com/octokit/rest.js#client-options'))
+    deprecateOptionsTimeout(log, new Deprecation('[@octokit/rest] new Octokit({timeout}) is deprecated. Use {request: {timeout}} instead. See https://github.com/octokit/rest.js#client-options'))
     clientDefaults.request.timeout = options.timeout
   }
 


### PR DESCRIPTION
This fixes a small typo in the deprecation warnings and fixes the link in these warnings to the request.js docs.

Bumped into this while doing a rest.js upgrade - the error was a bit puzzling so thought I would fix for others.