### PR TITLE
Include methods in search results again

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -74,21 +74,11 @@ module.exports = {
           // For any node of type MarkdownRemark, list how to resolve the fields` values
           MarkdownRemark: {
             title: node => node.frontmatter.title,
-            slug: node => `#${node.fields.idName}`,
-            type: node => "API"
-          },
-          OctokitApiGroup: {
-            title: node => upperFirst(node.name),
-            slug: node => `#${node.id}`,
-            type: node => "API"
-          },
-          OctokitApiMethod: {
-            name: node => node.name,
-            scope: node => node.scope,
-            route: node => `${node.method} ${node.url}`,
-            method: node => `${node.example}`,
-            slug: node => `#${node.id}`,
-            type: node => "API method"
+            name: node => node.frontmatter.name,
+            slug: node => `#${node.frontmatter.scope ? node.frontmatter.scope + '-' :  ''}${node.fields.idName}`,
+            route: node => `${node.frontmatter.route}`,
+            method: node => `${node.frontmatter.example}`,
+            type: node => node.frontmatter.type || "API"
           }
         }
       }


### PR DESCRIPTION
This moves the indexing config for elasticlunr search to only use
MarkdownRemark nodes, since everything is being source as markdown files
from `plugin-rest-endpoint-methods.js`.

Now all of the information that was previously available for search
indexing will be available in the frontmatter of each method's markdown
file.

I tried sourcing this information from the htmlAst and headings fields in the
MarkdownRemark nodes, but it appears that gatsby-transformer-remark
doesn't generate that information until it's queried for the first time,
and the config portion for building the search index happens before
that, so that was unavailable.

Placing it in the frontmatter seemed like a good way to have it
available during the build step without modifying the visible content of
the documentation or figuring out how to force that information to build
earlier and then parse an HTML AST for title and example snippets.

Here's the related PR link https://github.com/octokit/plugin-rest-endpoint-methods.js/pull/73

### Screenshot
![image](https://user-images.githubusercontent.com/2539016/80325957-15714d80-87ec-11ea-92e9-e1445846ed4a.png)

I put up an example site using the PR from plugin-rest-endpoint-methods.js.
https://loving-ride-404dcc.netlify.app/v17/

Closes #1678