### PR TITLE
bug: style(docs): fix overflow-y in sections

### DIFF
--- a/docs/src/components/api.module.css
+++ b/docs/src/components/api.module.css
@@ -57,7 +57,9 @@ main h2:first-child {
   .section > :not([data-language]) {
     max-width: 100%;
     overflow-x: auto;
+    overflow-y: hidden;
     grid-column: 1/2;
+    padding-bottom: 0.11rem;
   }
 
   .section > [data-language] {


### PR DESCRIPTION
There is an unnecessary scroll bar on each section header. It is actually confusing as I thought it does something more than just scrolling. This shows up both in chrome and the new edge. Firefox does not have this issue. Here is a picture:
![image](https://user-images.githubusercontent.com/16814184/82722825-146ef700-9c98-11ea-8597-7c91c5d1aca8.png)

This is a simple fix. I tested it on my local machine in Chrome, Firefox and new Edge.