### PR TITLE
fix(docs): Remove broken client-options link

### DIFF
--- a/docs/src/pages/api/11_logging.md
+++ b/docs/src/pages/api/11_logging.md
@@ -9,6 +9,6 @@ title: "Logging"
 1. `octokit.log.warn(message[, additionalInfo])`
 1. `octokit.log.error(message[, additionalInfo])`
 
-They can be configured using the [`log` client option](client-options). By default, `octokit.log.debug()` and `octokit.log.info()` are no-ops, while the other two call `console.warn()` and `console.error()` respectively.
+They can be configured using the `log` client option. By default, `octokit.log.debug()` and `octokit.log.info()` are no-ops, while the other two call `console.warn()` and `console.error()` respectively.
 
 This is useful if you build reusable [plugins](#plugins).

--- a/docs/src/pages/api/12_debug.md
+++ b/docs/src/pages/api/12_debug.md
@@ -2,7 +2,7 @@
 title: "Debug"
 ---
 
-The simplest way to receive debug information is to set the [`log` client option](client-options) to `console`.
+The simplest way to receive debug information is to set the `log` client option to `console`.
 
 ```js
 const octokit = require("@octokit/rest")({


### PR DESCRIPTION
Fixes #1773 .

I couldn't find anywhere that actually listed all of the client options, and from what I can tell these links never actually worked. So, as suggested in https://github.com/octokit/rest.js/issues/1773#issuecomment-648994043, I just removed the links altogether.

-----
[View rendered docs/src/pages/api/11_logging.md](https://github.com/redbmk/rest.js/blob/remove-broken-links/docs/src/pages/api/11_logging.md)
[View rendered docs/src/pages/api/12_debug.md](https://github.com/redbmk/rest.js/blob/remove-broken-links/docs/src/pages/api/12_debug.md)