### PR TITLE
Show a message for deprecated methods

### DIFF
--- a/docs/plugins/gatsby-source-octokit-routes/gatsby-node.js
+++ b/docs/plugins/gatsby-source-octokit-routes/gatsby-node.js
@@ -26,10 +26,16 @@ exports.sourceNodes = async ({ actions }) => {
     const example = `octokit.${endpoint.scope}.${_.camelCase(
       endpoint.id
     )}(${paramsString})`;
+    let renamedId;
+
+    if (endpoint.renamed) {
+      renamedId = `octokit-routes-${endpoint.scope}-${_.kebabCase(endpoint.renamed.after)}`
+    }
     const method = {
       ...endpoint,
       id: endpointId,
-      example
+      example,
+      renamed: endpoint.renamed ? {...endpoint.renamed, afterId: renamedId } : undefined,
     };
 
     createNode({
@@ -38,6 +44,7 @@ exports.sourceNodes = async ({ actions }) => {
       children: [],
       id: endpointId,
       example,
+      renamed: endpoint.renamed ? {...endpoint.renamed, afterId: renamedId } : undefined,
       internal: {
         description: `${endpoint.name} Method`,
         contentDigest: endpointId,

--- a/docs/src/components/api.module.css
+++ b/docs/src/components/api.module.css
@@ -146,6 +146,13 @@ main h2:first-child {
   font-weight: bold;
 }
 
+.deprecated {
+  background-color: #ffe7e8;
+  padding: 1.25rem;
+  border-radius: 0.25rem;
+  margin-bottom: 1rem;
+}
+
 /* Hide the navigation on small screens, until the toggle button is pressed */
 @media (max-width: 55em) {
   /* --wide-enough-for-two-columns */

--- a/docs/src/components/endpoint.js
+++ b/docs/src/components/endpoint.js
@@ -41,12 +41,29 @@ export default class EndPoint extends Component {
 
   render() {
     const method = this.props.method;
+    if (method.renamed) console.log(method);
     return (
       <React.Fragment>
         <h3 id={method.id} ref={this.headlineRef}>
           {method.name}
         </h3>
 
+        {method.isDeprecated && (
+          <aside className={apiStyles.deprecated}>
+            This method is deprecated.
+          </aside>
+        )}
+
+        {method.renamed && (
+          <aside className={apiStyles.deprecated}>
+            <div>
+              <strong>Deprecated</strong>
+            </div>
+            <span>
+              This method has been renamed from {method.renamed.before} to <a href={`#${method.renamed.afterId}`}>{method.renamed.after}</a>.
+            </span>
+          </aside>
+        )}
         <div dangerouslySetInnerHTML={{ __html: marked(method.description) }} />
 
         <div className="gatsby-highlight" data-language="js">

--- a/docs/src/components/endpoint.js
+++ b/docs/src/components/endpoint.js
@@ -41,7 +41,6 @@ export default class EndPoint extends Component {
 
   render() {
     const method = this.props.method;
-    if (method.renamed) console.log(method);
     return (
       <React.Fragment>
         <h3 id={method.id} ref={this.headlineRef}>
@@ -60,7 +59,8 @@ export default class EndPoint extends Component {
               <strong>Deprecated</strong>
             </div>
             <span>
-              This method has been renamed from {method.renamed.before} to <a href={`#${method.renamed.afterId}`}>{method.renamed.after}</a>.
+              This method has been renamed from {method.renamed.before} to{" "}
+              <a href={`#${method.renamed.afterId}`}>{method.renamed.after}</a>.
             </span>
           </aside>
         )}

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -43,10 +43,17 @@ export const query = graphql`
             description
             example
             documentationUrl
+            isDeprecated
+            scope
             parameters {
               name
               required
               description
+            }
+            renamed {
+              before
+              after
+              afterId
             }
           }
         }

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -44,7 +44,6 @@ export const query = graphql`
             example
             documentationUrl
             isDeprecated
-            scope
             parameters {
               name
               required


### PR DESCRIPTION
This shows a general deprecation warning for methods that are deprecated
by GitHub, and a slightly more informational warning for methods that
have been renamed by Octokit.

This adds a new field called `afterId` to the `return` field in the
`OctokitApiMethod` type, which is used for linking to the renamed
method in the documentation.

### Octokit Renamed Method Warning
<img width="619" alt="image" src="https://user-images.githubusercontent.com/2539016/66174774-a9d75100-e60b-11e9-8113-69cb826b7478.png">

### GitHub Deprecation Warning
<img width="614" alt="image" src="https://user-images.githubusercontent.com/2539016/66174808-c3789880-e60b-11e9-9b30-0adc75d6c4a8.png">

Since the GitHub deprecation warnings usually already have documentation saying that the endpoint is deprecated, maybe we can highlight that text instead of having a generic error message above that.

I'm still working on this, but I thought I'd open up a PR with the changes so far.