### PR TITLE
Fix typo in docs

### DIFF
--- a/HOW_IT_WORKS.md
+++ b/HOW_IT_WORKS.md
@@ -14,7 +14,7 @@
 <a name="endpoint-options"></a>
 ## Endpoint options (① - ④)
 
-`@octokit/rest` exposes a method for each [REST API endpoint](https://developer.github.com/v3/), for example `octokit.repos.getForOrg()` for [`GET /orgs/:org/repos`](https://developer.github.com/v3/repos/#list-organization-repositories). The methods are generated from the [plugins/rest-api-endpoints/routes.json](plugins/rest-api-endpoints/routes.json) file which defines the **② endpoint default options** `method`, `url` and in some cases `headers`.
+`@octokit/rest` exposes a method for each [REST API endpoint](https://developer.github.com/v3/), for example `octokit.repos.listForOrg()` for [`GET /orgs/:org/repos`](https://developer.github.com/v3/repos/#list-organization-repositories). The methods are generated from the [plugins/rest-api-endpoints/routes.json](plugins/rest-api-endpoints/routes.json) file which defines the **② endpoint default options** `method`, `url` and in some cases `headers`.
 
 **② endpoint default options** are merged with **① global defaults**, which are based on [@octokit/endpoint/lib/defaults.js](https://github.com/octokit/endpoint.js/blob/master/lib/defaults.js) and the options that were passed into the `require('@octokit/rest')(options)` client setup.
 
@@ -23,7 +23,7 @@ Both are merged with **③ user options** passed into the method. Altogether the
 **Example**: get all public repositories of the the [@octokit GitHub organization](https://github.com/octokit).
 
 ```js
-octokit.repos.getForOrg({ org: 'octokit', type: 'public' })
+octokit.repos.listForOrg({ org: 'octokit', type: 'public' })
 ```
 
 **④ endpoint options** will be

--- a/docs/src/pages/api/00_usage.md
+++ b/docs/src/pages/api/00_usage.md
@@ -195,7 +195,7 @@ const octokit = require("@octokit/rest");
 
 // Compare: https://developer.github.com/v3/repos/#list-organization-repositories
 octokit.repos
-  .getForOrg({
+  .listForOrg({
     org: "octokit",
     type: "public"
   })


### PR DESCRIPTION
<!-- 
1. Push your changes to your topic branch on your fork of the repo.
2. Submit a pull request from your topic branch to the master branch on the `rest.js` repository.
3. Be sure to tag any issues your pull request is taking care of / contributing to.
4. Adding "Closes #123" to a pull request description will auto close the issue once the pull request is merged in. 
-->

I found a little typos of method name in documentation.

-----
[View rendered HOW_IT_WORKS.md](https://github.com/zaki-yama/rest.js/blob/fix-docs-typo/HOW_IT_WORKS.md)
[View rendered docs/src/pages/api/00_usage.md](https://github.com/zaki-yama/rest.js/blob/fix-docs-typo/docs/src/pages/api/00_usage.md)