### PR TITLE
fix: Pass type parameters to the Core.plugin method to work around dpoint methods not being defined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,19 +2,12 @@ import { Octokit as Core } from "@octokit/core";
 import { requestLog } from "@octokit/plugin-request-log";
 import { paginateRest } from "@octokit/plugin-paginate-rest";
 import { restEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
+import { OctokitPlugin } from "@octokit/core/dist-types/types"
 
 import { VERSION } from "./version";
 
 export const Octokit = Core
-  // TODO: this really should be
-  //
-  //     .plugin([requestLog, paginateRest, restEndpointMethods])
-  //
-  // but for mystical reasons, using the line above does set the resulting the
-  // `octokit` instance type correctly. Neither `octokit.paginate()` nor all the
-  // endpoint methods such as `octokit.repos.get() are set
-  .plugin(requestLog)
-  .plugin([paginateRest, restEndpointMethods])
+  .plugin<typeof Octokit, OctokitPlugin[]>([requestLog, paginateRest, restEndpointMethods])
   .defaults({
     userAgent: `octokit-rest.js/${VERSION}`
   });


### PR DESCRIPTION
Without the types, it would pick an arbitrary plugin from the Array and assume the whole array was of that type instead of the more generic and appropriate type which is an Array of OctokitPlugin's
