### PR TITLE
docs(authentication): list official authentication strategies, clarify app authentication example

### DIFF
--- a/docs/src/pages/api/01_authentication.md
+++ b/docs/src/pages/api/01_authentication.md
@@ -6,7 +6,7 @@ Authentication is optional for some REST API endpoints accessing public data, bu
 
 GitHub supports different authentication strategies:
 
-1. **Personal access token** ([create](https://github.com/settings/tokens/new)). This is the default authentication strategy, simply set the `auth` option to the token when instantiating a new `Octokit` instance. Learn more about the built-in [`@octokit/auth-token` authentication strategy](https://github.com/octokit/auth-token.js).
+1. **Personal access token** ([create](https://github.com/settings/tokens/new)). This is the default authentication strategy. Set the `options.auth` option to the token in `new Octokit(options)`. Learn more about the built-in [`@octokit/auth-token` authentication strategy](https://github.com/octokit/auth-token.js).
 2. **OAuth Apps**: user access token (You grant an OAuth app access to scopes) or App authentication (OAuth authenticates using its `client_id` and `client_secret`). Learn more about the optional [`@octokit/auth-oauth-app` authentication strategy](https://github.com/octokit/auth-oauth-app.js)
 3. **GitHub Apps**: installation access token (expiring token that a GitHub app can create for each of its installations) or as GitHub using a JWT, which only permits access to [selected REST API endpoints](https://docs.github.com/en/free-pro-team@latest/rest/reference/apps). Learn more about the optional [`@octokit/auth-app` authentication strategy](https://github.com/octokit/auth-app.js/).
 4. **GitHub Actions**: A `GITHUB_TOKEN` secret is provided to GitHub Actions Workflows. Learn more about the optional [`@octokit/auth-action` authentication strategy](https://github.com/octokit/auth-action.js).

--- a/docs/src/pages/api/01_authentication.md
+++ b/docs/src/pages/api/01_authentication.md
@@ -7,7 +7,7 @@ Authentication is optional for some REST API endpoints accessing public data, bu
 GitHub supports different authentication strategies:
 
 1. **Personal access token** ([create](https://github.com/settings/tokens/new)). This is the default authentication strategy. Set the `options.auth` option to the token in `new Octokit(options)`. Learn more about the built-in [`@octokit/auth-token` authentication strategy](https://github.com/octokit/auth-token.js).
-2. **OAuth Apps**: authenticate using user access token created by an OAuth app, to which you granted selected permissions, or as the OAuth App itsel (OAuth using `client_id` and `client_secret`). Learn more about the optional [`@octokit/auth-oauth-app` authentication strategy](https://github.com/octokit/auth-oauth-app.js)
+2. **OAuth Apps**: authenticate using user access token created by an OAuth app, to which you granted selected permissions, or as the OAuth App itself (OAuth using `client_id` and `client_secret`). Learn more about the optional [`@octokit/auth-oauth-app` authentication strategy](https://github.com/octokit/auth-oauth-app.js)
 3. **GitHub Apps**: authenticate using an installation access token or as GitHub App itself. Learn more about the optional [`@octokit/auth-app` authentication strategy](https://github.com/octokit/auth-app.js/).
 4. **GitHub Actions**: authenticate using the `GITHUB_TOKEN` secret which is provided to GitHub Actions Workflows. Learn more about the optional [`@octokit/auth-action` authentication strategy](https://github.com/octokit/auth-action.js).
 

--- a/docs/src/pages/api/01_authentication.md
+++ b/docs/src/pages/api/01_authentication.md
@@ -7,9 +7,9 @@ Authentication is optional for some REST API endpoints accessing public data, bu
 GitHub supports different authentication strategies:
 
 1. **Personal access token** ([create](https://github.com/settings/tokens/new)). This is the default authentication strategy. Set the `options.auth` option to the token in `new Octokit(options)`. Learn more about the built-in [`@octokit/auth-token` authentication strategy](https://github.com/octokit/auth-token.js).
-2. **OAuth Apps**: user access token (You grant an OAuth app access to scopes) or App authentication (OAuth authenticates using its `client_id` and `client_secret`). Learn more about the optional [`@octokit/auth-oauth-app` authentication strategy](https://github.com/octokit/auth-oauth-app.js)
-3. **GitHub Apps**: installation access token (expiring token that a GitHub app can create for each of its installations) or as GitHub using a JWT, which only permits access to [selected REST API endpoints](https://docs.github.com/en/free-pro-team@latest/rest/reference/apps). Learn more about the optional [`@octokit/auth-app` authentication strategy](https://github.com/octokit/auth-app.js/).
-4. **GitHub Actions**: A `GITHUB_TOKEN` secret is provided to GitHub Actions Workflows. Learn more about the optional [`@octokit/auth-action` authentication strategy](https://github.com/octokit/auth-action.js).
+2. **OAuth Apps**: authenticate using user access token created by an OAuth app, to which you granted selected permissions, or as the OAuth App itsel (OAuth using `client_id` and `client_secret`). Learn more about the optional [`@octokit/auth-oauth-app` authentication strategy](https://github.com/octokit/auth-oauth-app.js)
+3. **GitHub Apps**: authenticate using an installation access token or as GitHub App itself. Learn more about the optional [`@octokit/auth-app` authentication strategy](https://github.com/octokit/auth-app.js/).
+4. **GitHub Actions**: authenticate using the `GITHUB_TOKEN` secret which is provided to GitHub Actions Workflows. Learn more about the optional [`@octokit/auth-action` authentication strategy](https://github.com/octokit/auth-action.js).
 
 Learn more about all official and community [authentication strategies](https://github.com/octokit/auth.js#readme).
 

--- a/docs/src/pages/api/01_authentication.md
+++ b/docs/src/pages/api/01_authentication.md
@@ -4,7 +4,16 @@ title: "Authentication"
 
 Authentication is optional for some REST API endpoints accessing public data, but is required for GraphQL queries. Using authentication also increases your [API rate limit](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting).
 
-By default, Octokit authenticates using the [token authentication strategy](https://github.com/octokit/auth-token.js). Pass in a token using `options.auth`. It can be a personal access token, an OAuth token, an installation access token or a JSON Web Token for GitHub App authentication. The `Authorization` header will be set according to the type of token.
+GitHub supports different authentication strategies:
+
+1. **Personal access token** ([create](https://github.com/settings/tokens/new)). This is the default authentication strategy, simply set the `auth` option to the token when instantiating a new `Octokit` instance. Learn more about the built-in [`@octokit/auth-token` authentication strategy](https://github.com/octokit/auth-token.js).
+2. **OAuth Apps**: user access token (You grant an OAuth app access to scopes) or App authentication (OAuth authenticates using its `client_id` and `client_secret`). Learn more about the optional [`@octokit/auth-oauth-app` authentication strategy](https://github.com/octokit/auth-oauth-app.js)
+3. **GitHub Apps**: installation access token (expiring token that a GitHub app can create for each of its installations) or as GitHub using a JWT, which only permits access to [selected REST API endpoints](https://docs.github.com/en/free-pro-team@latest/rest/reference/apps). Learn more about the optional [`@octokit/auth-app` authentication strategy](https://github.com/octokit/auth-app.js/).
+4. **GitHub Actions**: A `GITHUB_TOKEN` secret is provided to GitHub Actions Workflows. Learn more about the optional [`@octokit/auth-action` authentication strategy](https://github.com/octokit/auth-action.js).
+
+Learn more about all official and community [authentication strategies](https://github.com/octokit/auth.js#readme).
+
+By default, `@octokit/rest` authenticates using the [token authentication strategy](https://github.com/octokit/auth-token.js). Pass in a token using `options.auth`. It can be a personal access token, an OAuth token, an installation access token or a JSON Web Token for GitHub App authentication. The `Authorization` request header will be set according to the type of token.
 
 ```js
 const { Octokit } = require("@octokit/rest");
@@ -13,11 +22,11 @@ const octokit = new Octokit({
   auth: "mypersonalaccesstoken123",
 });
 
+// sends request with `Authorization: token mypersonalaccesstoken123` header
 const { data } = await octokit.request("/user");
 ```
 
-To use a different authentication strategy, set `options.authStrategy`. The officially supported authentication strategies are listed on the [`@octokit/auth` README](https://github.com/octokit/auth.js#readme).
-
+To use a different authentication strategy, set `options.authStrategy`.
 Here is an example for GitHub App authentication
 
 ```js
@@ -29,6 +38,9 @@ const appOctokit = new Octokit({
   auth: {
     id: 123,
     privateKey: process.env.PRIVATE_KEY,
+    // optional: this will make appOctokit authenticate as app (JWT)
+    //           or installation (access token), depending on the request URL
+    installationId: 123,
   },
 });
 
@@ -40,6 +52,7 @@ The `.auth()` method returned by the current authentication strategy can be acce
 ```js
 const { token } = await appOctokit.auth({
   type: "installation",
+  // defaults to `options.auth.installationId` set in the constructor
   installationId: 123,
 });
 ```


### PR DESCRIPTION
addresses #1893 /cc @webbertakken

-----
[View rendered docs/src/pages/api/01_authentication.md](https://github.com/octokit/rest.js/blob/1893/docs-clarify-authentication/docs/src/pages/api/01_authentication.md)