### PR TITLE
fix(README.md): deprecated cdn update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 <tr><th>
 Browsers
 </th><td width=100%>
-Load <code>@octokit/rest</code> directly from <a href="https://cdn.pika.dev">cdn.pika.dev</a>
+Load <code>@octokit/rest</code> directly from <a href="https://cdn.skypack.dev">cdn.skypack.dev</a>
         
 ```html
 <script type="module">
-import { Octokit } from "https://cdn.pika.dev/@octokit/rest";
+import { Octokit } from "https://cdn.skypack.dev/@octokit/rest";
 </script>
 ```
 


### PR DESCRIPTION
fixes #1898  Replace cdn.pika.dev with cdn.skypack.dev

-----
[View rendered README.md](https://github.com/MGF2/rest.js/blob/patch-1/README.md)