### PR TITLE
fix: load all plugins while preserving type information provided to Octokit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,11 @@ import { restEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
 import { VERSION } from "./version";
 
 export const Octokit = Core.plugin([
+  // Workaround to prevent TypeScript from widening the inferred return type of
+  // plugins passed to Octokit, which would result in type information (e.g.
+  // methods provided by plugins) not being added to Octokit instances.
+  //
+  // See https://github.com/octokit/core.js/issues/51#issuecomment-596846088
   (requestLog as unknown) as () => void,
   restEndpointMethods,
   paginateRest

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,16 +5,10 @@ import { restEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
 
 import { VERSION } from "./version";
 
-export const Octokit = Core
-  // TODO: this really should be
-  //
-  //     .plugin([requestLog, paginateRest, restEndpointMethods])
-  //
-  // but for mystical reasons, using the line above does set the resulting the
-  // `octokit` instance type correctly. Neither `octokit.paginate()` nor all the
-  // endpoint methods such as `octokit.repos.get() are set
-  .plugin(requestLog)
-  .plugin([paginateRest, restEndpointMethods])
-  .defaults({
-    userAgent: `octokit-rest.js/${VERSION}`
-  });
+export const Octokit = Core.plugin([
+  (requestLog as unknown) as () => void,
+  restEndpointMethods,
+  paginateRest
+]).defaults({
+  userAgent: `octokit-rest.js/${VERSION}`
+});


### PR DESCRIPTION
If you're still looking for a *one-liner* solution to load all plugins while preserving the type information provided by other plugins.

Okay, it's not one line after running `lint:fix`, but we do make one `.plugin()` call.

See the related issue and conversation at octokit/core.js#51.

**How does this work?**

Assuming you're familiar with the issue linked above: we're casting the `requestLog` as `() => void`. We still return `void`, but we have removed the parameters that Octokit/core's `.plugin()` method is expecting. This workaround means that TypeScript isn't able to [widen](https://github.com/octokit/core.js/issues/51#issuecomment-596846088) the return values from the plugins in the array - and therefore maintains type information within Octokit using one `.plugin()` call.

![octokit-plugins-one-liner](https://user-images.githubusercontent.com/10104630/76271923-33342480-6237-11ea-8d6a-2323a3554c03.gif)

_________

Supersedes and closes #1625 .
