### PR TITLE
Docs: Close nav menu when link is clicked on mobile

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gatsby-starter-hello-world",
-  "description": "Gatsby hello world starter",
+  "name": "octokit-rest.js-docs",
+  "description": "Documentation site for octokit/rest.js",
   "license": "MIT",
   "scripts": {
     "develop": "gatsby develop",

--- a/docs/src/components/api.js
+++ b/docs/src/components/api.js
@@ -61,7 +61,7 @@ export default class Api extends Component {
             {this.props.data.staticMethods.edges.map(({ node }) => {
               return (
                 <li key={node.id}>
-                  <a href={`#${node.fields.idName}`}>
+                  <a href={`#${node.fields.idName}`} onClick={this.props.onToggleMenu}>
                     {node.frontmatter.title}
                   </a>
                 </li>

--- a/docs/src/components/index-page.js
+++ b/docs/src/components/index-page.js
@@ -91,7 +91,7 @@ export default class IndexPage extends Component {
         </header>
 
         <div className={layoutStyles.container}>
-          <Api data={this.props.data} isMenuActive={this.isMenuActive}></Api>
+          <Api data={this.props.data} isMenuActive={this.isMenuActive} onToggleMenu={this.onToggleMenu}></Api>
         </div>
       </div>
     );


### PR DESCRIPTION
<!-- 
1. Push your changes to your topic branch on your fork of the repo.
2. Submit a pull request from your topic branch to the master branch on the `rest.js` repository.
3. Be sure to tag any issues your pull request is taking care of / contributing to.
4. Adding "Closes #123" to a pull request description will auto close the issue once the pull request is merged in. 
-->

This adds a small change to the dropdown nav on the docs site to close the nav when a nav entry is clicked. Previously clicking a nav entry would take you to that anchor/location on the page, but the nav dropdown would still be shown so you would have to click the hamburger button to retract the nav menu.

This also updates the name and description in the `package.json` to not be the default Gatsby starter messages, but I can remove those changes if they're a little too unrelated to the main point of this PR.

### Screenshots/Demo
![2020-04-06 14 15 31](https://user-images.githubusercontent.com/2539016/78605850-23493980-7811-11ea-81c4-49dc74a059a9.gif)
