### PR TITLE
Update throttling docs to clarify return values and reduce unnecessary ratelimit fails

### DIFF
--- a/docs/src/pages/api/09_throttling.md
+++ b/docs/src/pages/api/09_throttling.md
@@ -6,7 +6,9 @@ When you send too many requests in too little time you will likely hit errors du
 
 In order to automatically throttle requests as recommended in [GitHub’s best practices for integrators](https://developer.github.com/v3/guides/best-practices-for-integrators/), we recommend you install the [`@octokit/plugin-throttling` plugin](https://github.com/octokit/plugin-throttling.js).
 
-The `throttle.onAbuseLimit` and `throttle.onRateLimit` options are required. Return `true` to automatically retry the request after `retryAfter` seconds.
+The `throttle.onAbuseLimit` and `throttle.onRateLimit` options are required.
+
+Return `true` from these functions to automatically retry the request after `retryAfter` seconds.  Return `false` or `undefined` to skip retry and throw the error.
 
 ```js
 const { Octokit } = require("@octokit/rest");

--- a/docs/src/pages/api/09_throttling.md
+++ b/docs/src/pages/api/09_throttling.md
@@ -8,7 +8,7 @@ In order to automatically throttle requests as recommended in [GitHub’s best p
 
 The `throttle.onAbuseLimit` and `throttle.onRateLimit` options are required.
 
-Return `true` from these functions to automatically retry the request after `retryAfter` seconds.  Return `false` or `undefined` to skip retry and throw the error.  For rate limit errors, `retryAfter` defaults to seconds until `X-RateLimit-Reset`.  For abuse errors, `retryAfter` defaults to the `retry-after` header but is a minimum of five seconds.
+Return `true` from these functions to automatically retry the request after `retryAfter` seconds. Return `false` or `undefined` to skip retry and throw the error. For rate limit errors, `retryAfter` defaults to seconds until `X-RateLimit-Reset`. For abuse errors, `retryAfter` defaults to the `retry-after` header but is a minimum of five seconds.
 
 ```js
 const { Octokit } = require("@octokit/rest");

--- a/docs/src/pages/api/09_throttling.md
+++ b/docs/src/pages/api/09_throttling.md
@@ -21,8 +21,8 @@ const octokit = new MyOctokit({
         `Request quota exhausted for request ${options.method} ${options.url}`
       );
 
-      if (options.request.retryCount === 0) {
-        // only retries once
+      // Retry twice after hitting a rate limit error and waiting for X-RateLimit-Reset, then give up
+      if (options.request.retryCount <= 2) {
         console.log(`Retrying after ${retryAfter} seconds!`);
         return true;
       }

--- a/docs/src/pages/api/09_throttling.md
+++ b/docs/src/pages/api/09_throttling.md
@@ -8,7 +8,7 @@ In order to automatically throttle requests as recommended in [GitHub’s best p
 
 The `throttle.onAbuseLimit` and `throttle.onRateLimit` options are required.
 
-Return `true` from these functions to automatically retry the request after `retryAfter` seconds.  Return `false` or `undefined` to skip retry and throw the error.
+Return `true` from these functions to automatically retry the request after `retryAfter` seconds.  Return `false` or `undefined` to skip retry and throw the error.  For rate limit errors, `retryAfter` defaults to seconds until `X-RateLimit-Reset`.  For abuse errors, `retryAfter` defaults to the `retry-after` header but is a minimum of five seconds.
 
 ```js
 const { Octokit } = require("@octokit/rest");
@@ -23,7 +23,7 @@ const octokit = new MyOctokit({
         `Request quota exhausted for request ${options.method} ${options.url}`
       );
 
-      // Retry twice after hitting a rate limit error and waiting for X-RateLimit-Reset, then give up
+      // Retry twice after hitting a rate limit error, then give up
       if (options.request.retryCount <= 2) {
         console.log(`Retrying after ${retryAfter} seconds!`);
         return true;


### PR DESCRIPTION
I recently spent quite a bit of time debugging an issue where my script kept failing on a ratelimit 403, even though I had the throttling plugin installed and `onRateLimit` function defined.

I realized that the default function handler that I copy/pasted from the docs only attempts a ratelimit retry once.  My script kept falling into this loop:
  * Ratelimit hit, 403 returned and `onRateLimit` handler invoked
  * Script pauses until `X-RateLimit-Reset` passes
  * For some unknown reason (clock skew?  some kind of caching or clock coordination issue in the API?) the second attempt returns a 403 with the same `X-RateLimit-Reset`
  * A subsequent retry succeeds - but because the default is only a single retry, the 403 error is raised up the call stack

To help others traveling the same road, here I wanted to suggest:
  * increasing the suggested retryCount to 2, to avoid a failure if there is a clock skew
  * clarifying this behavior in the comment provided in the example
  * clarifying how the return values of these functions affect behavior (docs currently discuss what happens when `true` is returned, but not `false` or `undefined`)



-----
[View rendered docs/src/pages/api/09_throttling.md](https://github.com/bkoski/rest.js/blob/patch-1/docs/src/pages/api/09_throttling.md)