### PR TITLE
docs: Fix broken links in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,4 @@ Only one version number is bumped at a time, the highest version change trumps t
 Besides publishing a new version to npm, semantic-release also creates a git tag and release
 on GitHub, generates changelogs from the commit messages and puts them into the release notes.
 
-Before the publish it runs the `npm run build` script which generates type definitions for Typescript based on the [templates](scripts/templates/).
-The script also generates the API docs. After the publish, the API docs are automatically pushed to the `gh-pages` branch which updates the documentation at [octokit.github.io/rest.js](https://octokit.github.io/rest.js).
-
 If the pull request looks good but does not follow the commit conventions, use the "Squash & merge" button.

--- a/docs/src/pages/api/00_usage.md
+++ b/docs/src/pages/api/00_usage.md
@@ -119,7 +119,7 @@ const { data: pullRequest } = await octokit.pulls.get({
 
 Some API endpoints support alternative response formats, see [Media types](https://docs.github.com/en/rest/overview/media-types). For example, to [request the above pull request in a diff format](https://docs.github.com/en/rest/overview/media-types/#diff), pass the `mediaType.format` option.
 
-Learn more about [request formats](#request-formats).
+Learn more about [request formats](#request-formats-aborts).
 
 ```js
 const { data: diff } = await octokit.pulls.get({

--- a/docs/src/pages/api/03_request_formats.md
+++ b/docs/src/pages/api/03_request_formats.md
@@ -2,9 +2,9 @@
 title: "Request formats & aborts"
 ---
 
-Some API endpoints support alternative response formats, see [Media types](https://docs.github.com/en/rest/reference/media/).
+Some API endpoints support alternative response formats, see [Media types](https://docs.github.com/en/rest/overview/media-types).
 
-For example, to request a [pull request as diff format](https://docs.github.com/en/rest/reference/media/#diff), set the `mediaType.format` option
+For example, to request a [pull request as diff format](https://docs.github.com/en/rest/overview/media-types#commits-commit-comparison-and-pull-requests), set the `mediaType.format` option
 
 ```js
 const { data: prDiff } = await octokit.pulls.get({


### PR DESCRIPTION
The previous links were 404 and I believe I found the equivalent valid URLs to replace them with.

Note: I found one other broken link, but I didn't know how to fix it;
The "templates" link here:
https://github.com/octokit/rest.js/blob/master/CONTRIBUTING.md#merging-the-pull-request--releasing-a-new-version
>Before the publish it runs the npm run build script which generates type definitions for Typescript based on the [templates](https://github.com/octokit/rest.js/blob/master/scripts/templates). 

-----
[View rendered docs/src/pages/api/03_request_formats.md](https://github.com/per1234/rest.js/blob/fix-links/docs/src/pages/api/03_request_formats.md)