### PR TITLE
Clarify what errors to expect and how the library really works.

### DIFF
--- a/docs/src/pages/api/01_authentication.md
+++ b/docs/src/pages/api/01_authentication.md
@@ -16,6 +16,8 @@ const octokit = new Octokit({
 const { data } = await octokit.request("/user");
 ```
 
+_**Note:** Calling methods outside of the scope of the specific token will result in an `HttpError` with `Bad Credentials` as a message._
+
 To use a different authentication strategy, set `options.authStrategy`. The officially supported authentication strategies are listed on the [`@octokit/auth` README](https://github.com/octokit/auth.js#readme).
 
 Here is an example for GitHub App authentication
@@ -34,6 +36,8 @@ const appOctokit = new Octokit({
 
 const { data } = await appOctokit.request("/app");
 ```
+
+_**Note:** In order to automatically switch between `App` and `Installation` authentication scopes based on the method called on the resulting instance, it is possible to also add `installationId` to the `auth` object._
 
 The `.auth()` method returned by the current authentication strategy can be accessed at `octokit.auth()`. Example
 


### PR DESCRIPTION
After finally having figured out that there are several authentication scopes and one does not include the other, after ready [this](https://github.com/octokit/octokit.net/blob/main/docs/github-apps.md#authentication) and all related docs several times I managed to implement a method that uses the `installation` scope for a GitHub App.

Some things definitely threw me off at first and I have tried to write the yeast of it as concise as possible.

Hope this will help future implementers.

-----
[View rendered docs/src/pages/api/01_authentication.md](https://github.com/webbertakken/rest.js/blob/patch-1/docs/src/pages/api/01_authentication.md)