### PR TITLE
Add timezone option to Octokit constructor

### DIFF
--- a/docs/src/pages/api/00_usage.md
+++ b/docs/src/pages/api/00_usage.md
@@ -38,6 +38,14 @@ Learn more about [API Previews](#previews).
   previews: ['jean-grey', 'symmetra'],
 ```
 
+A default time zone can be enabled by setting the `timeZone` option.
+
+```js
+  timeZone: 'Europe/Amsterdam',
+```
+
+Learn more about [using time zones with the GitHub API](https://developer.github.com/v3/#using-the-time-zone-header).
+
 In order to use Octokit with GitHub Enterprise, set the `baseUrl` option.
 
 ```js

--- a/lib/parse-client-options.js
+++ b/lib/parse-client-options.js
@@ -43,6 +43,10 @@ function parseOptions(options, log, hook) {
     clientDefaults.mediaType.previews = options.previews;
   }
 
+  if (options.timeZone) {
+    clientDefaults.headers["time-zone"] = options.timeZone;
+  }
+
   if (options.timeout) {
     deprecateOptionsTimeout(
       log,

--- a/test/integration/smoke-test.js
+++ b/test/integration/smoke-test.js
@@ -83,6 +83,16 @@ describe("smoke", () => {
     });
   });
 
+  it("timeZone option", () => {
+    const octokit = new Octokit({
+      baseUrl: "https://smoke-test.com",
+      timeZone: "Europe/Amsterdam"
+    });
+
+    const requestOptions = octokit.repos.get.endpoint("GET /");
+    expect(requestOptions.headers["time-zone"]).to.equal("Europe/Amsterdam");
+  });
+
   it("request option", () => {
     const octokit = new Octokit({
       request: {


### PR DESCRIPTION
This adds a `timeZone` option to the `Octokit` constructor. The value provided is set as the `time-zone` header in the client defaults, so all requests made with that octokit instance will have that `time-zone` header.

I tested this by making a commit on a sandbox repo with the "Europe/Amsterdam" with an octokit instance with a `timeZone` option of "Europe/Amsterdam" and the date information on the commit was made with a timezone of GMT+2, instead of PST.

```git
bash-3.2$ git log -1
commit a5b12ad2038ba1a79a5dd6519db2768eefe0031b (HEAD -> master, origin/master)
Author: Chris Opperwall
Date:   Tue Oct 8 03:39:43 2019 +0200

    super cool commit
bash-3.2$ date
Mon Oct  7 18:45:36 PDT 2019
```

I also added a test case to `smoke-test.js`, since it looked like that's where most of the other options were tested.

I can also start working on the `octokit/core.js` version of this feature. :+1:

<!-- 
1. Push your changes to your topic branch on your fork of the repo.
2. Submit a pull request from your topic branch to the master branch on the `rest.js` repository.
3. Be sure to tag any issues your pull request is taking care of / contributing to.
4. Adding "Closes #123" to a pull request description will auto close the issue once the pull request is merged in. 
-->

Closes #1456 