### PR TITLE
ci: widen branch pattern to cover scoped packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
       - master
       - next
       - beta
-      - "greenkeeper/*"
+      - "greenkeeper/**"
       - 15.x
       - 16.x # TODO: can we use a pattern for these?
 


### PR DESCRIPTION
Packages that are scoped - maybe with an organization name - will not match the current pattern and the workflow will not be triggered.