### PR TITLE
docs(usage): Fix example plugin imports

### DIFF
--- a/docs/src/pages/api/00_usage.md
+++ b/docs/src/pages/api/00_usage.md
@@ -178,8 +178,8 @@ You can add more functionality with plugins. We recommend the retry and throttli
 Learn more about [throttling](#throttling), [automatic retries](#automatic-retries) and building your own [Plugins](#plugins).
 
 ```js
-import plugin as retry from '@octokit/plugin-retry'
-import plugin as throttling from '@octokit/plugin-throttling'
+import {retry} from '@octokit/plugin-retry'
+import {throttling} from '@octokit/plugin-throttling'
 
 const MyOctokit = Octokit.plugin([
   retry,

--- a/docs/src/pages/api/00_usage.md
+++ b/docs/src/pages/api/00_usage.md
@@ -178,8 +178,8 @@ You can add more functionality with plugins. We recommend the retry and throttli
 Learn more about [throttling](#throttling), [automatic retries](#automatic-retries) and building your own [Plugins](#plugins).
 
 ```js
-import {retry} from '@octokit/plugin-retry'
-import {throttling} from '@octokit/plugin-throttling'
+import { retry } from '@octokit/plugin-retry'
+import { throttling } from '@octokit/plugin-throttling'
 
 const MyOctokit = Octokit.plugin([
   retry,


### PR DESCRIPTION
The syntax is wrong and outdated. The plugins used in the example have named exports.


<!-- 
1. Push your changes to your topic branch on your fork of the repo.
2. Submit a pull request from your topic branch to the master branch on the `rest.js` repository.
3. Be sure to tag any issues your pull request is taking care of / contributing to.
4. Adding "Closes #123" to a pull request description will auto close the issue once the pull request is merged in. 
-->


-----
[View rendered docs/src/pages/api/00_usage.md](https://github.com/billyvg/rest.js/blob/patch-1/docs/src/pages/api/00_usage.md)