### PR TITLE
Fix a typo in a link on the Usage page

### DIFF
--- a/docs/src/pages/api/00_usage.md
+++ b/docs/src/pages/api/00_usage.md
@@ -117,7 +117,7 @@ const { data: pullRequest } = await octokit.pulls.get({
 });
 ```
 
-Some API endpoints support alternative response formats, see [Media types](https://docs.github.com/en/rest/overview/media-types). For example, to [request the above pull request in a diff format]((https://docs.github.com/en/rest/overview/media-types/#diff), pass the `mediaType.format` option.
+Some API endpoints support alternative response formats, see [Media types](https://docs.github.com/en/rest/overview/media-types). For example, to [request the above pull request in a diff format](https://docs.github.com/en/rest/overview/media-types/#diff), pass the `mediaType.format` option.
 
 Learn more about [request formats](#request-formats).
 


### PR DESCRIPTION
There's a double `((` on line 120 which is currently stopping the link being displayed as intended.

-----
[View rendered docs/src/pages/api/00_usage.md](https://github.com/felicitymay/rest.js/blob/patch-1/docs/src/pages/api/00_usage.md)