### PR TITLE
fix(search): remove "octokit-" prefix from markdown searches

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -76,7 +76,7 @@ module.exports = {
           // For any node of type MarkdownRemark, list how to resolve the fields` values
           MarkdownRemark: {
             title: node => node.frontmatter.title,
-            slug: node => `#octokit-${node.fields.idName}`,
+            slug: node => `#${node.fields.idName}`,
             type: node => "API"
           },
           OctokitApiGroup: {

--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -8,7 +8,7 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
 
   if (node.internal.type === `MarkdownRemark`) {
     const slug = createFilePath({ node, getNode, basePath: `pages` });
-    const idName = _.kebabCase(node.frontmatter.title);
+    const idName = `${_.kebabCase(node.frontmatter.title)}`;
     createNodeField({
       node,
       name: `slug`,

--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -8,7 +8,7 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
 
   if (node.internal.type === `MarkdownRemark`) {
     const slug = createFilePath({ node, getNode, basePath: `pages` });
-    const idName = `${_.kebabCase(node.frontmatter.title)}`;
+    const idName = _.kebabCase(node.frontmatter.title);
     createNodeField({
       node,
       name: `slug`,


### PR DESCRIPTION
This fixes a bug where the elasticsearch index always prepends
"octokit-" to the idName of the markdownPage node.

All of the results of the OctokitApiMethod already have octokit-
prefixed in their id field, but the MarkdownRemark nodes don't have the
octokit prefix. By removing the prefix from the MarkdownRemark search
hits, the links in the search results should now correctly point to the
same anchors as the links on the page.

This also doesn't change any existing anchors for the MarkdownPage
links, so this shouldn't break any existing hyperlinks. It should just
correct the MarkdownPage search results.

The difference between the selected links and the other links are that the highlighted links are built from the [allMarkdownRemark query](https://github.com/octokit/rest.js/blob/master/docs/src/pages/index.js#L21) and the others are built from the [allOctokitApiGroup query](https://github.com/octokit/rest.js/blob/master/docs/src/pages/index.js#L35).


![](https://user-images.githubusercontent.com/2993937/63122600-28513400-bf75-11e9-9903-fb47147c8f4b.png)

Here's the behavior after the fix

![2019-09-28 14 29 19](https://user-images.githubusercontent.com/2539016/65822630-7906ae80-e1fc-11e9-99b8-de3607e91658.gif)

Closes #1446 