### PR TITLE
Added docs for advanced requests using AbortController

### DIFF
--- a/docs/src/pages/api/03_request_formats.md
+++ b/docs/src/pages/api/03_request_formats.md
@@ -1,5 +1,5 @@
 ---
-title: "Request formats"
+title: "Request formats & aborts"
 ---
 
 Some API endpoints support alternative response formats, see [Media types](https://developer.github.com/v3/media/).
@@ -16,21 +16,19 @@ const { data: prDiff } = await octokit.pulls.get({
   }
 })
 ```
-### Advanced Requests
-The [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) interface can be used to abort one or more requests as and when desired.
-When the request is initiated, we can pass in the [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) as an option inside the request's options object.
+
+The [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) interface can be used to abort one or more requests as and when desired. When the request is initiated, an [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) instance can be passed as an option inside the request's options object. For usage in Node, the [`abort-controller`](https://github.com/mysticatea/abort-controller) package can be used.
 
 ```js
 const controller = new AbortController()
-const signal = controller.signal
 const { data: prDiff } = await octokit.pulls.get({
   owner: 'octokit',
   repo: 'rest.js',
   pull_number: 1278,
-  mediaType: {
-    format: 'diff'
-  },
-  signal
+  request: {
+    signal: controller.signal
+  }
 })
 ```
+
 Use `controller.abort()` to abort the request when desired.

--- a/docs/src/pages/api/03_request_formats.md
+++ b/docs/src/pages/api/03_request_formats.md
@@ -16,3 +16,21 @@ const { data: prDiff } = await octokit.pulls.get({
   }
 })
 ```
+### Advanced Requests
+The [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) interface can be used to abort one or more requests as and when desired.
+When the request is initiated, we can pass in the [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) as an option inside the request's options object.
+
+```js
+const controller = new AbortController()
+const signal = controller.signal
+const { data: prDiff } = await octokit.pulls.get({
+  owner: 'octokit',
+  repo: 'rest.js',
+  pull_number: 1278,
+  mediaType: {
+    format: 'diff'
+  },
+  signal
+})
+```
+Use `controller.abort()` to abort the request when desired.


### PR DESCRIPTION
**What's new?**
- fixes #1426 
- Added documentation for `advanced request formats` that can be aborted by a user when desired.
- Changes to [Request formats](https://github.com/octokit/rest.js/blob/master/docs/src/pages/api/03_request_formats.md) are shown below.

### Advanced Requests
The [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) interface can be used to abort one or more requests as and when desired.
When the request is initiated, we can pass in the [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) as an option inside the request's options object.

```js
const controller = new AbortController()
const signal = controller.signal
const { data: prDiff } = await octokit.pulls.get({
  owner: 'octokit',
  repo: 'rest.js',
  pull_number: 1278,
  mediaType: {
    format: 'diff'
  },
  request: {
    signal
  }
})
```

Use `controller.abort()` to abort the request when desired.


-----
[View rendered docs/src/pages/api/03_request_formats.md](https://github.com/naseemali925/rest.js/blob/docs/abortable-request/docs/src/pages/api/03_request_formats.md)