### PR TITLE
Docs: Fix whitespace on mobile sizing due to wide content

### DIFF
--- a/docs/src/components/layout.css
+++ b/docs/src/components/layout.css
@@ -131,6 +131,17 @@ header > button:focus {
   color: #1ca086;
 }
 
+/* Set table-layout: fixed for small screens where table contents can break out of their container */
+table {
+  table-layout: fixed;
+}
+
+@media (min-width: 55em) {
+  table {
+    table-layout: auto;
+  }
+}
+
 /* Hide the navigation toggle button on big screens, since it’s not needed */
 @media (min-width: 55em) {
   /* --wide-enough-for-two-columns */
@@ -157,4 +168,6 @@ main :not(pre) > code[class*="language-"] {
   background: #1b1f230d;
   text-shadow: none;
   font-size: 85%;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }

--- a/docs/src/pages/api/00_usage.md
+++ b/docs/src/pages/api/00_usage.md
@@ -4,24 +4,23 @@ title: "Usage"
 
 Import the Octokit constructor based on your platform.
 
-<table>
-<tbody valign=top align=left>
-<tr><th>
-Browsers
-</th><td width=100%>
+### Browsers
+
+<div>
 Load <code>@octokit/rest</code> directly from <a href="https://cdn.pika.dev">cdn.pika.dev</a>
-        
+
 ```html
 <script type="module">
-import { Octokit } from "https://cdn.pika.dev/@octokit/rest";
+  import { Octokit } from "https://cdn.pika.dev/@octokit/rest";
 </script>
 ```
 
-</td></tr>
-<tr><th>
-Node
-</th><td>
+</div>
+<hr />
 
+### Node
+
+<div>
 Install with <code>npm install @octokit/rest</code>
 
 ```js
@@ -29,9 +28,8 @@ const { Octokit } = require("@octokit/rest");
 // or: import { Octokit } from "@octokit/rest";
 ```
 
-</td></tr>
-</tbody>
-</table>
+</div>
+<hr />
 
 ```js
 const { Octokit } = require("@octokit/rest");

--- a/docs/src/pages/api/07_custom_endpoints.md
+++ b/docs/src/pages/api/07_custom_endpoints.md
@@ -79,4 +79,4 @@ octokit.foo.bar({
 });
 ```
 
-This is useful when you participate in private beta features and prefer the convenience of methods for the new endpoints instead of using [`octokit.request()`]('#custom-requests').
+This is useful when you participate in private beta features and prefer the convenience of methods for the new endpoints instead of using [`octokit.request()`](#custom-requests).


### PR DESCRIPTION
### Description

This adds a `table-layout: fixed` rule for tables on smaller
screen sizes so that the contents don't overflow the container
element, and adds an `overflow-wrap` rule for long URLs in
code elements.

This also changes the table style in 00_usage.md to use `h3` tags
and `div`s to style the usage snippets so that they don't expand
past the parent container. When using a table with `table-layout: fixed`,
the table header text would be squashed due to the width of the code
snippet part of the table row. If that's too much of a layout change from before I can try out some css grid or flexbox stuff to keep the table look and feel on large screens but then collapse that on smaller screens.

Also there was a small markdown issue where the browser snippet wasn't rendering, this fixes that too.

### Screenshots

Usage Before
![image](https://user-images.githubusercontent.com/2539016/79669242-0bf24080-816f-11ea-89f2-e93248c284be.png)


Usage After
![image](https://user-images.githubusercontent.com/2539016/79669244-0f85c780-816f-11ea-9b72-2f4edbb94ef3.png)


Table Before
![image](https://user-images.githubusercontent.com/2539016/79669248-144a7b80-816f-11ea-9984-c330406ae0de.png)


Table After
![image](https://user-images.githubusercontent.com/2539016/79669249-17de0280-816f-11ea-98a7-af0c25c4b2d8.png)


Long URL Before
![image](https://user-images.githubusercontent.com/2539016/79669252-1d3b4d00-816f-11ea-9468-962c15d994ed.png)


Long URL After
![image](https://user-images.githubusercontent.com/2539016/79669256-21676a80-816f-11ea-9aea-1d0c95a81695.png)

### Test Site
https://loving-ride-404dcc.netlify.app/v17

-----
[View rendered docs/src/pages/api/00_usage.md](https://github.com/copperwall/rest.js/blob/fix-whitespace-on-docs/docs/src/pages/api/00_usage.md)