### PR TITLE
Add a header for listing and replacing topics on a repository

### DIFF
--- a/plugins/rest-api-endpoints/routes.json
+++ b/plugins/rest-api-endpoints/routes.json
@@ -9029,6 +9029,9 @@
       "url": "/repos/:owner/:repo/teams"
     },
     "listTopics": {
+      "headers": {
+        "accept": "application/vnd.github.mercy-preview+json"
+      },
       "method": "GET",
       "params": {
         "owner": {
@@ -9371,6 +9374,9 @@
       "url": "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
     },
     "replaceTopics": {
+      "headers": {
+        "accept": "application/vnd.github.mercy-preview+json"
+      },
       "method": "PUT",
       "params": {
         "names": {


### PR DESCRIPTION
When making a request to list/replace topics, an error is shown:

> To view the topics property in calls that return repository results, you must provide a custom media type in the Accept header: 
> `application/vnd.github.mercy-preview+json`

as per the [docs](https://developer.github.com/v3/repos/#list-all-topics-for-a-repository).
This commit adds the header that is required for both methods.
