### PR TITLE
feat(typescript): `import { RestEndpointMethodTypes } from "@octokit/rest";`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,4 @@ jobs:
       - run: npm run start-fixtures-server &
       - run: sleep 3 # give server some time to start
       - run: npm run test
+      - run: npm run test:typescript

--- a/docs/src/pages/api/00_usage.md
+++ b/docs/src/pages/api/00_usage.md
@@ -210,17 +210,3 @@ const myOctokit = new MyOctokit({
   },
 });
 ```
-
-```js
-const octokit = require("@octokit/rest");
-
-// Compare: https://developer.github.com/v3/repos/#list-organization-repositories
-octokit.repos
-  .listForOrg({
-    org: "octokit",
-    type: "public",
-  })
-  .then(({ data, headers, status }) => {
-    // handle data
-  });
-```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1575,12 +1575,22 @@
       "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw=="
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.6.0.tgz",
-      "integrity": "sha512-dCrx/4R2SE32CBOVZF7gvBwhsZrtlZh4XLLXUO2USs3Qjd4zj4QoDa8ix9pXhzIs1Z/d8Ll7s+c1C6XozxFjWw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.7.0.tgz",
+      "integrity": "sha512-oFNENhdGEkNRX1UyJ0fmgWAkyw7H61M7LpwjnJYlI9xQMnTf5cEfksf75lmuatkGOoDwBabzWvm7TgHa0zTgFg==",
       "requires": {
-        "@octokit/types": "^2.0.1",
+        "@octokit/types": "^2.11.1",
         "deprecation": "^2.3.1"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "2.11.1",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.11.1.tgz",
+          "integrity": "sha512-QaLoLkmFdfoNbk3eOzPv7vKrUY0nRJIYmZDoz/pTer4ICpqu80aSQTVHnnUxEFuURCiidig76CcxUOYC/bY3RQ==",
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        }
       }
     },
     "@octokit/request": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "lint:fix": "prettier --write '{src,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' README.md package.json",
     "start-fixtures-server": "octokit-fixtures-server",
     "pretestx": "npm run -s lint",
-    "test": "jest --coverage"
+    "test": "jest --coverage",
+    "test:typescript": "npx tsc --noEmit --declaration --noUnusedLocals test/typescript-validate.ts"
   },
   "license": "MIT",
   "@pika/pack": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@octokit/core": "^2.4.3",
     "@octokit/plugin-paginate-rest": "^2.1.0",
     "@octokit/plugin-request-log": "^1.0.0",
-    "@octokit/plugin-rest-endpoint-methods": "3.6.0"
+    "@octokit/plugin-rest-endpoint-methods": "3.7.0"
   },
   "devDependencies": {
     "@octokit/auth": "^2.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Octokit as Core } from "@octokit/core";
 import { requestLog } from "@octokit/plugin-request-log";
 import { paginateRest } from "@octokit/plugin-paginate-rest";
 import { restEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
+export { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
 
 import { VERSION } from "./version";
 
@@ -10,7 +11,7 @@ export const Octokit = Core.plugin(
   restEndpointMethods,
   paginateRest
 ).defaults({
-  userAgent: `octokit-rest.js/${VERSION}`
+  userAgent: `octokit-rest.js/${VERSION}`,
 });
 
 export type Octokit = InstanceType<typeof Octokit>;

--- a/test/scenarios/mark-notifications-as-read.test.ts
+++ b/test/scenarios/mark-notifications-as-read.test.ts
@@ -5,13 +5,13 @@ describe("api.github.com", () => {
 
   beforeEach(() => {
     return getInstance("mark-notifications-as-read", {
-      auth: "token 0000000000000000000000000000000000000001"
-    }).then(instance => {
+      auth: "token 0000000000000000000000000000000000000001",
+    }).then((instance) => {
       octokit = instance;
     });
   });
 
-  it("octokit.activity.markAsRead()", () => {
-    return octokit.activity.markAsRead();
+  it("octokit.activity.markNotificationsAsRead()", () => {
+    return octokit.activity.markNotificationsAsRead();
   });
 });

--- a/test/scenarios/paginate-issues.test.ts
+++ b/test/scenarios/paginate-issues.test.ts
@@ -4,7 +4,7 @@ type IteratorResult = {
   value: {
     data: any[];
   };
-  done: boolean;
+  done?: boolean;
 };
 
 describe("api.github.com", () => {
@@ -12,8 +12,8 @@ describe("api.github.com", () => {
 
   beforeEach(() => {
     return getInstance("paginate-issues", {
-      auth: "token 0000000000000000000000000000000000000001"
-    }).then(instance => {
+      auth: "token 0000000000000000000000000000000000000001",
+    }).then((instance) => {
       octokit = instance;
     });
   });
@@ -24,8 +24,8 @@ describe("api.github.com", () => {
       repo: "paginate-issues",
       per_page: 3,
       headers: {
-        accept: "application/vnd.github.v3+json"
-      }
+        accept: "application/vnd.github.v3+json",
+      },
     };
 
     const iterator = octokit.paginate

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -212,7 +212,7 @@ export default async function () {
       installationId: 12345,
     },
   });
-  
+
   const { data } = await updateLabel({
     owner: "octocat",
     repo: "hello-world",
@@ -220,13 +220,13 @@ export default async function () {
     color: "cc0000",
   });
 
-  console.log(data.color)
-  
+  console.log(data.color);
+
   async function updateLabel(
     options: RestEndpointMethodTypes["issues"]["updateLabel"]["parameters"]
   ): Promise<RestEndpointMethodTypes["issues"]["updateLabel"]["response"]> {
-    console.log(options)
-    
+    console.log(options);
+
     return {
       headers: {},
       data: {
@@ -242,6 +242,4 @@ export default async function () {
       url: "",
     };
   }
-  });
 }
-

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -1,13 +1,11 @@
-import { Octokit } from "../index";
+import { Octokit } from "../src";
 import { Agent } from "http";
-import { request } from "https";
-const http = require("http");
 
 // ************************************************************
 // THIS CODE IS NOT EXECUTED. IT IS JUST FOR TYPECHECKING
 // ************************************************************
 
-export default async function() {
+export default async function () {
   // Check empty constructor
   new Octokit();
 
@@ -16,19 +14,19 @@ export default async function() {
     timeout: 0,
     headers: {
       accept: "application/vnd.github.v3+json",
-      "user-agent": "octokit/rest.js v1.2.3"
+      "user-agent": "octokit/rest.js v1.2.3",
     },
     baseUrl: "https://api.github.com",
     agent: new Agent({ keepAlive: true }),
     custom: {
-      foo: "bar"
-    }
+      foo: "bar",
+    },
   });
 
   // check responses
   const repoResponse = await octokit.repos.get({
     owner: "octokit",
-    repo: "rest.js"
+    repo: "rest.js",
   });
   repoResponse.data;
   repoResponse.status;
@@ -37,13 +35,13 @@ export default async function() {
   repoResponse.headers.status;
 
   const userResponse = await octokit.users.getByUsername({
-    username: "octokit"
+    username: "octokit",
   });
   userResponse.data.login;
   userResponse.data.type;
 
   const userIssuesResponse = await octokit.issues.listForAuthenticatedUser({
-    state: "open"
+    state: "open",
   });
   userIssuesResponse.data[0].locked;
 
@@ -51,8 +49,8 @@ export default async function() {
   await octokit.issues.addLabels({
     owner: "octokit",
     repo: "rest.js",
-    number: 10,
-    labels: ["label"]
+    issue_number: 10,
+    labels: ["label"],
   });
 
   const requestOptions = octokit.issues.addLabels.endpoint({
@@ -61,32 +59,32 @@ export default async function() {
     number: 10,
     labels: ["label"],
     request: {
-      foo: "bar"
-    }
+      foo: "bar",
+    },
   });
   requestOptions.method;
   requestOptions.url;
   requestOptions.headers;
   requestOptions.body;
   requestOptions.request.foo;
-  const endpointOptions = octokit.issues.addLabels.endpoint.merge({
-    foo: "bar"
+  octokit.issues.addLabels.endpoint.merge({
+    foo: "bar",
   });
 
   // parameter deprecation
   await octokit.issues.get({
     owner: "octokit",
     repo: "rest.js",
-    number: 10 // deprecated, renamed to "issue_number", see below
+    issue_number: 10, // deprecated, renamed to "issue_number", see below
   });
   await octokit.issues.get({
     owner: "octokit",
     repo: "rest.js",
-    issue_number: 10
+    issue_number: 10,
   });
 
   // hooks
-  octokit.hook.before("request", async options => {
+  octokit.hook.before("request", async (options) => {
     console.log("before hook", options.url);
   });
   octokit.hook.after("request", async (response, options) => {
@@ -110,32 +108,26 @@ export default async function() {
   octokit.request("/");
   octokit.request("GET /repos/:owner/:repo/issues", {
     owner: "octokit",
-    repo: "rest.js"
+    repo: "rest.js",
   });
   octokit.request({
     method: "GET",
     url: "/repos/:owner/:repo/issues",
     owner: "octokit",
-    repo: "rest.js"
+    repo: "rest.js",
   });
   octokit.request.endpoint("/");
   octokit.request.endpoint("GET /repos/:owner/:repo/issues", {
     owner: "octokit",
-    repo: "rest.js"
+    repo: "rest.js",
   });
   octokit.request.endpoint({
     method: "GET",
     url: "/repos/:owner/:repo/issues",
     owner: "octokit",
-    repo: "rest.js"
+    repo: "rest.js",
   });
   octokit.request.endpoint.merge({ foo: "bar" });
-  octokit.request.endpoint.parse({
-    method: "GET",
-    url: "/repos/:owner/:repo/issues",
-    owner: "octokit",
-    repo: "rest.js"
-  });
   octokit.request.endpoint
     .defaults({ owner: "octokit", repo: "rest.js" })
     .merge({ method: "GET", url: "/repos/:owner/:repo/issues" });
@@ -144,28 +136,31 @@ export default async function() {
   octokit
     .paginate("GET /repos/:owner/:repo/issues", {
       owner: "octokit",
-      repo: "rest.js"
+      repo: "rest.js",
     })
-    .then(issues => {
+    .then((issues) => {
       // issues is an array of all issue objects
     });
 
   octokit
-    .paginate(
+    .paginate<{ title: string }, string[]>(
       "GET /repos/:owner/:repo/issues",
       { owner: "octokit", repo: "rest.js" },
-      response => response.data.map(issue => issue.title)
+      (response) => response.data.map((issue) => issue.title)
     )
-    .then(issueTitles => {
+    .then((issueTitles) => {
       // issueTitles is now an array with the titles only
     });
 
   const options = octokit.issues.listForRepo.endpoint.merge({
     owner: "octokit",
-    repo: "rest.js"
+    repo: "rest.js",
   });
-  for await (const response of octokit.paginate.iterator(options)) {
+  for await (const response of octokit.paginate.iterator<{ id: number }>(
+    options
+  )) {
     // do whatever you want with each response, break out of the loop, etc.
+    console.log(response.data.map((repo) => repo.id));
   }
 
   // register endpoints
@@ -174,9 +169,9 @@ export default async function() {
       method: "DELETE",
       url: "/funk",
       request: {
-        foo: "bar"
-      }
-    }
+        foo: "bar",
+      },
+    },
   });
 
   // Plugins
@@ -185,8 +180,9 @@ export default async function() {
       const time = Date.now();
       const response = await request(options);
       console.log(
-        `${options.method} ${options.url} – ${response.status} in ${Date.now() -
-          time}ms`
+        `${options.method} ${options.url} – ${response.status} in ${
+          Date.now() - time
+        }ms`
       );
       return response;
     });
@@ -202,8 +198,8 @@ export default async function() {
     repo: "repo",
     pull_number: 123,
     mediaType: {
-      format: "diff"
-    }
+      format: "diff",
+    },
   });
 
   // Auth strategies
@@ -213,7 +209,7 @@ export default async function() {
     auth: {
       id: 123,
       privateKey: "private key here",
-      installationId: 12345
-    }
+      installationId: 12345,
+    },
   });
 }

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -1,4 +1,4 @@
-import { Octokit } from "../src";
+import { Octokit, RestEndpointMethodTypes } from "../src";
 import { Agent } from "http";
 
 // ************************************************************
@@ -212,4 +212,36 @@ export default async function () {
       installationId: 12345,
     },
   });
+  
+  const { data } = await updateLabel({
+    owner: "octocat",
+    repo: "hello-world",
+    name: "bug",
+    color: "cc0000",
+  });
+
+  console.log(data.color)
+  
+  async function updateLabel(
+    options: RestEndpointMethodTypes["issues"]["updateLabel"]["parameters"]
+  ): Promise<RestEndpointMethodTypes["issues"]["updateLabel"]["response"]> {
+    console.log(options)
+    
+    return {
+      headers: {},
+      data: {
+        id: 123,
+        node_id: "123",
+        color: "cc0000",
+        default: false,
+        description: "",
+        name: "bug",
+        url: "",
+      },
+      status: 201,
+      url: "",
+    };
+  }
+  });
 }
+


### PR DESCRIPTION
fixes https://github.com/octokit/plugin-rest-endpoint-methods.js/issues/47, fixes #1679, addresses https://github.com/octokit/rest.js/issues/1668, fixes #1670