### PR TITLE
fix(typescript): Include done callback in Paginate interface

### DIFF
--- a/scripts/update-endpoints/templates/index.d.ts.tpl
+++ b/scripts/update-endpoints/templates/index.d.ts.tpl
@@ -256,11 +256,11 @@ declare namespace Octokit {
     (
       Route: string,
       EndpointOptions?: Octokit.EndpointOptions,
-      callback?: (response: Octokit.AnyResponse) => any
+      callback?: (response: Octokit.AnyResponse, done: () => void) => any
     ): Promise<any[]>;
     (
       EndpointOptions: Octokit.EndpointOptions,
-      callback?: (response: Octokit.AnyResponse) => any
+      callback?: (response: Octokit.AnyResponse, done: () => void) => any
     ): Promise<any[]>;
     iterator: (
       EndpointOptions: Octokit.EndpointOptions


### PR DESCRIPTION
The `Paginate` interface included in this package has a `callback` property that does not accept the `done` callback that causes pagination to exit early. This PR simply adds those parameters to the interface.