### PR TITLE
Fix various documentation nits

### DIFF
--- a/docs/src/pages/api/00_usage.md
+++ b/docs/src/pages/api/00_usage.md
@@ -119,9 +119,9 @@ const { data: pullRequest } = await octokit.pulls.get({
 });
 ```
 
-Some API endpoints support alternative response formats, see [Media types](https://developer.github.com/v3/media/). For example, to [`request the above pull request in a diff format`](https://developer.github.com/v3/media/#diff), pass the `mediaType.format` option.
+Some API endpoints support alternative response formats, see [Media types](https://developer.github.com/v3/media/). For example, to [request the above pull request in a diff format](https://developer.github.com/v3/media/#diff), pass the `mediaType.format` option.
 
-Learn more about [request formats](#request-formats)
+Learn more about [request formats](#request-formats).
 
 ```js
 const { data: diff } = await octokit.pulls.get({
@@ -187,7 +187,7 @@ const MyOctokit = Octokit.plugin([
 ])
 ```
 
-`Octokit.plugin()` returns a new constructor. The same options can be passed to the constructor. The options are passed on to all plugin functions as the 2nd argument
+`Octokit.plugin()` returns a new constructor. The same options can be passed to the constructor. The options are passed on to all plugin functions as the 2nd argument.
 
 ```js
 const myOctokit = new MyOctokit({

--- a/index.d.ts
+++ b/index.d.ts
@@ -34756,7 +34756,7 @@ export class Octokit {
       endpoint: Octokit.Endpoint;
     };
     /**
-     * Returns only active subscriptions. You must use a [user-to-server OAuth access token](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint. . OAuth Apps must authenticate using an [OAuth token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/).
+     * Returns only active subscriptions. You must use a [user-to-server OAuth access token](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint. OAuth Apps must authenticate using an [OAuth token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/).
      */
     listMarketplacePurchasesForAuthenticatedUser: {
       (
@@ -34771,7 +34771,7 @@ export class Octokit {
       endpoint: Octokit.Endpoint;
     };
     /**
-     * Returns only active subscriptions. You must use a [user-to-server OAuth access token](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint. . OAuth Apps must authenticate using an [OAuth token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/).
+     * Returns only active subscriptions. You must use a [user-to-server OAuth access token](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint. OAuth Apps must authenticate using an [OAuth token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/).
      */
     listMarketplacePurchasesForAuthenticatedUserStubbed: {
       (


### PR DESCRIPTION
* ~Fix missing whitespace, eaten by React~

  Edit: This fix was lost in a rebase; perhaps fixed on master.

  Fixes:
  <img width="562" alt="Screen Shot 2020-02-17 at 11 20 24 AM" src="https://user-images.githubusercontent.com/103167/74681168-8f93af00-5177-11ea-8d2f-f23bd3ef9930.png">
  (This `{" "}` trick is used elsewhere in `endpoint.js`.)

* Remove unwarranted code formatting on text; add period. Fixes:
  <img width="519" alt="Screen Shot 2020-02-17 at 11 19 16 AM" src="https://user-images.githubusercontent.com/103167/74681102-62df9780-5177-11ea-89fe-18715e461c48.png">
* Remove duplicate periods. Fixes:
  <img width="542" alt="Screen Shot 2020-02-17 at 11 22 16 AM" src="https://user-images.githubusercontent.com/103167/74681264-c964b580-5177-11ea-9543-a24829f4dd25.png">


-----
[View rendered docs/src/pages/api/00_usage.md](https://github.com/srawlins/rest.js/blob/documentation-nits/docs/src/pages/api/00_usage.md)