### PR TITLE
fix(search): remove extra octokit prefix in search results

### DIFF
--- a/docs/src/components/search-results.js
+++ b/docs/src/components/search-results.js
@@ -22,7 +22,7 @@ class Row extends PureComponent {
               (<code>{page.route}</code>)
             </small>
             <br />
-            <code>octokit.{page.method}</code>
+            <code>{page.method}</code>
           </a>
         </li>
       );


### PR DESCRIPTION
This fixes a bug in the search results caused by #1481 (sorry). The search
results now return the `example` field from `OctokitApiMethod` in its
entirety, which looks something like `octokit.teams.get`. However, the
`SearchResults` component was also prefixing the value with `octokit.`
as well. This lead to results that looked like
`octokit.octokit.teams.get`.

By removing the prefix from SearchResults, this fixes the bug.

Current Behavior:
<img width="599" alt="image" src="https://user-images.githubusercontent.com/2539016/66012187-07886380-e47b-11e9-8187-b384e60b235c.png">


Behavior on this branch:
<img width="525" alt="image" src="https://user-images.githubusercontent.com/2539016/66012179-fdfefb80-e47a-11e9-9376-82c952ed6be0.png">
