### PR TITLE
v18 - removes all deprecated methods

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,8 @@ name: Test
       - next
       - beta
       - dependabot/npm_and_yarn/**
-      - *.x
+      - 16.x
+      - 17.x
   pull_request:
     types:
       - opened
@@ -19,6 +20,7 @@ jobs:
         node_version:
           - 10
           - 12
+          - 14
     steps:
       - uses: actions/checkout@master
       - name: "Test with Node.js ${{ matrix.node_version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,7 @@ name: Test
       - next
       - beta
       - dependabot/npm_and_yarn/**
-      - 15.x
-      - 16.x
+      - *.x
   pull_request:
     types:
       - opened

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -1,5 +1,3 @@
-const upperFirst = require("lodash/upperFirst");
-
 module.exports = {
   // https://www.gatsbyjs.org/docs/how-gatsby-works-with-github-pages/
   pathPrefix: "/rest.js",

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -90,12 +90,17 @@ module.exports = {
     {
       resolve: "gatsby-plugin-versioned-docs",
       options: {
-        currentVersion: "v17", // configure the path for the current version
+        currentVersion: "v18", // configure the path for the current version
         versions: [
           {
             name: "v16", // the path of the older version
             branch: "16.x", // older versions specify a branch name for this repo
             endpoints: "2.x", // ...and one for the endpoint methods
+          },
+          {
+            name: "v17", // the path of the older version
+            branch: "17.x", // older versions specify a branch name for this repo
+            endpoints: "3.x", // ...and one for the endpoint methods
           },
         ],
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1494,22 +1494,22 @@
       }
     },
     "@octokit/core": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.5.3.tgz",
-      "integrity": "sha512-23AHK9xBW0v79Ck8h5U+5iA4MW7aosqv+Yr6uZXolVGNzzHwryNH5wM386/6+etiKUTwLFZTqyMU9oQpIBZcFA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-FGUUqZbIwl5UPvuUTWq8ly2B12gJGWjYh1DviBzZLXp5LzHUgyzL+NDGsXeE4vszXoGsD/JfpZS+kjkLiD2T9w==",
       "requires": {
         "@octokit/auth-token": "^2.4.0",
         "@octokit/graphql": "^4.3.1",
         "@octokit/request": "^5.4.0",
-        "@octokit/types": "^4.0.1",
+        "@octokit/types": "^5.0.0",
         "before-after-hook": "^2.1.0",
         "universal-user-agent": "^5.0.0"
       },
       "dependencies": {
         "@octokit/types": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.0.1.tgz",
-          "integrity": "sha512-Ho6h7w2h9y8RRE8r656hIj1oiSbwbIHJGF5r9G5FOwS2VdDPq8QLGvsG4x6pKHpvyGK7j+43sAc2cJKMiFoIJw==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.0.0.tgz",
+          "integrity": "sha512-3LVS+MbeqwSd5G4KS8123cZz+hWomsiGeMnQ/QJIBFDwL/YHX8kkr0FZXrgWEMO7Fgi2/VOrhbiFnk9sZ+s4qA==",
           "requires": {
             "@types/node": ">= 8"
           }
@@ -1566,19 +1566,19 @@
       }
     },
     "@octokit/graphql": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.0.tgz",
-      "integrity": "sha512-StJWfn0M1QfhL3NKBz31e1TdDNZrHLLS57J2hin92SIfzlOVBuUaRkp31AGkGOAFOAVtyEX6ZiZcsjcJDjeb5g==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.1.tgz",
+      "integrity": "sha512-qgMsROG9K2KxDs12CO3bySJaYoUu2aic90qpFrv7A8sEBzZ7UFGvdgPKiLw5gOPYEYbS0Xf8Tvf84tJutHPulQ==",
       "requires": {
         "@octokit/request": "^5.3.0",
-        "@octokit/types": "^4.0.1",
+        "@octokit/types": "^5.0.0",
         "universal-user-agent": "^5.0.0"
       },
       "dependencies": {
         "@octokit/types": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.0.1.tgz",
-          "integrity": "sha512-Ho6h7w2h9y8RRE8r656hIj1oiSbwbIHJGF5r9G5FOwS2VdDPq8QLGvsG4x6pKHpvyGK7j+43sAc2cJKMiFoIJw==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.0.0.tgz",
+          "integrity": "sha512-3LVS+MbeqwSd5G4KS8123cZz+hWomsiGeMnQ/QJIBFDwL/YHX8kkr0FZXrgWEMO7Fgi2/VOrhbiFnk9sZ+s4qA==",
           "requires": {
             "@types/node": ">= 8"
           }
@@ -1674,6 +1674,31 @@
         "@octokit/plugin-rest-endpoint-methods": "^3.12.2"
       },
       "dependencies": {
+        "@octokit/core": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.5.4.tgz",
+          "integrity": "sha512-HCp8yKQfTITYK+Nd09MHzAlP1v3Ii/oCohv0/TW9rhSLvzb98BOVs2QmVYuloE6a3l6LsfyGIwb6Pc4ycgWlIQ==",
+          "dev": true,
+          "requires": {
+            "@octokit/auth-token": "^2.4.0",
+            "@octokit/graphql": "^4.3.1",
+            "@octokit/request": "^5.4.0",
+            "@octokit/types": "^5.0.0",
+            "before-after-hook": "^2.1.0",
+            "universal-user-agent": "^5.0.0"
+          },
+          "dependencies": {
+            "@octokit/types": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.0.0.tgz",
+              "integrity": "sha512-3LVS+MbeqwSd5G4KS8123cZz+hWomsiGeMnQ/QJIBFDwL/YHX8kkr0FZXrgWEMO7Fgi2/VOrhbiFnk9sZ+s4qA==",
+              "dev": true,
+              "requires": {
+                "@types/node": ">= 8"
+              }
+            }
+          }
+        },
         "@octokit/plugin-rest-endpoint-methods": {
           "version": "3.17.0",
           "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.17.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1609,18 +1609,18 @@
       "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw=="
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.17.0.tgz",
-      "integrity": "sha512-NFV3vq7GgoO2TrkyBRUOwflkfTYkFKS0tLAPym7RNpkwLCttqShaEGjthOsPEEL+7LFcYv3mU24+F2yVd3npmg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.0.0.tgz",
+      "integrity": "sha512-emS6gysz4E9BNi9IrCl7Pm4kR+Az3MmVB0/DoDCmF4U48NbYG3weKyDlgkrz6Jbl4Mu4nDx8YWZwC4HjoTdcCA==",
       "requires": {
-        "@octokit/types": "^4.1.6",
+        "@octokit/types": "^5.0.0",
         "deprecation": "^2.3.1"
       },
       "dependencies": {
         "@octokit/types": {
-          "version": "4.1.9",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.1.9.tgz",
-          "integrity": "sha512-hinM/BA2c1vebN2HSR3JtVdYtrSbmvn/doUBZXXuQuh/9o60hYwitQQAGTpJu+k6pjtjURskDHQxUFvqLvYCeA==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.0.0.tgz",
+          "integrity": "sha512-3LVS+MbeqwSd5G4KS8123cZz+hWomsiGeMnQ/QJIBFDwL/YHX8kkr0FZXrgWEMO7Fgi2/VOrhbiFnk9sZ+s4qA==",
           "requires": {
             "@types/node": ">= 8"
           }
@@ -1672,6 +1672,27 @@
         "@octokit/plugin-paginate-rest": "^2.2.0",
         "@octokit/plugin-request-log": "^1.0.0",
         "@octokit/plugin-rest-endpoint-methods": "^3.12.2"
+      },
+      "dependencies": {
+        "@octokit/plugin-rest-endpoint-methods": {
+          "version": "3.17.0",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.17.0.tgz",
+          "integrity": "sha512-NFV3vq7GgoO2TrkyBRUOwflkfTYkFKS0tLAPym7RNpkwLCttqShaEGjthOsPEEL+7LFcYv3mU24+F2yVd3npmg==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^4.1.6",
+            "deprecation": "^2.3.1"
+          }
+        },
+        "@octokit/types": {
+          "version": "4.1.10",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.1.10.tgz",
+          "integrity": "sha512-/wbFy1cUIE5eICcg0wTKGXMlKSbaAxEr00qaBXzscLXpqhcwgXeS6P8O0pkysBhRfyjkKjJaYrvR1ExMO5eOXQ==",
+          "dev": true,
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        }
       }
     },
     "@octokit/types": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "repository": "https://github.com/octokit/rest.js",
   "dependencies": {
-    "@octokit/core": "^2.4.3",
+    "@octokit/core": "^3.0.0",
     "@octokit/plugin-paginate-rest": "^2.2.0",
     "@octokit/plugin-request-log": "^1.0.0",
     "@octokit/plugin-rest-endpoint-methods": "4.0.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@octokit/core": "^2.4.3",
     "@octokit/plugin-paginate-rest": "^2.2.0",
     "@octokit/plugin-request-log": "^1.0.0",
-    "@octokit/plugin-rest-endpoint-methods": "3.17.0"
+    "@octokit/plugin-rest-endpoint-methods": "4.0.0"
   },
   "devDependencies": {
     "@octokit/auth": "^2.0.0",


### PR DESCRIPTION
follow up to https://github.com/octokit/plugin-rest-endpoint-methods.js/pull/135

Commit message body for squash & commit

```
BREAKING CHANGE: `Octokit.plugin()` no longer accepts an array as first argument. Pass multiple arguments instead, e.g. `Octokit.plugin(plugin1, plugin2)`

BREAKING CHANGE: deprecated `octokit.reactions.deleteLegacy()` has been removed

BREAKING CHANGE: deprecated `octokit.repos.getDownloads()` has been removed

BREAKING CHANGE: deprecated `octokit.repos.listDownloads()` has been removed

BREAKING CHANGE: deprecated `octokit.repos.deleteDownloads()` has been removed

BREAKING CHANGE: `octokit.actions.createOrUpdateRepoSecret()`: parameter `name` has been renamed to `secret_name`

BREAKING CHANGE: `octokit.actions.createOrUpdateSecretForRepo()` has been renamed to `octokit.actions.createOrUpdateRepoSecret()`

BREAKING CHANGE: `octokit.actions.createOrUpdateRepoSecret()`: parameter `name` has been renamed to `secret_name`

BREAKING CHANGE: `octokit.actions.createRegistrationToken()` has been renamed to `octokit.actions.createRegistrationTokenForRepo()`

BREAKING CHANGE: `octokit.actions.createRemoveToken()` has been renamed to `octokit.actions.createRemoveTokenForRepo()`

BREAKING CHANGE: `octokit.actions.deleteRepoSecret()`: parameter `name` has been renamed to `secret_name`

BREAKING CHANGE: `octokit.actions.deleteSecretFromRepo()` has been renamed to `octokit.actions.deleteRepoSecret()`

BREAKING CHANGE: `octokit.actions.deleteRepoSecret()`: parameter `name` has been renamed to `secret_name`

BREAKING CHANGE: `octokit.actions.downloadWorkflowJobLogs()` has been renamed to `octokit.actions.downloadJobLogsForWorkflowRun()`

BREAKING CHANGE: `octokit.actions.getPublicKey()` has been renamed to `octokit.actions.getRepoPublicKey()`

BREAKING CHANGE: `octokit.actions.getRepoSecret()`: parameter `name` has been renamed to `secret_name`

BREAKING CHANGE: `octokit.actions.getSecret()` has been renamed to `octokit.actions.getRepoSecret()`

BREAKING CHANGE: `octokit.actions.getRepoSecret()`: parameter `name` has been renamed to `secret_name`

BREAKING CHANGE: `octokit.actions.getSelfHostedRunner()` has been renamed to `octokit.actions.getSelfHostedRunnerForRepo()`

BREAKING CHANGE: `octokit.actions.getWorkflowJob()` has been renamed to `octokit.actions.getJobForWorkflowRun()`

BREAKING CHANGE: `octokit.actions.listDownloadsForSelfHostedRunnerApplication()` has been renamed to `octokit.actions.listRunnerApplicationsForRepo()`

BREAKING CHANGE: `octokit.actions.listRepoWorkflowRuns()` has been renamed to `octokit.actions.listWorkflowRunsForRepo()`

BREAKING CHANGE: `octokit.actions.listSecretsForRepo()` has been renamed to `octokit.actions.listRepoSecrets()`

BREAKING CHANGE: `octokit.actions.listWorkflowJobLogs()` has been renamed to `octokit.actions.downloadWorkflowJobLogs()`

BREAKING CHANGE: `octokit.actions.listWorkflowRunLogs()` has been renamed to `octokit.actions.downloadWorkflowRunLogs()`

BREAKING CHANGE: `octokit.actions.removeSelfHostedRunner()` has been renamed to `octokit.actions.deleteSelfHostedRunnerFromRepo()`

BREAKING CHANGE: `octokit.activity.checkStarringRepo()` has been renamed to `octokit.activity.checkRepoIsStarredByAuthenticatedUser()`

BREAKING CHANGE: `octokit.activity.getThreadSubscription()` has been renamed to `octokit.activity.getThreadSubscriptionForAuthenticatedUser()`

BREAKING CHANGE: `octokit.activity.listEventsForOrg()` has been renamed to `octokit.activity.listOrgEventsForAuthenticatedUser()`

BREAKING CHANGE: `octokit.activity.listEventsForUser()` has been renamed to `octokit.activity.listEventsForAuthenticatedUser()`

BREAKING CHANGE: `octokit.activity.listFeeds()` has been renamed to `octokit.activity.getFeeds()`

BREAKING CHANGE: `octokit.activity.listNotifications()` has been renamed to `octokit.activity.listNotificationsForAuthenticatedUser()`

BREAKING CHANGE: `octokit.activity.listNotificationsForRepo()` has been renamed to `octokit.activity.listRepoNotificationsForAuthenticatedUser()`

BREAKING CHANGE: `octokit.activity.listPublicEventsForOrg()` has been renamed to `octokit.activity.listPublicOrgEvents()`

BREAKING CHANGE: `octokit.activity.markAsRead()` has been renamed to `octokit.activity.markNotificationsAsRead()`

BREAKING CHANGE: `octokit.activity.markNotificationsAsReadForRepo()` has been renamed to `octokit.activity.markRepoNotificationsAsRead()`

BREAKING CHANGE: `octokit.activity.starRepo()` has been renamed to `octokit.activity.starRepoForAuthenticatedUser()`

BREAKING CHANGE: `octokit.activity.unstarRepo()` has been renamed to `octokit.activity.unstarRepoForAuthenticatedUser()`

BREAKING CHANGE: `octokit.apps.checkAccountIsAssociatedWithAny()` has been renamed to `octokit.apps.getSubscriptionPlanForAccount()`

BREAKING CHANGE: `octokit.apps.checkAccountIsAssociatedWithAnyStubbed()` has been renamed to `octokit.apps.getSubscriptionPlanForAccountStubbed()`

BREAKING CHANGE: `octokit.apps.createInstallationToken()` has been renamed to `octokit.apps.createInstallationAccessToken()`

BREAKING CHANGE: `octokit.apps.listAccountsUserOrOrgOnPlan()` has been renamed to `octokit.apps.listAccountsForPlan()`

BREAKING CHANGE: `octokit.apps.listAccountsUserOrOrgOnPlanStubbed()` has been renamed to `octokit.apps.listAccountsForPlanStubbed()`

BREAKING CHANGE: `octokit.apps.listMarketplacePurchasesForAuthenticatedUser()` has been renamed to `octokit.apps.listSubscriptionsForAuthenticatedUser()`

BREAKING CHANGE: `octokit.apps.listMarketplacePurchasesForAuthenticatedUserStubbed()` has been renamed to `octokit.apps.listSubscriptionsForAuthenticatedUserStubbed()`

BREAKING CHANGE: `octokit.apps.listRepos()` has been renamed to `octokit.apps.listReposAccessibleToInstallation()`

BREAKING CHANGE: `octokit.apps.revokeInstallationToken()` has been renamed to `octokit.apps.revokeInstallationAccessToken()`

BREAKING CHANGE: `octokit.codesOfConduct.listConductCodes()` has been renamed to `octokit.codesOfConduct.getAllCodesOfConduct()`

BREAKING CHANGE: `octokit.gists.listPublicForUser()` has been renamed to `octokit.gists.listForUser()`

BREAKING CHANGE: `octokit.gitignore.listTemplates()` has been renamed to `octokit.gitignore.getAllTemplates()`

BREAKING CHANGE: `octokit.interactions.addOrUpdateRestrictionsForOrg()` has been renamed to `octokit.interactions.setRestrictionsForOrg()`

BREAKING CHANGE: `octokit.interactions.addOrUpdateRestrictionsForRepo()` has been renamed to `octokit.interactions.setRestrictionsForRepo()`

BREAKING CHANGE: `octokit.issues.checkAssignee()` has been renamed to `octokit.issues.checkUserCanBeAssigned()`

BREAKING CHANGE: `octokit.issues.listMilestonesForRepo()` has been renamed to `octokit.issues.listMilestones()`

BREAKING CHANGE: `octokit.issues.removeLabels()` has been renamed to `octokit.issues.removeAllLabels()`

BREAKING CHANGE: `octokit.issues.replaceAllLabels()` has been renamed to `octokit.issues.setLabels()`

BREAKING CHANGE: `octokit.issues.replaceLabels()` has been renamed to `octokit.issues.replaceAllLabels()`

BREAKING CHANGE: `octokit.licenses.listCommonlyUsed()` has been renamed to `octokit.licenses.getAllCommonlyUsed()`

BREAKING CHANGE: `octokit.migrations.getImportProgress()` has been renamed to `octokit.migrations.getImportStatus()`

BREAKING CHANGE: `octokit.orgs.addOrUpdateMembership()` has been renamed to `octokit.orgs.setMembershipForUser()`

BREAKING CHANGE: `octokit.orgs.checkMembership()` has been renamed to `octokit.orgs.checkMembershipForUser()`

BREAKING CHANGE: `octokit.orgs.checkPublicMembership()` has been renamed to `octokit.orgs.checkPublicMembershipForUser()`

BREAKING CHANGE: `octokit.orgs.concealMembership()` has been renamed to `octokit.orgs.removePublicMembershipForAuthenticatedUser()`

BREAKING CHANGE: `octokit.orgs.createHook()` has been renamed to `octokit.orgs.createWebhook()`

BREAKING CHANGE: `octokit.orgs.deleteHook()` has been renamed to `octokit.orgs.deleteWebhook()`

BREAKING CHANGE: `octokit.orgs.getHook()` has been renamed to `octokit.orgs.getWebhook()`

BREAKING CHANGE: `octokit.orgs.getMembership()` has been renamed to `octokit.orgs.getMembershipForUser()`

BREAKING CHANGE: `octokit.orgs.listHooks()` has been renamed to `octokit.orgs.listWebhooks()`

BREAKING CHANGE: `octokit.orgs.listInstallations()` has been renamed to `octokit.orgs.listAppInstallations()`

BREAKING CHANGE: `octokit.orgs.listMemberships()` has been renamed to `octokit.orgs.listMembershipsForAuthenticatedUser()`

BREAKING CHANGE: `octokit.orgs.pingHook()` has been renamed to `octokit.orgs.pingWebhook()`

BREAKING CHANGE: `octokit.orgs.publicizeMembership()` has been renamed to `octokit.orgs.setPublicMembershipForAuthenticatedUser()`

BREAKING CHANGE: `octokit.orgs.removeMembership()` has been renamed to `octokit.orgs.removeMembershipForUser()`

BREAKING CHANGE: `octokit.orgs.updateHook()` has been renamed to `octokit.orgs.updateWebhook()`

BREAKING CHANGE: `octokit.orgs.updateMembership()` has been renamed to `octokit.orgs.updateMembershipForAuthenticatedUser()`

BREAKING CHANGE: `octokit.projects.reviewUserPermissionLevel()` has been renamed to `octokit.projects.getPermissionForUser()`

BREAKING CHANGE: `octokit.pulls.createComment()` has been renamed to `octokit.pulls.createReviewComment()`

BREAKING CHANGE: `octokit.pulls.createReviewCommentReply()` has been renamed to `octokit.pulls.createReplyForReviewComment()`

BREAKING CHANGE: `octokit.pulls.createReviewRequest()` has been renamed to `octokit.pulls.requestReviewers()`

BREAKING CHANGE: `octokit.pulls.deleteComment()` has been renamed to `octokit.pulls.deleteReviewComment()`

BREAKING CHANGE: `octokit.pulls.deleteReviewRequest()` has been renamed to `octokit.pulls.removeRequestedReviewers()`

BREAKING CHANGE: `octokit.pulls.getComment()` has been renamed to `octokit.pulls.getReviewComment()`

BREAKING CHANGE: `octokit.pulls.getCommentsForReview()` has been renamed to `octokit.pulls.listCommentsForReview()`

BREAKING CHANGE: `octokit.pulls.listComments()` has been renamed to `octokit.pulls.listReviewComments()`

BREAKING CHANGE: `octokit.pulls.listCommentsForRepo()` has been renamed to `octokit.pulls.listReviewCommentsForRepo()`

BREAKING CHANGE: `octokit.pulls.listReviewRequests()` has been renamed to `octokit.pulls.listRequestedReviewers()`

BREAKING CHANGE: `octokit.pulls.updateComment()` has been renamed to `octokit.pulls.updateReviewComment()`

BREAKING CHANGE: `octokit.reactions.delete()` has been renamed to `octokit.reactions.deleteLegacy()`

BREAKING CHANGE: `octokit.repos.addDeployKey()` has been renamed to `octokit.repos.createDeployKey()`

BREAKING CHANGE: `octokit.repos.addProtectedBranchAdminEnforcement()` has been renamed to `octokit.repos.setAdminBranchProtection()`

BREAKING CHANGE: `octokit.repos.addProtectedBranchAppRestrictions()` has been renamed to `octokit.repos.addAppAccessRestrictions()`

BREAKING CHANGE: `octokit.repos.addProtectedBranchRequiredSignatures()` has been renamed to `octokit.repos.createCommitSignatureProtection()`

BREAKING CHANGE: `octokit.repos.addProtectedBranchRequiredStatusChecksContexts()` has been renamed to `octokit.repos.addStatusCheckContexts()`

BREAKING CHANGE: `octokit.repos.addProtectedBranchTeamRestrictions()` has been renamed to `octokit.repos.addTeamAccessRestrictions()`

BREAKING CHANGE: `octokit.repos.addProtectedBranchUserRestrictions()` has been renamed to `octokit.repos.addUserAccessRestrictions()`

BREAKING CHANGE: `octokit.repos.createHook()` has been renamed to `octokit.repos.createWebhook()`

BREAKING CHANGE: `octokit.repos.createOrUpdateFile()` has been renamed to `octokit.repos.createOrUpdateFileContents()`

BREAKING CHANGE: `octokit.repos.createStatus()` has been renamed to `octokit.repos.createCommitStatus()`

BREAKING CHANGE: `octokit.repos.deleteHook()` has been renamed to `octokit.repos.deleteWebhook()`

BREAKING CHANGE: `octokit.repos.disablePagesSite()` has been renamed to `octokit.repos.deletePagesSite()`

BREAKING CHANGE: `octokit.repos.enablePagesSite()` has been renamed to `octokit.repos.createPagesSite()`

BREAKING CHANGE: `octokit.repos.getArchiveLink()` has been renamed to `octokit.repos.downloadArchive()`

BREAKING CHANGE: `octokit.repos.getContents()` has been renamed to `octokit.repos.getContent()`

BREAKING CHANGE: `octokit.repos.getHook()` has been renamed to `octokit.repos.getWebhook()`

BREAKING CHANGE: `octokit.repos.getProtectedBranchAdminEnforcement()` has been renamed to `octokit.repos.getAdminBranchProtection()`

BREAKING CHANGE: `octokit.repos.getProtectedBranchPullRequestReviewEnforcement()` has been renamed to `octokit.repos.getPullRequestReviewProtection()`

BREAKING CHANGE: `octokit.repos.getProtectedBranchRequiredSignatures()` has been renamed to `octokit.repos.getCommitSignatureProtection()`

BREAKING CHANGE: `octokit.repos.getProtectedBranchRequiredStatusChecks()` has been renamed to `octokit.repos.getStatusChecksProtection()`

BREAKING CHANGE: `octokit.repos.getProtectedBranchRestrictions()` has been renamed to `octokit.repos.getAccessRestrictions()`

BREAKING CHANGE: `octokit.repos.list()` has been renamed to `octokit.repos.listForAuthenticatedUser()`

BREAKING CHANGE: `octokit.repos.listAssetsForRelease()` has been renamed to `octokit.repos.listReleaseAssets()`

BREAKING CHANGE: `octokit.repos.listCommitComments()` has been renamed to `octokit.repos.listCommitCommentsForRepo()`

BREAKING CHANGE: `octokit.repos.listHooks()` has been renamed to `octokit.repos.listWebhooks()`

BREAKING CHANGE: `octokit.repos.listProtectedBranchRequiredStatusChecksContexts()` has been renamed to `octokit.repos.getAllStatusCheckContexts()`

BREAKING CHANGE: `octokit.repos.listStatusesForRef()` has been renamed to `octokit.repos.listCommitStatusesForRef()`

BREAKING CHANGE: `octokit.repos.listTopics()` has been renamed to `octokit.repos.getAllTopics()`

BREAKING CHANGE: `octokit.repos.pingHook()` has been renamed to `octokit.repos.pingWebhook()`

BREAKING CHANGE: `octokit.repos.removeBranchProtection()` has been renamed to `octokit.repos.deleteBranchProtection()`

BREAKING CHANGE: `octokit.repos.removeDeployKey()` has been renamed to `octokit.repos.deleteDeployKey()`

BREAKING CHANGE: `octokit.repos.removeProtectedBranchAdminEnforcement()` has been renamed to `octokit.repos.deleteAdminBranchProtection()`

BREAKING CHANGE: `octokit.repos.removeProtectedBranchAppRestrictions()` has been renamed to `octokit.repos.removeAppAccessRestrictions()`

BREAKING CHANGE: `octokit.repos.removeProtectedBranchPullRequestReviewEnforcement()` has been renamed to `octokit.repos.deletePullRequestReviewProtection()`

BREAKING CHANGE: `octokit.repos.removeProtectedBranchRequiredSignatures()` has been renamed to `octokit.repos.deleteCommitSignatureProtection()`

BREAKING CHANGE: `octokit.repos.removeProtectedBranchRequiredStatusChecks()` has been renamed to `octokit.repos.removeStatusChecksProtection()`

BREAKING CHANGE: `octokit.repos.removeProtectedBranchRequiredStatusChecksContexts()` has been renamed to `octokit.repos.removeStatusCheckContexts()`

BREAKING CHANGE: `octokit.repos.removeProtectedBranchRestrictions()` has been renamed to `octokit.repos.deleteAccessRestrictions()`

BREAKING CHANGE: `octokit.repos.removeProtectedBranchTeamRestrictions()` has been renamed to `octokit.repos.removeTeamAccessRestrictions()`

BREAKING CHANGE: `octokit.repos.removeProtectedBranchUserRestrictions()` has been renamed to `octokit.repos.removeUserAccessRestrictions()`

BREAKING CHANGE: `octokit.repos.replaceProtectedBranchAppRestrictions()` has been renamed to `octokit.repos.setAppAccessRestrictions()`

BREAKING CHANGE: `octokit.repos.replaceProtectedBranchRequiredStatusChecksContexts()` has been renamed to `octokit.repos.setStatusCheckContexts()`

BREAKING CHANGE: `octokit.repos.replaceProtectedBranchTeamRestrictions()` has been renamed to `octokit.repos.setTeamAccessRestrictions()`

BREAKING CHANGE: `octokit.repos.replaceProtectedBranchUserRestrictions()` has been renamed to `octokit.repos.setUserAccessRestrictions()`

BREAKING CHANGE: `octokit.repos.replaceTopics()` has been renamed to `octokit.repos.replaceAllTopics()`

BREAKING CHANGE: `octokit.repos.requestPageBuild()` has been renamed to `octokit.repos.requestPagesBuild()`

BREAKING CHANGE: `octokit.repos.retrieveCommunityProfileMetrics()` has been renamed to `octokit.repos.getCommunityProfileMetrics()`

BREAKING CHANGE: `octokit.repos.testPushHook()` has been renamed to `octokit.repos.testPushWebhook()`

BREAKING CHANGE: `octokit.repos.updateHook()` has been renamed to `octokit.repos.updateWebhook()`

BREAKING CHANGE: `octokit.repos.updateProtectedBranchPullRequestReviewEnforcement()` has been renamed to `octokit.repos.updatePullRequestReviewProtection()`

BREAKING CHANGE: `octokit.repos.updateProtectedBranchRequiredStatusChecks()` has been renamed to `octokit.repos.updateStatusChecksProtection()`

BREAKING CHANGE: `octokit.teams.addOrUpdateMembershipInOrg()` has been renamed to `octokit.teams.addOrUpdateMembershipForUserInOrg()`

BREAKING CHANGE: `octokit.teams.addOrUpdateProjectInOrg()` has been renamed to `octokit.teams.addOrUpdateProjectPermissionsInOrg()`

BREAKING CHANGE: `octokit.teams.addOrUpdateRepoInOrg()` has been renamed to `octokit.teams.addOrUpdateRepoPermissionsInOrg()`

BREAKING CHANGE: `octokit.teams.checkManagesRepoInOrg()` has been renamed to `octokit.teams.checkPermissionsForRepoInOrg()`

BREAKING CHANGE: `octokit.teams.getMembershipInOrg()` has been renamed to `octokit.teams.getMembershipForUserInOrg()`

BREAKING CHANGE: `octokit.teams.removeMembershipInOrg()` has been renamed to `octokit.teams.removeMembershipForUserInOrg()`

BREAKING CHANGE: `octokit.teams.reviewProjectInOrg()` has been renamed to `octokit.teams.checkPermissionsForProjectInOrg()`

BREAKING CHANGE: `octokit.users.addEmails()` has been renamed to `octokit.users.addEmailsForAuthenticated()`

BREAKING CHANGE: `octokit.users.checkFollowing()` has been renamed to `octokit.users.checkPersonIsFollowedByAuthenticated()`

BREAKING CHANGE: `octokit.users.createGpgKey()` has been renamed to `octokit.users.createGpgKeyForAuthenticated()`

BREAKING CHANGE: `octokit.users.createPublicKey()` has been renamed to `octokit.users.createPublicSshKeyForAuthenticated()`

BREAKING CHANGE: `octokit.users.deleteEmails()` has been renamed to `octokit.users.deleteEmailsForAuthenticated()`

BREAKING CHANGE: `octokit.users.deleteGpgKey()` has been renamed to `octokit.users.deleteGpgKeyForAuthenticated()`

BREAKING CHANGE: `octokit.users.deletePublicKey()` has been renamed to `octokit.users.deletePublicSshKeyForAuthenticated()`

BREAKING CHANGE: `octokit.users.getGpgKey()` has been renamed to `octokit.users.getGpgKeyForAuthenticated()`

BREAKING CHANGE: `octokit.users.getPublicKey()` has been renamed to `octokit.users.getPublicSshKeyForAuthenticated()`

BREAKING CHANGE: `octokit.users.listBlocked()` has been renamed to `octokit.users.listBlockedByAuthenticated()`

BREAKING CHANGE: `octokit.users.listEmails()` has been renamed to `octokit.users.listEmailsForAuthenticated()`

BREAKING CHANGE: `octokit.users.listFollowingForAuthenticatedUser()` has been renamed to `octokit.users.listFollowedByAuthenticated()`

BREAKING CHANGE: `octokit.users.listGpgKeys()` has been renamed to `octokit.users.listGpgKeysForAuthenticated()`

BREAKING CHANGE: `octokit.users.listPublicEmails()` has been renamed to `octokit.users.listPublicEmailsForAuthenticatedUser()`

BREAKING CHANGE: `octokit.users.listPublicKeys()` has been renamed to `octokit.users.listPublicSshKeysForAuthenticated()`

BREAKING CHANGE: `octokit.users.togglePrimaryEmailVisibility()` has been renamed to `octokit.users.setPrimaryEmailVisibilityForAuthenticated()`
```