### PR TITLE
docs: clarify pagination

### DIFF
--- a/docs/src/pages/api/05_pagination.md
+++ b/docs/src/pages/api/05_pagination.md
@@ -13,11 +13,14 @@ octokit
     repo: "rest.js"
   })
   .then(issues => {
-    // issues is an array of all issue objects
+    // issues is an array of all issue objects. It is not wrapped in a { data, headers, status, url } object
+    // like results from `octokit.request()` or any of the endpoint methods such as `octokit.issues.listForRepo()`
   });
 ```
 
 `octokit.paginate()` accepts the same options as [`octokit.request()`](#custom-requests). You can optionally pass an additional function to map the results from each response. The map must return a new value, usually an array with mapped data.
+
+**Note:** the map function is called with the `{ data, headers, status, url }` response object. The `data` property is guaranteed to be an array of the result items, even for list endpoints that respond with an object instead of an array, such as the [search endpoints](https://developer.github.com/v3/search/#example).
 
 ```js
 octokit


### PR DESCRIPTION
fixes #1386

@mrchief could you have a look if the additions make the sublet differences yuo mentioned in #1386 more clear?

-----
[View rendered docs/src/pages/api/05_pagination.md](https://github.com/octokit/rest.js/blob/clarify-pagination/docs/src/pages/api/05_pagination.md)