### PR TITLE
Milestone Update: Allow due date to removed from a milestone

### DIFF
--- a/plugins/rest-api-endpoints/routes.json
+++ b/plugins/rest-api-endpoints/routes.json
@@ -3411,7 +3411,8 @@
           "type": "string"
         },
         "due_on": {
-          "type": "string"
+          "type": "string",
+          "allowNull": true
         },
         "milestone_number": {
           "required": true,


### PR DESCRIPTION
Currently there is no way with updateMilestone to remove the due date. This change allows passing null as the due_on parameter, which will remove the exsiting due date from the milestone.
