### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/src/pages/api/00_usage.md
+++ b/docs/src/pages/api/00_usage.md
@@ -46,7 +46,7 @@ In order to use Octokit with GitHub Enterprise, set the `baseUrl` option.
 
 For custom loggin, pass an object with `debug`, `info`, `warn` and `error` methods as the `log` option.
 
-Learn more about [logging](#logging) and [debuging](#debuging).
+Learn more about [logging](#logging) and [debugging](#debug).
 
 ```js
   log: {


### PR DESCRIPTION
This fixes a typo and broken link in the usage docs