### PR TITLE
deprecate `const Octokit = require("@octokit/rest")` in favor of `const { Octokit } = require("@octokit/rest")`

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,4 +16,17 @@ const CORE_PLUGINS = [
   require("octokit-pagination-methods") // deprecated: remove in v17
 ];
 
-module.exports = Octokit.plugin(CORE_PLUGINS);
+const OctokitRest = Octokit.plugin(CORE_PLUGINS);
+
+function DeprecatedOctokit(options) {
+  const warn =
+    options.log && options.log.warn ? options.log.warn : console.warn;
+  warn(
+    '[@octokit/rest] `const Octokit = require("@octokit/rest")` is deprecated. Use `const { Octokit } = require("@octokit/rest")` instead'
+  );
+  return new OctokitRest(options);
+}
+
+module.exports = Object.assign(DeprecatedOctokit, {
+  Octokit: OctokitRest
+});

--- a/test/integration/agent-ca/agent-ca-test.js
+++ b/test/integration/agent-ca/agent-ca-test.js
@@ -2,7 +2,7 @@ const https = require("https");
 const { readFileSync } = require("fs");
 const { resolve } = require("path");
 
-const Octokit = require("../../..");
+const { Octokit } = require("../../..");
 const ca = readFileSync(resolve(__dirname, "./ca.crt"));
 
 require("../../mocha-node-setup");

--- a/test/integration/apps-test.js
+++ b/test/integration/apps-test.js
@@ -1,6 +1,6 @@
 const nock = require("nock");
 
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 const BEARER_TOKEN =
   "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1NTM4MTkzMTIsImV4cCI6MTU1MzgxOTM3MiwiaXNzIjoxfQ.etiSZ4LFQZ8tiMGJVqKDoGn8hxMCgwL4iLvU5xBUqbAPr4pbk_jJZmMQjuxTlOnRxq4e7NouTizGCdfohRMb3R1mpLzGPzOH9_jqSA_BWYxolsRP_WDSjuNcw6nSxrPRueMVRBKFHrqcTOZJej0djRB5pI61hDZJ_-DGtiOIFexlK3iuVKaqBkvJS5-TbTekGuipJ652g06gXuz-l8i0nHiFJldcuIruwn28hTUrjgtPbjHdSBVn_QQLKc2Fhij8OrhcGqp_D_fvb_KovVmf1X6yWiwXV5VXqWARS-JGD9JTAr2495ZlLV_E4WPxdDpz1jl6XS9HUhMuwBpaCOuipw";
 

--- a/test/integration/authentication-test.js
+++ b/test/integration/authentication-test.js
@@ -2,7 +2,7 @@ const lolex = require("lolex");
 const nock = require("nock");
 const { createActionAuth, createAppAuth } = require("@octokit/auth");
 
-const Octokit = require("../..");
+const { Octokit } = require("../..");
 
 require("../mocha-node-setup");
 

--- a/test/integration/conditional-request-test.js
+++ b/test/integration/conditional-request-test.js
@@ -1,6 +1,6 @@
 const nock = require("nock");
 
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 require("../mocha-node-setup");
 

--- a/test/integration/deprecations-test.js
+++ b/test/integration/deprecations-test.js
@@ -1,7 +1,8 @@
 const btoa = require("btoa-lite");
 const nock = require("nock");
 
-const Octokit = require("../../");
+const DeprecatedOctokit = require("../../");
+const { Octokit } = DeprecatedOctokit;
 
 require("../mocha-node-setup");
 
@@ -10,6 +11,18 @@ const Mocktokit = Octokit.plugin(octokit => {
 });
 
 describe("deprecations", () => {
+  it('const Octokit = require("@octokit/rest")', () => {
+    let warnCalledCount = 0;
+    const octokit = new DeprecatedOctokit({
+      log: {
+        warn: deprecation => {
+          warnCalledCount++;
+        }
+      }
+    });
+
+    expect(warnCalledCount).to.equal(1);
+  });
   it("octokit.search.issues() has been renamed to octokit.search.issuesAndPullRequests() (2018-12-27)", () => {
     let warnCalledCount = 0;
     const octokit = new Mocktokit({

--- a/test/integration/pagination-test.js
+++ b/test/integration/pagination-test.js
@@ -1,6 +1,6 @@
 const nock = require("nock");
 
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 require("../mocha-node-setup");
 

--- a/test/integration/params-validations-test.js
+++ b/test/integration/params-validations-test.js
@@ -1,6 +1,6 @@
 const nock = require("nock");
 
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 require("../mocha-node-setup");
 

--- a/test/integration/plugins-test.js
+++ b/test/integration/plugins-test.js
@@ -1,4 +1,4 @@
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 require("../mocha-node-setup");
 

--- a/test/integration/register-endpoints-test.js
+++ b/test/integration/register-endpoints-test.js
@@ -1,6 +1,6 @@
 const nock = require("nock");
 
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 require("../mocha-node-setup");
 

--- a/test/integration/request-errors-test.js
+++ b/test/integration/request-errors-test.js
@@ -1,6 +1,6 @@
 const nock = require("nock");
 
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 require("../mocha-node-setup");
 

--- a/test/integration/smoke-test.js
+++ b/test/integration/smoke-test.js
@@ -1,7 +1,7 @@
 const nock = require("nock");
 const { getUserAgent } = require("universal-user-agent");
 
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 require("../mocha-node-setup");
 

--- a/test/issues/1134-missing-endpoint-scopes-test.js
+++ b/test/issues/1134-missing-endpoint-scopes-test.js
@@ -1,4 +1,4 @@
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 require("../mocha-node-setup");
 

--- a/test/issues/1279-store-otp-send-header-all-requests-test.js
+++ b/test/issues/1279-store-otp-send-header-all-requests-test.js
@@ -1,5 +1,5 @@
 const nock = require("nock");
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 require("../mocha-node-setup");
 

--- a/test/issues/1323-parameter-deprecation-bug-test.js
+++ b/test/issues/1323-parameter-deprecation-bug-test.js
@@ -1,5 +1,5 @@
 const nock = require("nock");
-const Octokit = require("../..");
+const { Octokit } = require("../..");
 
 require("../mocha-node-setup");
 

--- a/test/issues/1497-include-error-message-on-validation-error-test.js
+++ b/test/issues/1497-include-error-message-on-validation-error-test.js
@@ -1,5 +1,5 @@
 const nock = require("nock");
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 require("../mocha-node-setup");
 

--- a/test/issues/1553-deprecated-teams-methods-test.js
+++ b/test/issues/1553-deprecated-teams-methods-test.js
@@ -1,5 +1,5 @@
 const nock = require("nock");
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 require("../mocha-node-setup");
 

--- a/test/issues/765-remove-milestone-from-issue-test.js
+++ b/test/issues/765-remove-milestone-from-issue-test.js
@@ -1,5 +1,5 @@
 const nock = require("nock");
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 require("../mocha-node-setup");
 

--- a/test/issues/818-get-installations-test.js
+++ b/test/issues/818-get-installations-test.js
@@ -1,5 +1,5 @@
 const nock = require("nock");
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 require("../mocha-node-setup");
 

--- a/test/issues/826-fail-on-304-test.js
+++ b/test/issues/826-fail-on-304-test.js
@@ -1,5 +1,5 @@
 const nock = require("nock");
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 require("../mocha-node-setup");
 

--- a/test/issues/841-head-request-test.js
+++ b/test/issues/841-head-request-test.js
@@ -1,5 +1,5 @@
 const nock = require("nock");
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 require("../mocha-node-setup");
 

--- a/test/issues/861-custom-accept-header-test.js
+++ b/test/issues/861-custom-accept-header-test.js
@@ -1,5 +1,5 @@
 const nock = require("nock");
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 require("../mocha-node-setup");
 

--- a/test/issues/881-redirect-url-test.js
+++ b/test/issues/881-redirect-url-test.js
@@ -1,5 +1,5 @@
 const nock = require("nock");
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 require("../mocha-node-setup");
 

--- a/test/issues/922-create-check-with-empty-actions-array-test.js
+++ b/test/issues/922-create-check-with-empty-actions-array-test.js
@@ -1,5 +1,5 @@
 const nock = require("nock");
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 require("../mocha-node-setup");
 

--- a/test/memory-test.js
+++ b/test/memory-test.js
@@ -2,7 +2,7 @@
 // as installing leakage broke for recent Node versions.
 // We are looking for an alternative.
 const { iterate } = require("leakage");
-const Octokit = require("../");
+const { Octokit } = require("../");
 
 const TestOctokit = Octokit.plugin(octokit => {
   // skip sending requests altogether

--- a/test/unit/upload-asset-test.js
+++ b/test/unit/upload-asset-test.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const chai = require("chai");
 const nock = require("nock");
 
-const Octokit = require("../../");
+const { Octokit } = require("../../");
 
 chai.should();
 

--- a/test/util.js
+++ b/test/util.js
@@ -4,7 +4,7 @@ module.exports = {
   getInstance
 };
 
-const Octokit = require("../");
+const { Octokit } = require("../");
 const { request } = require("@octokit/request");
 
 function loadFixture(scenario) {


### PR DESCRIPTION
part of #1546