### PR TITLE
docs: update CDN url for browser/Deno usage

### DIFF
--- a/docs/src/pages/api/00_usage.md
+++ b/docs/src/pages/api/00_usage.md
@@ -7,11 +7,11 @@ Import the Octokit constructor based on your platform.
 ### Browsers
 
 <div>
-Load <code>@octokit/rest</code> directly from <a href="https://cdn.pika.dev">cdn.pika.dev</a>
+Load <code>@octokit/rest</code> directly from <a href="https://cdn.skypack.dev">cdn.skypack.dev</a>
 
 ```html
 <script type="module">
-  import { Octokit } from "https://cdn.pika.dev/@octokit/rest";
+  import { Octokit } from "https://cdn.skypack.dev/@octokit/rest";
 </script>
 ```
 


### PR DESCRIPTION
Fixes #1853

-----
[View rendered docs/src/pages/api/00_usage.md](https://github.com/jeroen/rest.js/blob/patch-1/docs/src/pages/api/00_usage.md)