### PR TITLE
Docs: App authentication parameter id -> appId

### DIFF
--- a/docs/src/pages/api/01_authentication.md
+++ b/docs/src/pages/api/01_authentication.md
@@ -36,7 +36,7 @@ const { createAppAuth } = require("@octokit/auth-app");
 const appOctokit = new Octokit({
   authStrategy: createAppAuth,
   auth: {
-    id: 123,
+    appId: 123,
     privateKey: process.env.PRIVATE_KEY,
     // optional: this will make appOctokit authenticate as app (JWT)
     //           or installation (access token), depending on the request URL


### PR DESCRIPTION
This is to prevent the following deprecation warning:
```
Deprecation: [@octokit/auth-app] "createAppAuth({ id })" is deprecated, use "createAppAuth({ appId })" instead
    at createAppAuth (/Users/honza/projects/github-apps-tests/node_modules/@octokit/auth-app/dist-node/index.js:470:14)
    at new Octokit (/Users/honza/projects/github-apps-tests/node_modules/@octokit/core/dist-node/index.js:111:20)
    at new _a (/Users/honza/projects/github-apps-tests/node_modules/@octokit/core/dist-node/index.js:165:30)
    at new OctokitWithDefaults (/Users/honza/projects/github-apps-tests/node_modules/@octokit/core/dist-node/index.js:145:9)
    at main (/Users/honza/projects/github-apps-tests/index.js:21:24)
    at Object.<anonymous> (/Users/honza/projects/github-apps-tests/index.js:77:1)
    at Module._compile (internal/modules/cjs/loader.js:1133:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1153:10)
    at Module.load (internal/modules/cjs/loader.js:977:32)
    at Function.Module._load (internal/modules/cjs/loader.js:877:14)
```

-----
[View rendered docs/src/pages/api/01_authentication.md](https://github.com/jstastny/rest.js/blob/js/app-auth-deprecation/docs/src/pages/api/01_authentication.md)