### PR TITLE
docs: fix documentation URLs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Static documentation website, built with [Gatsby](https://www.gatsbyjs.org/) using [`@octokit/rest`](https://github.com/octokit/rest.js/) and deployed to GitHub Pages: [https://octokit.rest.github.io/rest.js/](https://octokit.rest.github.io/rest.js/)
+Static documentation website, built with [Gatsby](https://www.gatsbyjs.org/) using [`@octokit/rest`](https://github.com/octokit/rest.js/) and deployed to GitHub Pages: [https://octokit.github.io/rest.js/](https://octokit.github.io/rest.js/)
 
 ## Local Development
 

--- a/test/integration/deprecations-test.js
+++ b/test/integration/deprecations-test.js
@@ -659,7 +659,7 @@ describe("deprecations", () => {
         expect(authentication).to.deep.equal({
           type: "deprecated",
           message:
-            'Setting the "new Octokit({ auth })" option to an object without also setting the "authStrategy" option is deprecated and will be removed in v17. See (https://octokit.rest.github.io/rest.js/#authentication)',
+            'Setting the "new Octokit({ auth })" option to an object without also setting the "authStrategy" option is deprecated and will be removed in v17. See (https://octokit.github.io/rest.js/#authentication)',
         });
       });
   });


### PR DESCRIPTION
fix `.rest` added to urls

-----
[View rendered docs/README.md](https://github.com/UziTech/rest.js/blob/patch-1/docs/README.md)