### PR TITLE
fix(docs): Minor typo correction

### DIFF
--- a/.github/workflows/bundlesize.yml
+++ b/.github/workflows/bundlesize.yml
@@ -14,4 +14,4 @@ jobs:
       - run: npm run build:browser
       - run: npx bundlesize
         env:
-          BUNDLESIZE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUNDLESIZE_GITHUB_TOKEN: ${{ secrets.BUNDLESIZE_GITHUB_TOKEN }}

--- a/docs/src/pages/api/00_usage.md
+++ b/docs/src/pages/api/00_usage.md
@@ -44,7 +44,7 @@ In order to use Octokit with GitHub Enterprise, set the `baseUrl` option.
   baseUrl: 'https://api.github.com',
 ```
 
-For custom loggin, pass an object with `debug`, `info`, `warn` and `error` methods as the `log` option.
+For custom logging, pass an object with `debug`, `info`, `warn` and `error` methods as the `log` option.
 
 Learn more about [logging](#logging) and [debugging](#debug).
 


### PR DESCRIPTION
~`loggin` => `login`.~
`loggin` => `logging`.

-----
[View rendered docs/src/pages/api/00_usage.md](https://github.com/Kosai106/rest.js/blob/patch-1/docs/src/pages/api/00_usage.md)