### PR TITLE
docs: add required 'new' keyword to usage

### DIFF
--- a/docs/src/pages/api/00_usage.md
+++ b/docs/src/pages/api/00_usage.md
@@ -40,7 +40,7 @@ const { Octokit } = require("@octokit/rest");
 Now instantiate your octokit API. All options are optional, but authentication is strongly encouraged.
 
 ```js
-const octokit = Octokit({
+const octokit = new Octokit({
 ```
 
 You can set `auth` to a personal access token string.


### PR DESCRIPTION
Resolves https://github.com/octokit/rest.js/issues/1640

-----
[View rendered docs/src/pages/api/00_usage.md](https://github.com/octokit/rest.js/blob/document-new-keyword/docs/src/pages/api/00_usage.md)