### PR TITLE
docs: Fix authentication strategies link

### DIFF
--- a/docs/src/pages/api/01_authentication.md
+++ b/docs/src/pages/api/01_authentication.md
@@ -16,7 +16,7 @@ const octokit = new Octokit({
 const { data } = await octokit.request("/user");
 ```
 
-To use a different authentication strategy, set `options.authStrategy`. The officially supported authentication strategies are listed on the [`@octokit/auth` README](https://github.com/octokit/auth-app.js#readme).
+To use a different authentication strategy, set `options.authStrategy`. The officially supported authentication strategies are listed on the [`@octokit/auth` README](https://github.com/octokit/auth.js#readme).
 
 Here is an example for GitHub App authentication
 


### PR DESCRIPTION
Authentication strategies are listed in the main `auth.js` repo rather than in a specific strategy implementation repo.

-----
[View rendered docs/src/pages/api/01_authentication.md](https://github.com/gordey4doronin/rest.js/blob/patch-1/docs/src/pages/api/01_authentication.md)