### PR TITLE
feat(typescript): set types for parameters and results/responses automagically

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1552,17 +1552,17 @@
       }
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.1.0.tgz",
-      "integrity": "sha512-7+/7urDH8cy6DmTwkewysf7/Or9dFtwZK7aQOc/IImjyeHJy+C8CEKOPo7L5Qb+66HyAr/4p/zV76LMVMuiRtA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.2.0.tgz",
+      "integrity": "sha512-KoNxC3PLNar8UJwR+1VMQOw2IoOrrFdo5YOiDKnBhpVbKpw+zkBKNMNKwM44UWL25Vkn0Sl3nYIEGKY+gW5ebw==",
       "requires": {
-        "@octokit/types": "^2.9.0"
+        "@octokit/types": "^2.12.1"
       },
       "dependencies": {
         "@octokit/types": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.9.0.tgz",
-          "integrity": "sha512-IzptUpoDsFlXF+AOys+KnfItIVY3EK+eH9Akv+lJYELnMSGkJnIcClt6Cm0QRR4ecsUTsmFJWn10iFgJ9BQqIQ==",
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.12.1.tgz",
+          "integrity": "sha512-LRLR1tjbcCfAmUElvTmMvLEzstpx6Xt/aQVTg2xvd+kHA2Ekp1eWl5t+gU7bcwjXHYEAzh4hH4WH+kS3vh+wRw==",
           "requires": {
             "@types/node": ">= 8"
           }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "repository": "https://github.com/octokit/rest.js",
   "dependencies": {
     "@octokit/core": "^2.4.3",
-    "@octokit/plugin-paginate-rest": "^2.1.0",
+    "@octokit/plugin-paginate-rest": "^2.2.0",
     "@octokit/plugin-request-log": "^1.0.0",
     "@octokit/plugin-rest-endpoint-methods": "3.8.0"
   },

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -143,7 +143,7 @@ export default async function () {
     });
 
   octokit
-    .paginate<{ title: string }, string[]>(
+    .paginate(
       "GET /repos/:owner/:repo/issues",
       { owner: "octokit", repo: "rest.js" },
       (response) => response.data.map((issue) => issue.title)


### PR DESCRIPTION
It's not perfect, but pretty close

![octokit-paginate-typeahead-small](https://user-images.githubusercontent.com/39992/80161911-ae069400-8586-11ea-81ff-a13e160a84c9.gif)
