### PR TITLE
fix(elasticlunr-plugin): use url field instead of url

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -87,8 +87,8 @@ module.exports = {
           OctokitApiMethod: {
             name: node => node.name,
             scope: node => node.scope,
-            route: node => `${node.method} ${node.path}`,
-            method: node => `${node.scope}.${camelCase(node.idName)}`,
+            route: node => `${node.method} ${node.url}`,
+            method: node => `${node.example}`,
             slug: node => `#${node.id}`,
             type: node => "API method"
           }


### PR DESCRIPTION
This adds a fix in the elasticlunr search plugin resolvers config to use
the url field instead of path when building an index of search results.
The url after the method in search results was undefined, now it's the
correct API URL for that resource.

This also updates the method index field to use OctokitApiMethod.example
to show an example octokit call.

The search dropdown looks like this on master
<img width="392" alt="image" src="https://user-images.githubusercontent.com/2539016/65401171-2f8d0e00-dd7b-11e9-9c0b-f64a0169f270.png">

and like this after the fixes

<img width="616" alt="image" src="https://user-images.githubusercontent.com/2539016/65401174-39af0c80-dd7b-11e9-9cdd-da1241a6ee45.png">



<!-- 
1. Push your changes to your topic branch on your fork of the repo.
2. Submit a pull request from your topic branch to the master branch on the `rest.js` repository.
3. Be sure to tag any issues your pull request is taking care of / contributing to.
4. Adding "Closes #123" to a pull request description will auto close the issue once the pull request is merged in. 
-->

Closes #1475 